### PR TITLE
Release/v0.1.8

### DIFF
--- a/.github/workflows/bun-semgrep.yml
+++ b/.github/workflows/bun-semgrep.yml
@@ -20,7 +20,7 @@ jobs:
     name: Semgrep (Web)
     runs-on: ubuntu-latest
     container:
-      image: semgrep/semgrep:1.155.0
+      image: semgrep/semgrep:1.156.0
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -61,7 +61,7 @@ jobs:
 
       - name: Initialize CodeQL
         if: env.HAS_GH_PAT != 'true'
-        uses: github/codeql-action/init@fb0994ef1c058010acf1efccff928b0a83b1ed54 # v4.32.6
+        uses: github/codeql-action/init@b1bff81932f5cdfc8695c7752dcee935dcd061c8 # v4.33.0
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
@@ -70,7 +70,7 @@ jobs:
 
       - name: Initialize CodeQL with private repo access
         if: env.HAS_GH_PAT == 'true'
-        uses: github/codeql-action/init@fb0994ef1c058010acf1efccff928b0a83b1ed54 # v4.32.6
+        uses: github/codeql-action/init@b1bff81932f5cdfc8695c7752dcee935dcd061c8 # v4.33.0
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
@@ -118,6 +118,6 @@ jobs:
         run: git config --global --remove-section "url.https://${GH_PAT}@github.com" 2>/dev/null || true
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@fb0994ef1c058010acf1efccff928b0a83b1ed54 # v4.32.6
+        uses: github/codeql-action/analyze@b1bff81932f5cdfc8695c7752dcee935dcd061c8 # v4.33.0
         with:
           category: "/language:${{matrix.language}}"

--- a/.github/workflows/go-lint.yml
+++ b/.github/workflows/go-lint.yml
@@ -24,7 +24,7 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     env:
-      GH_PAT: ${{ secrets.gh_pat }}
+      HAS_GH_PAT: ${{ secrets.gh_pat != '' }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -39,8 +39,9 @@ jobs:
         run: mise run prepare
 
       - name: Configure private git repository
-        if: env.GH_PAT != ''
+        if: env.HAS_GH_PAT == 'true'
         env:
+          GH_PAT: ${{ secrets.gh_pat }}
           GO_PRIVATE_FULL: ${{ inputs.go_private_full }}
         run: |
           if [ "$GO_PRIVATE_FULL" = "true" ]; then

--- a/.github/workflows/go-lint.yml
+++ b/.github/workflows/go-lint.yml
@@ -63,3 +63,11 @@ jobs:
       - name: Run lint
         if: github.event_name != 'pull_request'
         run: mise run lint
+
+      - name: Revoke private git repository access
+        if: always() && env.HAS_GH_PAT == 'true'
+        env:
+          GH_PAT: ${{ secrets.gh_pat }}
+        run: |
+          git config --global --remove-section "url.https://${GH_PAT}@github.com/" 2>/dev/null || true
+          git config --global --remove-section "url.https://${GH_PAT}@github.com/nics-dp" 2>/dev/null || true

--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -130,7 +130,9 @@ jobs:
     needs: prepare
     runs-on: ${{ fromJSON(inputs.runs_on) }}
     permissions:
+      actions: read
       contents: read
+      pull-requests: write
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.prepare.outputs.matrix) }}
@@ -256,6 +258,14 @@ jobs:
           name: build-${{ matrix.goos }}-${{ matrix.goarch }}${{ matrix.goarm && format('-v{0}', matrix.goarm) || '' }}
           path: ${{ steps.archive.outputs.file }}
           retention-days: ${{ inputs.snapshot && 7 || 30 }}
+
+      - name: Revoke private git repository access
+        if: always() && env.HAS_GH_PAT == 'true'
+        env:
+          GH_PAT: ${{ secrets.gh_pat }}
+        run: |
+          git config --global --remove-section "url.https://${GH_PAT}@github.com/" 2>/dev/null || true
+          git config --global --remove-section "url.https://${GH_PAT}@github.com/nics-dp" 2>/dev/null || true
 
   release:
     needs: [prepare, build]

--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -135,7 +135,7 @@ jobs:
       fail-fast: false
       matrix: ${{ fromJSON(needs.prepare.outputs.matrix) }}
     env:
-      GH_PAT: ${{ secrets.gh_pat }}
+      HAS_GH_PAT: ${{ secrets.gh_pat != '' }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -147,8 +147,9 @@ jobs:
           cache: true
 
       - name: Configure private git repository
-        if: env.GH_PAT != ''
+        if: env.HAS_GH_PAT == 'true'
         env:
+          GH_PAT: ${{ secrets.gh_pat }}
           GO_PRIVATE_FULL: ${{ inputs.go_private_full }}
         run: |
           if [[ "$GO_PRIVATE_FULL" == "true" ]]; then

--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -130,9 +130,7 @@ jobs:
     needs: prepare
     runs-on: ${{ fromJSON(inputs.runs_on) }}
     permissions:
-      actions: read
       contents: read
-      pull-requests: write
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.prepare.outputs.matrix) }}

--- a/.github/workflows/go-sec.yml
+++ b/.github/workflows/go-sec.yml
@@ -23,7 +23,7 @@ jobs:
     name: Security Scan
     runs-on: ubuntu-latest
     env:
-      GH_PAT: ${{ secrets.gh_pat }}
+      HAS_GH_PAT: ${{ secrets.gh_pat != '' }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -38,8 +38,9 @@ jobs:
         run: mise run prepare
 
       - name: Configure private git repository
-        if: env.GH_PAT != ''
+        if: env.HAS_GH_PAT == 'true'
         env:
+          GH_PAT: ${{ secrets.gh_pat }}
           GO_PRIVATE_FULL: ${{ inputs.go_private_full }}
         run: |
           if [ "$GO_PRIVATE_FULL" = "true" ]; then

--- a/.github/workflows/go-sec.yml
+++ b/.github/workflows/go-sec.yml
@@ -87,6 +87,14 @@ jobs:
 
             </details>
 
+      - name: Revoke private git repository access
+        if: always() && env.HAS_GH_PAT == 'true'
+        env:
+          GH_PAT: ${{ secrets.gh_pat }}
+        run: |
+          git config --global --remove-section "url.https://${GH_PAT}@github.com/" 2>/dev/null || true
+          git config --global --remove-section "url.https://${GH_PAT}@github.com/nics-dp" 2>/dev/null || true
+
       - name: Fail if scan found issues
         if: always() && steps.gosec.outputs.exit_code != '0'
         run: exit 1

--- a/.github/workflows/go-semgrep.yml
+++ b/.github/workflows/go-semgrep.yml
@@ -20,7 +20,7 @@ jobs:
     name: Semgrep (Go)
     runs-on: ubuntu-latest
     container:
-      image: semgrep/semgrep:1.155.0
+      image: semgrep/semgrep:1.156.0
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 

--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -79,6 +79,14 @@ jobs:
           path: coverage.out
           retention-days: 1
 
+      - name: Revoke private git repository access
+        if: always() && env.HAS_GH_PAT == 'true'
+        env:
+          GH_PAT: ${{ secrets.gh_pat }}
+        run: |
+          git config --global --remove-section "url.https://${GH_PAT}@github.com/" 2>/dev/null || true
+          git config --global --remove-section "url.https://${GH_PAT}@github.com/nics-dp" 2>/dev/null || true
+
   report:
     name: Test Report
     runs-on: ubuntu-latest
@@ -159,3 +167,11 @@ jobs:
         with:
           header: go-test-coverage
           message: ${{ steps.coverage-summary.outputs.message }}
+
+      - name: Revoke private git repository access
+        if: always() && env.HAS_GH_PAT == 'true'
+        env:
+          GH_PAT: ${{ secrets.gh_pat }}
+        run: |
+          git config --global --remove-section "url.https://${GH_PAT}@github.com/" 2>/dev/null || true
+          git config --global --remove-section "url.https://${GH_PAT}@github.com/nics-dp" 2>/dev/null || true

--- a/.github/workflows/go-vulncheck.yml
+++ b/.github/workflows/go-vulncheck.yml
@@ -23,7 +23,7 @@ jobs:
     name: Vulnerability Check
     runs-on: ubuntu-latest
     env:
-      GH_PAT: ${{ secrets.gh_pat }}
+      HAS_GH_PAT: ${{ secrets.gh_pat != '' }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -38,8 +38,9 @@ jobs:
         run: mise run prepare
 
       - name: Configure private git repository
-        if: env.GH_PAT != ''
+        if: env.HAS_GH_PAT == 'true'
         env:
+          GH_PAT: ${{ secrets.gh_pat }}
           GO_PRIVATE_FULL: ${{ inputs.go_private_full }}
         run: |
           if [ "$GO_PRIVATE_FULL" = "true" ]; then

--- a/.github/workflows/go-vulncheck.yml
+++ b/.github/workflows/go-vulncheck.yml
@@ -89,6 +89,14 @@ jobs:
 
             </details>
 
+      - name: Revoke private git repository access
+        if: always() && env.HAS_GH_PAT == 'true'
+        env:
+          GH_PAT: ${{ secrets.gh_pat }}
+        run: |
+          git config --global --remove-section "url.https://${GH_PAT}@github.com/" 2>/dev/null || true
+          git config --global --remove-section "url.https://${GH_PAT}@github.com/nics-dp" 2>/dev/null || true
+
       - name: Fail if vulnerabilities found
         if: always() && steps.vulncheck.outputs.exit_code != '0'
         run: exit 1

--- a/.github/workflows/sbom-image.yml
+++ b/.github/workflows/sbom-image.yml
@@ -73,7 +73,7 @@ jobs:
             echo "version_tag=${TAG}" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Generate SBOM from image (CycloneDX JSON 1.5)
+      - name: Generate SBOM from image (CycloneDX JSON 1.6)
         uses: anchore/sbom-action@57aae528053a48a3f6235f2d9461b05fbcb7366d # v0.23.1
         with:
           image: ${{ env.REGISTRY_GHCR }}/${{ env.GHCR_NAMESPACE }}/${{ inputs.image_name }}@${{ inputs.digest }}

--- a/.github/workflows/sbom-image.yml
+++ b/.github/workflows/sbom-image.yml
@@ -101,7 +101,7 @@ jobs:
 
       - name: Upload Trivy SARIF to GitHub Security tab
         if: always()
-        uses: github/codeql-action/upload-sarif@fb0994ef1c058010acf1efccff928b0a83b1ed54 # v4.32.6
+        uses: github/codeql-action/upload-sarif@b1bff81932f5cdfc8695c7752dcee935dcd061c8 # v4.33.0
         with:
           sarif_file: trivy-image.sarif
           category: trivy-image
@@ -123,7 +123,7 @@ jobs:
 
       - name: Upload Grype SARIF to GitHub Security tab
         if: always()
-        uses: github/codeql-action/upload-sarif@fb0994ef1c058010acf1efccff928b0a83b1ed54 # v4.32.6
+        uses: github/codeql-action/upload-sarif@b1bff81932f5cdfc8695c7752dcee935dcd061c8 # v4.33.0
         with:
           sarif_file: ${{ steps.grype-sarif.outputs.sarif }}
           category: grype-image

--- a/.github/workflows/sbom-image.yml
+++ b/.github/workflows/sbom-image.yml
@@ -76,7 +76,7 @@ jobs:
         uses: anchore/sbom-action@57aae528053a48a3f6235f2d9461b05fbcb7366d # v0.23.1
         with:
           image: ${{ env.REGISTRY_GHCR }}/${{ env.GHCR_NAMESPACE }}/${{ inputs.image_name }}@${{ inputs.digest }}
-          format: cyclonedx-json@1.6
+          format: cyclonedx-json
           output-file: sbom-image.cdx.json
           upload-artifact: false
 

--- a/.github/workflows/sbom-source.yml
+++ b/.github/workflows/sbom-source.yml
@@ -60,7 +60,7 @@ jobs:
         uses: anchore/sbom-action@57aae528053a48a3f6235f2d9461b05fbcb7366d # v0.23.1
         with:
           path: ${{ inputs.scan_path }}
-          format: cyclonedx-json@1.6
+          format: cyclonedx-json
           output-file: sbom-source.cdx.json
           dependency-snapshot: ${{ !inputs.snapshot }}
           upload-artifact: false

--- a/.github/workflows/sbom-source.yml
+++ b/.github/workflows/sbom-source.yml
@@ -86,7 +86,7 @@ jobs:
 
       - name: Upload Trivy SARIF to GitHub Security tab
         if: always()
-        uses: github/codeql-action/upload-sarif@fb0994ef1c058010acf1efccff928b0a83b1ed54 # v4.32.6
+        uses: github/codeql-action/upload-sarif@b1bff81932f5cdfc8695c7752dcee935dcd061c8 # v4.33.0
         with:
           sarif_file: trivy-source.sarif
           category: trivy-source
@@ -108,7 +108,7 @@ jobs:
 
       - name: Upload Grype SARIF to GitHub Security tab
         if: always()
-        uses: github/codeql-action/upload-sarif@fb0994ef1c058010acf1efccff928b0a83b1ed54 # v4.32.6
+        uses: github/codeql-action/upload-sarif@b1bff81932f5cdfc8695c7752dcee935dcd061c8 # v4.33.0
         with:
           sarif_file: ${{ steps.grype-sarif.outputs.sarif }}
           category: grype-source

--- a/.github/workflows/sbom-source.yml
+++ b/.github/workflows/sbom-source.yml
@@ -57,7 +57,7 @@ jobs:
             echo "version_tag=${TAG}" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Generate SBOM (CycloneDX JSON 1.5)
+      - name: Generate SBOM (CycloneDX JSON 1.6)
         uses: anchore/sbom-action@57aae528053a48a3f6235f2d9461b05fbcb7366d # v0.23.1
         with:
           path: ${{ inputs.scan_path }}

--- a/.github/workflows/trivy-iac.yml
+++ b/.github/workflows/trivy-iac.yml
@@ -27,7 +27,7 @@ jobs:
           exit-code: "0"
 
       - name: Upload SARIF to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@fb0994ef1c058010acf1efccff928b0a83b1ed54 # v4.32.6
+        uses: github/codeql-action/upload-sarif@b1bff81932f5cdfc8695c7752dcee935dcd061c8 # v4.33.0
         with:
           sarif_file: trivy-iac.sarif
           category: trivy-iac

--- a/.github/workflows/trivy-license.yml
+++ b/.github/workflows/trivy-license.yml
@@ -23,7 +23,7 @@ jobs:
     name: License Check
     runs-on: ubuntu-latest
     env:
-      GH_PAT: ${{ secrets.gh_pat }}
+      HAS_GH_PAT: ${{ secrets.gh_pat != '' }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -38,8 +38,9 @@ jobs:
         run: mise run prepare
 
       - name: Configure private git repository
-        if: env.GH_PAT != ''
+        if: env.HAS_GH_PAT == 'true'
         env:
+          GH_PAT: ${{ secrets.gh_pat }}
           GO_PRIVATE_FULL: ${{ inputs.go_private_full }}
         run: |
           if [ "$GO_PRIVATE_FULL" = "true" ]; then

--- a/.github/workflows/trivy-license.yml
+++ b/.github/workflows/trivy-license.yml
@@ -119,3 +119,11 @@ jobs:
         with:
           header: trivy-license
           message: ${{ steps.summary.outputs.body }}
+
+      - name: Revoke private git repository access
+        if: always() && env.HAS_GH_PAT == 'true'
+        env:
+          GH_PAT: ${{ secrets.gh_pat }}
+        run: |
+          git config --global --remove-section "url.https://${GH_PAT}@github.com/" 2>/dev/null || true
+          git config --global --remove-section "url.https://${GH_PAT}@github.com/nics-dp" 2>/dev/null || true

--- a/README.md
+++ b/README.md
@@ -390,8 +390,9 @@ with:
   project_name: dcf-platform
   binary: "platform:./cmd/platform"
   cgo_enabled: true
+  runs_on: '{"group":"releasers"}'  # 選用
 secrets:
-  gh_pat: ${{ secrets.GH_PAT_READ_NICSDP }}
+  gh_pat: ${{ secrets.GH_PAT_RELEASE_NICSDP }}  # 選用；若需要存取私有模組，通常沿用 release PAT
 
 # 多 binary
 with:
@@ -404,19 +405,19 @@ with:
 | `project_name` | string | — | **是** | 專案名稱 (影響 archive 命名) |
 | `binary` | string | — | **是** | Binary 建置清單 (`name:path,...`) |
 | `platforms` | string | `linux/amd64,linux/arm64,darwin/amd64,darwin/arm64,windows/amd64` | 否 | 目標平台 |
-| `go_version` | string | `stable` | 否 | Go 版本 (由 mise.toml 決定，通常不需覆寫) |
-| `cgo_enabled` | boolean | `false` | 否 | 啟用 CGO |
+| `go_version` | string | `stable` | 否 | Go 版本 (`actions/setup-go` 使用的版本字串) |
+| `cgo_enabled` | boolean | `false` | 否 | 啟用 CGO；啟用時建議同時把 `platforms` 覆寫為僅 Linux 目標 |
 | `go_env` | string | `GOEXPERIMENT=jsonv2,simd,runtimesecret,goroutineleakprofile` | 否 | 建置環境變數 |
 | `ldflags` | string | `""` | 否 | 自訂 ldflags (預設注入 version/commit/date) |
 | `extra_build_flags` | string | `-trimpath` | 否 | 額外 go build flags |
 | `go_private_full` | boolean | `true` | 否 | 設定 GOPRIVATE/GONOSUMDB |
 | `notarize` | boolean | `false` | 否 | macOS notarize (需 quill secrets) |
-| `snapshot` | boolean | `false` | 否 | 預覽建置 (不上傳 Release) |
+| `snapshot` | boolean | `false` | 否 | 預覽建置模式；版本會改用 `0.0.0-snapshot+<sha>`，不上傳 GitHub Release |
 | `ref` | string | `""` | 否 | Git ref (預設使用事件 ref) |
-| `runs_on` | string | `"ubuntu-latest"` | 否 | Runner (JSON 格式) |
+| `runs_on` | string | `"ubuntu-latest"` | 否 | Runner (JSON 格式，經 `fromJSON()` 解析) |
 
-**必要 Secrets:**
-- `gh_pat` — 存取私有模組
+**選用 Secrets:**
+- `gh_pat` — 存取私有模組；consumer repo 的 `release.yml` 通常傳 `GH_PAT_RELEASE_NICSDP`
 - macOS notarize (當 `notarize: true`): `quill_sign_p12`, `quill_sign_password`, `quill_notary_key`, `quill_notary_key_id`, `quill_notary_issuer`
 
 ---
@@ -476,7 +477,7 @@ secrets:
 ```yaml
 uses: nics-dp/meta/.github/workflows/release-please.yml@main
 secrets:
-  gh_pat: ${{ secrets.GH_PAT_READ_NICSDP }}  # 必要，GITHUB_TOKEN 不會觸發下游 workflows
+  gh_pat: ${{ secrets.GH_PAT_RELEASE_NICSDP }}  # 必要，GITHUB_TOKEN 不會觸發下游 workflows
 ```
 
 | 參數 | 類型 | 預設值 | 必要 | 說明 |
@@ -491,11 +492,12 @@ secrets:
 
 ### sbom-source.yml — Source Code SBOM
 
-產出 CycloneDX 1.6 SBOM + parlay 增強 + Trivy/Grype 漏洞掃描，上傳至 GitHub Release + Security tab + Dependency Graph。
+產出 CycloneDX 1.6 SBOM + parlay 增強 + Trivy/Grype 漏洞掃描，上傳至 GitHub Release 與 GitHub Security tab。非 snapshot 模式時，`anchore/sbom-action` 也會提交 dependency snapshot。
 
 ```yaml
 uses: nics-dp/meta/.github/workflows/sbom-source.yml@main
 permissions:
+  actions: read
   contents: write
   security-events: write
 with:
@@ -514,11 +516,12 @@ with:
 
 ### sbom-image.yml — Container Image SBOM
 
-對 container image 產出 CycloneDX 1.6 SBOM + Trivy/Grype 漏洞掃描，上傳至 GitHub Release + Security tab。
+對 container image 產出 CycloneDX 1.6 SBOM + Trivy/Grype 漏洞掃描，上傳至 GitHub Release 與 GitHub Security tab。
 
 ```yaml
 uses: nics-dp/meta/.github/workflows/sbom-image.yml@main
 permissions:
+  actions: read
   contents: write
   packages: read
   security-events: write
@@ -614,6 +617,7 @@ secrets:
 uses: nics-dp/meta/.github/workflows/artifacts-comment.yml@main
 permissions:
   actions: read
+  issues: write
   pull-requests: write
 ```
 
@@ -621,7 +625,7 @@ permissions:
 |------|------|--------|------|
 | `pr_number` | number | `0` | PR 編號 (自動偵測 `pull_request` / `workflow_run` 事件) |
 
-支援兩種情境：
+會在 PR 上建立或更新同一則 comment，支援兩種情境：
 - **`pull_request` 觸發的 workflow** — 自動偵測 PR 編號
 - **`workflow_run` 觸發的 workflow** (如 snapshot) — 從 `workflow_run.pull_requests` 自動偵測
 
@@ -717,7 +721,10 @@ secrets:
 3. 替換 `TODO` 標記 (`project_name`, `binary`, `image_name`)
 4. 新增 `configs/codeqls/<repo-name>.yml`，設定 CodeQL workflow
 5. 更新 `cron.yml` 的 repo 清單 (`CODEQL_REPOS`, `GO_REPOS`, `ALL_REPOS`, `RENOVATE_SYNC_REPOS`)
-6. 確認 repo secrets: `GH_PAT_READ_NICSDP`, `DOCKERHUB_USERNAME`, `DOCKERHUB_TOKEN`
+6. 確認 repo secrets:
+   - `GH_PAT_READ_NICSDP` (私有 Go modules / snapshot / CodeQL 用)
+   - `GH_PAT_RELEASE_NICSDP` (release-please / release 用)
+   - `DOCKERHUB_USERNAME`, `DOCKERHUB_TOKEN` (僅 Docker image repos 需要)
 
 ### Web 專案
 
@@ -726,7 +733,7 @@ secrets:
 3. 安裝 devDependencies (見 `web-templates/.github/README.md`)
 4. 新增 `configs/codeqls/<repo-name>.yml` (使用 `javascript-typescript` language)
 5. 更新 `cron.yml` 的 repo 清單 (`CODEQL_REPOS`, `WEB_REPOS`, `ALL_REPOS`, `RENOVATE_SYNC_REPOS`)
-6. 確認 repo secrets: `GH_PAT_READ_NICSDP`
+6. 確認 repo secrets: `GH_PAT_RELEASE_NICSDP`
 
 ---
 
@@ -737,14 +744,14 @@ secrets:
 1. **mise.toml** — 定義 `prepare`, `lint`, `security`, `test`, `vulncheck`, `report` tasks (建議直接使用 `golang-templates/mise.toml`)
 2. **coverage.out** — `mise run test` 需產出此檔案 (go-test.yml 預期此路徑)
 3. **Go module** — go.mod 存在且版本正確
-4. **Private module access** — `GH_PAT_READ_NICSDP` secret 已設定
+4. **Private module access** — 若 repo 會引用私有 `nics-dp` modules，需設定 `GH_PAT_READ_NICSDP`
 
 ### Web repos
 
 1. **mise.toml** — 建議直接使用 `web-templates/mise.toml`
 2. **bun.lock** — 使用 Bun 作為 package manager
 3. **package.json scripts** — 需包含 `lint`, `typecheck`, `build`, `test:coverage`, `format:check`
-4. **Private access** — `GH_PAT_READ_NICSDP` secret 已設定 (用於 release-please)
+4. **Release token** — `GH_PAT_RELEASE_NICSDP` secret 已設定 (供 release-please 建立 release/tag 並觸發下游 workflows)
 
 ## 相關文件
 

--- a/configs/codeqls/ZenQuery.yml
+++ b/configs/codeqls/ZenQuery.yml
@@ -43,7 +43,7 @@ jobs:
           fetch-depth: 0
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@fb0994ef1c058010acf1efccff928b0a83b1ed54 # v4.32.6
+        uses: github/codeql-action/init@b1bff81932f5cdfc8695c7752dcee935dcd061c8 # v4.33.0
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
@@ -61,6 +61,6 @@ jobs:
           go build ./...
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@fb0994ef1c058010acf1efccff928b0a83b1ed54 # v4.32.6
+        uses: github/codeql-action/analyze@b1bff81932f5cdfc8695c7752dcee935dcd061c8 # v4.33.0
         with:
           category: "/language:${{matrix.language}}"

--- a/configs/codeqls/dcf-access-cli.yml
+++ b/configs/codeqls/dcf-access-cli.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Initialize CodeQL
         if: env.HAS_GH_PAT != 'true'
-        uses: github/codeql-action/init@fb0994ef1c058010acf1efccff928b0a83b1ed54 # v4.32.6
+        uses: github/codeql-action/init@b1bff81932f5cdfc8695c7752dcee935dcd061c8 # v4.33.0
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
@@ -55,7 +55,7 @@ jobs:
 
       - name: Initialize CodeQL with private repo access
         if: env.HAS_GH_PAT == 'true'
-        uses: github/codeql-action/init@fb0994ef1c058010acf1efccff928b0a83b1ed54 # v4.32.6
+        uses: github/codeql-action/init@b1bff81932f5cdfc8695c7752dcee935dcd061c8 # v4.33.0
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
@@ -87,6 +87,6 @@ jobs:
         run: git config --global --remove-section "url.https://${GH_PAT}@github.com" 2>/dev/null || true
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@fb0994ef1c058010acf1efccff928b0a83b1ed54 # v4.32.6
+        uses: github/codeql-action/analyze@b1bff81932f5cdfc8695c7752dcee935dcd061c8 # v4.33.0
         with:
           category: "/language:${{matrix.language}}"

--- a/configs/codeqls/dcf-access-web.yml
+++ b/configs/codeqls/dcf-access-web.yml
@@ -43,7 +43,7 @@ jobs:
           fetch-depth: 0
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@fb0994ef1c058010acf1efccff928b0a83b1ed54 # v4.32.6
+        uses: github/codeql-action/init@b1bff81932f5cdfc8695c7752dcee935dcd061c8 # v4.33.0
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
@@ -51,6 +51,6 @@ jobs:
           queries: security-extended,security-and-quality
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@fb0994ef1c058010acf1efccff928b0a83b1ed54 # v4.32.6
+        uses: github/codeql-action/analyze@b1bff81932f5cdfc8695c7752dcee935dcd061c8 # v4.33.0
         with:
           category: "/language:${{matrix.language}}"

--- a/configs/codeqls/dcf-access.yml
+++ b/configs/codeqls/dcf-access.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Initialize CodeQL
         if: env.HAS_GH_PAT != 'true'
-        uses: github/codeql-action/init@fb0994ef1c058010acf1efccff928b0a83b1ed54 # v4.32.6
+        uses: github/codeql-action/init@b1bff81932f5cdfc8695c7752dcee935dcd061c8 # v4.33.0
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
@@ -55,7 +55,7 @@ jobs:
 
       - name: Initialize CodeQL with private repo access
         if: env.HAS_GH_PAT == 'true'
-        uses: github/codeql-action/init@fb0994ef1c058010acf1efccff928b0a83b1ed54 # v4.32.6
+        uses: github/codeql-action/init@b1bff81932f5cdfc8695c7752dcee935dcd061c8 # v4.33.0
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
@@ -92,6 +92,6 @@ jobs:
         run: git config --global --remove-section "url.https://${GH_PAT}@github.com" 2>/dev/null || true
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@fb0994ef1c058010acf1efccff928b0a83b1ed54 # v4.32.6
+        uses: github/codeql-action/analyze@b1bff81932f5cdfc8695c7752dcee935dcd061c8 # v4.33.0
         with:
           category: "/language:${{matrix.language}}"

--- a/configs/codeqls/dcf-platform-cli.yml
+++ b/configs/codeqls/dcf-platform-cli.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Initialize CodeQL
         if: env.HAS_GH_PAT != 'true'
-        uses: github/codeql-action/init@fb0994ef1c058010acf1efccff928b0a83b1ed54 # v4.32.6
+        uses: github/codeql-action/init@b1bff81932f5cdfc8695c7752dcee935dcd061c8 # v4.33.0
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
@@ -55,7 +55,7 @@ jobs:
 
       - name: Initialize CodeQL with private repo access
         if: env.HAS_GH_PAT == 'true'
-        uses: github/codeql-action/init@fb0994ef1c058010acf1efccff928b0a83b1ed54 # v4.32.6
+        uses: github/codeql-action/init@b1bff81932f5cdfc8695c7752dcee935dcd061c8 # v4.33.0
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
@@ -87,6 +87,6 @@ jobs:
         run: git config --global --remove-section "url.https://${GH_PAT}@github.com" 2>/dev/null || true
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@fb0994ef1c058010acf1efccff928b0a83b1ed54 # v4.32.6
+        uses: github/codeql-action/analyze@b1bff81932f5cdfc8695c7752dcee935dcd061c8 # v4.33.0
         with:
           category: "/language:${{matrix.language}}"

--- a/configs/codeqls/dcf-platform-web.yml
+++ b/configs/codeqls/dcf-platform-web.yml
@@ -43,7 +43,7 @@ jobs:
           fetch-depth: 0
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@fb0994ef1c058010acf1efccff928b0a83b1ed54 # v4.32.6
+        uses: github/codeql-action/init@b1bff81932f5cdfc8695c7752dcee935dcd061c8 # v4.33.0
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
@@ -51,6 +51,6 @@ jobs:
           queries: security-extended,security-and-quality
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@fb0994ef1c058010acf1efccff928b0a83b1ed54 # v4.32.6
+        uses: github/codeql-action/analyze@b1bff81932f5cdfc8695c7752dcee935dcd061c8 # v4.33.0
         with:
           category: "/language:${{matrix.language}}"

--- a/configs/codeqls/dcf-platform.yml
+++ b/configs/codeqls/dcf-platform.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Initialize CodeQL
         if: env.HAS_GH_PAT != 'true'
-        uses: github/codeql-action/init@fb0994ef1c058010acf1efccff928b0a83b1ed54 # v4.32.6
+        uses: github/codeql-action/init@b1bff81932f5cdfc8695c7752dcee935dcd061c8 # v4.33.0
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
@@ -55,7 +55,7 @@ jobs:
 
       - name: Initialize CodeQL with private repo access
         if: env.HAS_GH_PAT == 'true'
-        uses: github/codeql-action/init@fb0994ef1c058010acf1efccff928b0a83b1ed54 # v4.32.6
+        uses: github/codeql-action/init@b1bff81932f5cdfc8695c7752dcee935dcd061c8 # v4.33.0
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
@@ -87,6 +87,6 @@ jobs:
         run: git config --global --remove-section "url.https://${GH_PAT}@github.com" 2>/dev/null || true
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@fb0994ef1c058010acf1efccff928b0a83b1ed54 # v4.32.6
+        uses: github/codeql-action/analyze@b1bff81932f5cdfc8695c7752dcee935dcd061c8 # v4.33.0
         with:
           category: "/language:${{matrix.language}}"

--- a/configs/codeqls/dcf-service.yml
+++ b/configs/codeqls/dcf-service.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Initialize CodeQL
         if: env.HAS_GH_PAT != 'true'
-        uses: github/codeql-action/init@fb0994ef1c058010acf1efccff928b0a83b1ed54 # v4.32.6
+        uses: github/codeql-action/init@b1bff81932f5cdfc8695c7752dcee935dcd061c8 # v4.33.0
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
@@ -55,7 +55,7 @@ jobs:
 
       - name: Initialize CodeQL with private repo access
         if: env.HAS_GH_PAT == 'true'
-        uses: github/codeql-action/init@fb0994ef1c058010acf1efccff928b0a83b1ed54 # v4.32.6
+        uses: github/codeql-action/init@b1bff81932f5cdfc8695c7752dcee935dcd061c8 # v4.33.0
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
@@ -87,6 +87,6 @@ jobs:
         run: git config --global --remove-section "url.https://${GH_PAT}@github.com" 2>/dev/null || true
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@fb0994ef1c058010acf1efccff928b0a83b1ed54 # v4.32.6
+        uses: github/codeql-action/analyze@b1bff81932f5cdfc8695c7752dcee935dcd061c8 # v4.33.0
         with:
           category: "/language:${{matrix.language}}"

--- a/configs/codeqls/libdcf.yml
+++ b/configs/codeqls/libdcf.yml
@@ -48,7 +48,7 @@ jobs:
 
       - name: Initialize CodeQL
         if: env.HAS_GH_PAT != 'true'
-        uses: github/codeql-action/init@fb0994ef1c058010acf1efccff928b0a83b1ed54 # v4.32.6
+        uses: github/codeql-action/init@b1bff81932f5cdfc8695c7752dcee935dcd061c8 # v4.33.0
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
@@ -57,7 +57,7 @@ jobs:
 
       - name: Initialize CodeQL with private repo access
         if: env.HAS_GH_PAT == 'true'
-        uses: github/codeql-action/init@fb0994ef1c058010acf1efccff928b0a83b1ed54 # v4.32.6
+        uses: github/codeql-action/init@b1bff81932f5cdfc8695c7752dcee935dcd061c8 # v4.33.0
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
@@ -94,6 +94,6 @@ jobs:
         run: git config --global --remove-section "url.https://${GH_PAT}@github.com" 2>/dev/null || true
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@fb0994ef1c058010acf1efccff928b0a83b1ed54 # v4.32.6
+        uses: github/codeql-action/analyze@b1bff81932f5cdfc8695c7752dcee935dcd061c8 # v4.33.0
         with:
           category: "/language:${{matrix.language}}"

--- a/configs/codeqls/otel-bundle.yml
+++ b/configs/codeqls/otel-bundle.yml
@@ -43,7 +43,7 @@ jobs:
           fetch-depth: 0
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@fb0994ef1c058010acf1efccff928b0a83b1ed54 # v4.32.6
+        uses: github/codeql-action/init@b1bff81932f5cdfc8695c7752dcee935dcd061c8 # v4.33.0
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
@@ -61,6 +61,6 @@ jobs:
           go build ./...
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@fb0994ef1c058010acf1efccff928b0a83b1ed54 # v4.32.6
+        uses: github/codeql-action/analyze@b1bff81932f5cdfc8695c7752dcee935dcd061c8 # v4.33.0
         with:
           category: "/language:${{matrix.language}}"

--- a/configs/codeqls/test-repo.yml
+++ b/configs/codeqls/test-repo.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Initialize CodeQL
         if: env.HAS_GH_PAT != 'true'
-        uses: github/codeql-action/init@fb0994ef1c058010acf1efccff928b0a83b1ed54 # v4.32.6
+        uses: github/codeql-action/init@b1bff81932f5cdfc8695c7752dcee935dcd061c8 # v4.33.0
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
@@ -55,7 +55,7 @@ jobs:
 
       - name: Initialize CodeQL with private repo access
         if: env.HAS_GH_PAT == 'true'
-        uses: github/codeql-action/init@fb0994ef1c058010acf1efccff928b0a83b1ed54 # v4.32.6
+        uses: github/codeql-action/init@b1bff81932f5cdfc8695c7752dcee935dcd061c8 # v4.33.0
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
@@ -87,6 +87,6 @@ jobs:
         run: git config --global --remove-section "url.https://${GH_PAT}@github.com" 2>/dev/null || true
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@fb0994ef1c058010acf1efccff928b0a83b1ed54 # v4.32.6
+        uses: github/codeql-action/analyze@b1bff81932f5cdfc8695c7752dcee935dcd061c8 # v4.33.0
         with:
           category: "/language:${{matrix.language}}"

--- a/golang-templates/.github/README.md
+++ b/golang-templates/.github/README.md
@@ -9,10 +9,157 @@ All workflows call reusable workflows from `nics-dp/meta`.
 |---|---|---|
 | `ci.yml` | Managed file check, commitlint, hadolint, trivy-iac, trivy-license, lint, security scan, vulnerability check, Semgrep, test | push, PR, manual |
 | `release-please.yml` | Auto-create Release PR with changelog, then GitHub Release | push to main/release |
-| `release.yml` | Build Go binaries, Docker image, SBOMs, sign artifacts | release created |
+| `release.yml` | Build Go binaries, Docker image, SBOMs, sign artifacts | push tag v*, manual |
 | `snapshot.yml` | Build snapshot artifacts on PR, post artifact links via `artifacts-comment` | CI success on PR, manual |
 | `codeql.yml` | CodeQL security analysis (Go + Actions) | push, PR, weekly, manual |
 | `notify.yml` | Google Chat notifications for PR/push/release/issue/CI events | various |
+
+## Workflow Details
+
+### ci.yml — CI Checks
+
+Runs comprehensive CI checks including code style, security scanning, and unit tests.
+
+**Triggers:**
+- Push to `main`, `dev`, `release/**`, `feature/**`
+- PR targeting `main`, `dev`, `release/**`
+- Manual (`workflow_dispatch`)
+
+**Jobs:**
+
+```
+check-managed ─┐
+commitlint ────┤
+hadolint ──────┤ (Service repos only)
+trivy-iac ─────┤ (Service repos only)
+trivy-license ─┤ (all independent)
+go-lint ───────┼──► go-test
+go-sec ────────┘
+go-vulncheck ──┐
+go-semgrep ────┘ (independent)
+```
+
+| Job | Meta Workflow | Description |
+|-----|---------------|-------------|
+| check-managed | `check-managed-files.yml` | Check managed files are in sync with meta |
+| commitlint | `commitlint.yml` | Validate commit messages (conventional commits) |
+| hadolint | `hadolint.yml` | Dockerfile linting (Service/Docker repos only) |
+| trivy-iac | `trivy-iac.yml` | IaC security scanning (Service/Docker repos only) |
+| trivy-license | `trivy-license.yml` | Dependency license compliance check |
+| go-lint | `go-lint.yml` | Go code linting (golangci-lint) |
+| go-sec | `go-sec.yml` | Go security scanning (gosec) |
+| go-vulncheck | `go-vulncheck.yml` | Go known vulnerability check (govulncheck) |
+| go-semgrep | `go-semgrep.yml` | Semgrep static analysis |
+| go-test | `go-test.yml` | Go unit tests (depends on go-lint, go-sec) |
+
+---
+
+### release-please.yml — Automated Release Management
+
+Auto-creates Release PRs with changelog based on conventional commits. After merge, creates GitHub Release + tag which triggers release.yml.
+
+**Triggers:**
+- Push to `main`, `release/**`
+
+**Flow:**
+1. Detect conventional commits, calculate next semver version
+2. Create/update Release PR (with auto-generated changelog)
+3. After Release PR merge, create GitHub Release + tag
+4. Tag push triggers release.yml
+
+---
+
+### release.yml — Production Release
+
+Builds Go binaries (multi-platform cross-compilation), Docker images, and uploads to GitHub Release with cosign signatures.
+
+**Triggers:**
+- Push tag `v*`
+- Manual (`workflow_dispatch`)
+
+**Jobs:**
+
+```
+go-release ──► sbom-source
+image-build ──► sbom-image    (Service repos only)
+```
+
+| Job | Meta Workflow | Description |
+|-----|---------------|-------------|
+| go-release | `go-release.yml` | Multi-platform Go binary build, optional CGO/Linux-only override, cosign signing |
+| sbom-source | `sbom-source.yml` | Source SBOM (CycloneDX 1.6) + vulnerability scan (Trivy + Grype) + Security tab upload |
+| image-build | `image-release.yml` | Docker image build + push on `{"group":"releasers"}` (Service repos only) |
+| sbom-image | `sbom-image.yml` | Image SBOM + vulnerability scan + Security tab upload (Service repos only) |
+
+**Notes:**
+- The shipped template pins release builds to `runs_on: '{"group":"releasers"}'`.
+- `sbom-source` and `sbom-image` require `actions: read` in addition to `contents: write` / `security-events: write`.
+- `go-release` receives `GH_PAT_RELEASE_NICSDP` in the template so release jobs can both read private modules and create downstream release activity.
+
+---
+
+### snapshot.yml — Preview Build
+
+Automatically builds preview artifacts after CI passes on PRs.
+
+**Triggers:**
+- CI workflow success (PR events only, same-repo branches only)
+- Manual (`workflow_dispatch`)
+
+**Jobs:**
+
+```
+go-release ──┐
+image-build ─┼──► artifacts-comment
+             │    (Service repos: both; CLI repos: go-release only)
+```
+
+| Job | Meta Workflow | Description |
+|-----|---------------|-------------|
+| go-release | `go-release.yml` | Snapshot build (snapshot mode, PR-only for `workflow_run`) |
+| image-build | `image-release.yml` | Snapshot Docker image with SBOM/provenance/attest disabled (Service repos only) |
+| artifacts-comment | `artifacts-comment.yml` | Post artifact links as PR comment; for CLI repos change `needs` to `[go-release]` |
+
+**Notes:**
+- `workflow_run` execution only proceeds for successful same-repo pull requests; manual dispatch bypasses that gate.
+- The shipped template pins snapshot builds to `runs_on: '{"group":"releasers"}'`.
+- `go-release` needs `actions: read` and `pull-requests: write`; `artifacts-comment` needs `actions: read`, `pull-requests: write`, and `issues: write`.
+
+---
+
+### codeql.yml — CodeQL Analysis
+
+GitHub CodeQL static security analysis. Managed centrally via `configs/codeqls/<repo-name>.yml` and synced by `sync-codeql`.
+
+**Triggers:**
+- Push to `main`, `dev` (excluding `*.md`, `*.txt`)
+- PR targeting `main`, `dev` (excluding `*.md`, `*.txt`)
+- Weekly schedule (Monday 00:00 UTC)
+- Manual (`workflow_dispatch`)
+
+**Languages analyzed:**
+- `actions` (build-mode: none)
+- `go` (build-mode: manual)
+
+**Features:**
+- Uses `security-extended` and `security-and-quality` query suites
+- Supports private repo access via `external-repository-token`
+
+---
+
+### notify.yml — Google Chat Notifications
+
+Sends GitHub event notifications to Google Chat.
+
+**Events and notifications:**
+
+| Event | Notification |
+|-------|-------------|
+| PR opened/closed/reopened | PR title, status, branch info |
+| Push to main/dev | Commit message |
+| Release published | Release tag and content |
+| Issue opened/closed | Issue title |
+| ci/release workflow failure | Failed workflow name and link |
 
 ## Setup
 
@@ -45,13 +192,16 @@ All workflows call reusable workflows from `nics-dp/meta`.
    - `ci.yml`: remove `hadolint` and `trivy-iac` jobs, remove `security-events: write`
    - Remove `release.yml` and `snapshot.yml` entirely
 
-5. For private repos importing `nics-dp` modules, ensure `GH_PAT_READ_NICSDP` is configured as a repo secret.
+5. Configure repo secrets as needed:
+   - `GH_PAT_READ_NICSDP` for private repos importing `nics-dp` modules, snapshot builds, or private-module CodeQL access
+   - `GH_PAT_RELEASE_NICSDP` for `release-please.yml`, `release.yml`, and release-time private module access
 
 ## Required Secrets
 
 | Secret | Used by | Required |
 |---|---|---|
-| `GH_PAT_READ_NICSDP` | ci, release, snapshot, release-please | Private repos |
+| `GH_PAT_READ_NICSDP` | ci, snapshot, codeql | Private repos / private module access |
+| `GH_PAT_RELEASE_NICSDP` | release-please, release | All repos (triggers downstream workflows) |
 | `DOCKERHUB_USERNAME` | release, snapshot | Docker image repos |
 | `DOCKERHUB_TOKEN` | release, snapshot | Docker image repos |
 | `GOOGLE_CHAT_WEBHOOK` | notify | Optional |

--- a/golang-templates/.github/README.md
+++ b/golang-templates/.github/README.md
@@ -123,7 +123,7 @@ image-build ─┼──► artifacts-comment
 **Notes:**
 - `workflow_run` execution only proceeds for successful same-repo pull requests; manual dispatch bypasses that gate.
 - The shipped template pins snapshot builds to `runs_on: '{"group":"releasers"}'`.
-- `go-release` needs `actions: read` and `pull-requests: write`; `artifacts-comment` needs `actions: read`, `pull-requests: write`, and `issues: write`.
+- `go-release` uses `contents: write` and `id-token: write`; `artifacts-comment` needs `actions: read`, `pull-requests: write`, and `issues: write`.
 
 ---
 

--- a/golang-templates/.github/workflows/codeql.yml
+++ b/golang-templates/.github/workflows/codeql.yml
@@ -55,7 +55,7 @@ jobs:
 
       - name: Initialize CodeQL
         if: env.HAS_GH_PAT != 'true'
-        uses: github/codeql-action/init@fb0994ef1c058010acf1efccff928b0a83b1ed54 # v4.32.6
+        uses: github/codeql-action/init@b1bff81932f5cdfc8695c7752dcee935dcd061c8 # v4.33.0
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
@@ -64,7 +64,7 @@ jobs:
 
       - name: Initialize CodeQL with private repo access
         if: env.HAS_GH_PAT == 'true'
-        uses: github/codeql-action/init@fb0994ef1c058010acf1efccff928b0a83b1ed54 # v4.32.6
+        uses: github/codeql-action/init@b1bff81932f5cdfc8695c7752dcee935dcd061c8 # v4.33.0
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
@@ -102,6 +102,6 @@ jobs:
         run: git config --global --remove-section "url.https://${GH_PAT}@github.com" 2>/dev/null || true
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@fb0994ef1c058010acf1efccff928b0a83b1ed54 # v4.32.6
+        uses: github/codeql-action/analyze@b1bff81932f5cdfc8695c7752dcee935dcd061c8 # v4.33.0
         with:
           category: "/language:${{matrix.language}}"

--- a/golang-templates/.github/workflows/release.yml
+++ b/golang-templates/.github/workflows/release.yml
@@ -8,6 +8,7 @@
 # - Service repo (Go binary + Docker image): 保留 go-release + image-build jobs
 # - CLI repo (Go binary only): 移除 image-build job，移除 cgo_enabled
 # - Docker-only repo: 移除 go-release job，以及所有相依 go-release 的 jobs（例如 sbom-source）
+# - 若啟用 CGO，請同時把 platforms 覆寫為僅 Linux 目標，或改用支援該目標的 runners
 #
 # 必須修改的參數 (標記為 TODO):
 # - project_name: 專案名稱
@@ -30,21 +31,23 @@ jobs:
     uses: nics-dp/meta/.github/workflows/go-release.yml@main
     permissions:
       contents: write
-      id-token: write
+      id-token: write # cosign keyless signing
     with:
       project_name: TODO        # TODO: 專案名稱 (例如 dcf-platform)
       binary: "TODO:./cmd/TODO" # TODO: Binary 建置清單 (例如 "platform:./cmd/platform")
       # cgo_enabled: true       # 取消註解以啟用 CGO (service repos 需要)
       # platforms: linux/amd64,linux/arm64 # 啟用 CGO 時，請同時覆寫 platforms 僅建置 Linux (或調整 go-release workflow 的 runners)
+      runs_on: '{"group":"releasers"}' # TODO: 若無 self-hosted releasers runner，改回 '"ubuntu-latest"'
     secrets:
-      gh_pat: ${{ secrets.GH_PAT_READ_NICSDP }}
+      gh_pat: ${{ secrets.GH_PAT_RELEASE_NICSDP }} # 供 release 時讀取 private modules
 
   sbom-source:
     needs: [go-release]
     uses: nics-dp/meta/.github/workflows/sbom-source.yml@main
     permissions:
-      contents: write
-      security-events: write
+      actions: read # 讓 SBOM workflow 可讀取 action metadata / artifacts
+      contents: write # 上傳 GitHub Release assets
+      security-events: write # 上傳 Trivy / Grype SARIF 到 Security tab
     with:
       project_name: TODO        # TODO: 與 go-release 的 project_name 一致
 
@@ -55,10 +58,10 @@ jobs:
       contents: read
       packages: write
       attestations: write
-      id-token: write
+      id-token: write # cosign keyless signing / attestations
     with:
       image_name: TODO          # TODO: Docker image 名稱 (例如 dcf-platform)
-      runs_on: '{"group":"releasers"}'
+      runs_on: '{"group":"releasers"}' # TODO: 若無 self-hosted releasers runner，改回 '"ubuntu-latest"'
     secrets:
       dockerhub_username: ${{ secrets.DOCKERHUB_USERNAME }}
       dockerhub_token: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -68,9 +71,10 @@ jobs:
     needs: [image-build]
     uses: nics-dp/meta/.github/workflows/sbom-image.yml@main
     permissions:
-      contents: write
-      packages: read
-      security-events: write
+      actions: read # 讓 SBOM workflow 可讀取 action metadata / artifacts
+      contents: write # 上傳 GitHub Release assets
+      packages: read # 從 GHCR 拉取 image 產生 SBOM
+      security-events: write # 上傳 Trivy / Grype SARIF 到 Security tab
     with:
       project_name: TODO        # TODO: 與 go-release 的 project_name 一致
       image_name: TODO          # TODO: 與 image-build 的 image_name 一致

--- a/golang-templates/.github/workflows/snapshot.yml
+++ b/golang-templates/.github/workflows/snapshot.yml
@@ -34,8 +34,6 @@ jobs:
     permissions:
       contents: write
       id-token: write
-      actions: read # 讓下游 comment / artifact 流程可讀取 action metadata
-      pull-requests: write # snapshot/reusable workflow 需要回寫 PR
     with:
       project_name: TODO        # TODO: 與 release.yml 一致
       binary: "TODO:./cmd/TODO" # TODO: 與 release.yml 一致

--- a/golang-templates/.github/workflows/snapshot.yml
+++ b/golang-templates/.github/workflows/snapshot.yml
@@ -9,6 +9,7 @@
 # - Service repo: 保留 go-release + image-build jobs
 # - CLI repo: 移除 image-build job
 # - Docker-only repo: 移除 go-release job
+# - 若啟用 CGO，請同時把 platforms 覆寫為僅 Linux 目標，或改用支援該目標的 runners
 
 name: snapshot
 
@@ -31,17 +32,21 @@ jobs:
        github.event.workflow_run.head_repository.full_name == github.repository)
     uses: nics-dp/meta/.github/workflows/go-release.yml@main
     permissions:
-      contents: read
+      contents: write
+      id-token: write
+      actions: read # 讓下游 comment / artifact 流程可讀取 action metadata
+      pull-requests: write # snapshot/reusable workflow 需要回寫 PR
     with:
       project_name: TODO        # TODO: 與 release.yml 一致
       binary: "TODO:./cmd/TODO" # TODO: 與 release.yml 一致
       # cgo_enabled: true       # TODO: 與 release.yml 一致
       #                         # 注意: 若啟用 CGO，請同時在 release.yml / snapshot.yml 覆寫 `platforms`
       #                         # (或改用僅支援 Linux 的 runners)，以避免 darwin/windows 目標的 CGO cross-compilation 失敗
+      runs_on: '{"group":"releasers"}' # TODO: 若無 self-hosted releasers runner，改回 '"ubuntu-latest"'
       snapshot: true
       ref: ${{ github.event.workflow_run.head_sha || '' }}
     secrets:
-      gh_pat: ${{ secrets.GH_PAT_READ_NICSDP }}
+      gh_pat: ${{ secrets.GH_PAT_READ_NICSDP }} # snapshot 讀取 private modules 用
 
   # 僅 service/Docker repos 需要，CLI repos 請移除此 job
   image-build:
@@ -57,10 +62,10 @@ jobs:
       id-token: write
     with:
       image_name: TODO          # TODO: 與 release.yml 一致
-      runs_on: '{"group":"releasers"}'
-      sbom: false
-      provenance: false
-      attest: false
+      runs_on: '{"group":"releasers"}' # TODO: 若無 self-hosted releasers runner，改回 '"ubuntu-latest"'
+      sbom: false # snapshot 不額外產出 BuildKit SBOM
+      provenance: false # snapshot 不產生 provenance attestation
+      attest: false # snapshot 不產生 artifact attestation
       snapshot: true
       ref: ${{ github.event.workflow_run.head_sha || '' }}
     secrets:
@@ -68,11 +73,12 @@ jobs:
       dockerhub_token: ${{ secrets.DOCKERHUB_TOKEN }}
       gh_pat: ${{ secrets.GH_PAT_READ_NICSDP }}
 
-  # 將 artifact 連結回報到 PR，調整 needs 符合專案類型
+  # 將 artifact 連結回報到 PR；CLI repos 請把 needs 改為 [go-release]
   artifacts-comment:
     if: github.event.workflow_run.event == 'pull_request'
     needs: [go-release, image-build] # TODO: CLI repos 改為 [go-release]
     uses: nics-dp/meta/.github/workflows/artifacts-comment.yml@main
     permissions:
-      actions: read
-      pull-requests: write
+      actions: read # 讀取 workflow artifacts
+      pull-requests: write # 更新 PR comment
+      issues: write # sticky comment action 需要

--- a/web-templates/.github/README.md
+++ b/web-templates/.github/README.md
@@ -8,9 +8,117 @@ All workflows call reusable workflows from `nics-dp/meta`, and CI tasks run thro
 | File | Purpose | Triggers |
 |---|---|---|
 | `ci.yml` | Lint, typecheck, build, audit, test, format check, Semgrep, trivy-license, knip, lighthouse | push, PR, manual |
+| `release-please.yml` | Automated release management | push to main/release |
 | `codeql.yml` | CodeQL security analysis (JS/TS + Actions) | push, PR, weekly, manual |
 | `notify.yml` | Google Chat notifications | PR, push, release, issue, CI events |
-| `release-please.yml` | Automated release management | push to main/release |
+
+## Workflow Details
+
+### ci.yml — Web CI Checks
+
+Runs comprehensive CI checks for web projects including linting, type checking, build, security scanning, and tests.
+
+**Triggers:**
+- Push to `main`, `dev`, `release/**`, `feature/**`
+- PR targeting `main`, `dev`, `release/**`
+- Manual (`workflow_dispatch`)
+
+**Jobs:**
+
+```
+check-managed ─┐
+commitlint ────┤
+audit ─────────┤
+format-check ──┤
+trivy-license ─┤ (all independent)
+semgrep ───────┤
+knip ──────────┤
+lint ──────────┼──► build ──► lighthouse
+typecheck ─────┘      │
+                      └──► test
+```
+
+#### Required (enabled by default)
+
+| Job | Meta Workflow | Description |
+|-----|---------------|-------------|
+| check-managed | `check-managed-files.yml` | Check managed files are in sync with meta |
+| commitlint | `commitlint.yml` | Validate commit messages (conventional commits) |
+| lint | `bun-lint.yml` | Runs `mise run lint` |
+| typecheck | `bun-typecheck.yml` | Runs `mise run typecheck` |
+| build | `bun-build.yml` | Runs `mise run build` (depends on lint, typecheck) |
+| audit | `bun-audit.yml` | Runs `mise run audit` |
+
+#### Recommended (enabled by default)
+
+| Job | Meta Workflow | Description |
+|-----|---------------|-------------|
+| test | `bun-test.yml` | Runs `mise run test` (depends on lint, typecheck) |
+| format-check | `bun-format-check.yml` | Runs `mise run format-check` |
+| trivy-license | `trivy-license.yml` | License compliance (no `gh_pat` needed) |
+| semgrep | `bun-semgrep.yml` | Semgrep static analysis (JS/TS) |
+
+#### Optional
+
+These jobs are enabled in the shipped `ci.yml`. If you don't want them, comment them out or remove them before the first CI run.
+
+| Job | Meta Workflow | Description |
+|-----|---------------|-------------|
+| knip | `bun-knip.yml` | Runs `mise run knip` |
+| lighthouse | `bun-lighthouse.yml` | Runs `mise run lighthouse` (depends on build) |
+| bundle-size | `bun-bundle-size.yml` | Disabled by default; enable after adding repo-specific `size-limit` config |
+
+---
+
+### release-please.yml — Automated Release Management
+
+Auto-creates Release PRs with changelog based on conventional commits. After merge, creates GitHub Release + tag.
+
+**Triggers:**
+- Push to `main`, `release/**`
+
+**Flow:**
+1. Detect conventional commits, calculate next semver version
+2. Create/update Release PR (with auto-generated changelog)
+3. After Release PR merge, create GitHub Release + tag
+
+---
+
+### codeql.yml — CodeQL Analysis
+
+GitHub CodeQL static security analysis for web projects. Managed centrally via `configs/codeqls/<repo-name>.yml` and synced by `sync-codeql`.
+
+**Triggers:**
+- Push to `main`, `dev` (excluding `*.md`, `*.txt`)
+- PR targeting `main`, `dev` (excluding `*.md`, `*.txt`)
+- Weekly schedule (Monday 00:00 UTC)
+- Manual (`workflow_dispatch`)
+
+**Languages analyzed:**
+- `actions` (build-mode: none)
+- `javascript-typescript` (build-mode: none)
+
+**Features:**
+- Uses `security-extended` and `security-and-quality` query suites
+- No `GH_PAT` needed (no private module access)
+
+For repos managed by `sync-codeql`, copy this template to `configs/codeqls/<repo-name>.yml`.
+
+---
+
+### notify.yml — Google Chat Notifications
+
+Sends GitHub event notifications to Google Chat.
+
+**Events and notifications:**
+
+| Event | Notification |
+|-------|-------------|
+| PR opened/closed/reopened | PR title, status, branch info |
+| Push to main/dev | Commit message |
+| Release published | Release tag and content |
+| Issue opened/closed | Issue title |
+| ci workflow failure | Failed workflow name and link |
 
 ## Setup
 
@@ -65,59 +173,32 @@ All workflows call reusable workflows from `nics-dp/meta`, and CI tasks run thro
 
 6. Install devDependencies:
    ```bash
-   # 必備
+   # Required
    bun add -d prettier prettier-plugin-tailwindcss
 
-   # 必備 (預設 ci.yml 會跑 test)
+   # Required (ci.yml runs test by default)
    bun add -d vitest jsdom @vitest/coverage-v8
 
-   # 若保留 ci.yml 內預設啟用的 optional jobs，這些也需要安裝
+   # If keeping optional jobs enabled in ci.yml
    bun add -d knip @lhci/cli
    ```
-
-## CI Jobs
-
-### Required (enabled by default)
-
-| Job | Tool | What it checks |
-|---|---|---|
-| `check-managed` | `check-managed-files.yml` | Blocks PRs modifying synced files |
-| `commitlint` | `commitlint.yml` | Conventional commit messages |
-| `lint` | `bun-lint.yml` | Runs `mise run lint` |
-| `typecheck` | `bun-typecheck.yml` | Runs `mise run typecheck` |
-| `build` | `bun-build.yml` | Runs `mise run build` |
-| `audit` | `bun-audit.yml` | Runs `mise run audit` |
-
-### Recommended (enabled by default)
-
-| Job | Tool | What it checks |
-|---|---|---|
-| `test` | `bun-test.yml` | Runs `mise run test` |
-| `format-check` | `bun-format-check.yml` | Runs `mise run format-check` |
-| `trivy-license` | `trivy-license.yml` | License compliance (no `gh_pat` needed — web repos don't access private Go modules) |
-| `semgrep` | `bun-semgrep.yml` | Semgrep static analysis (JS/TS) |
-
-### Optional tools
-
-These jobs are enabled in the shipped `ci.yml`. If you don't want them, comment them out or remove them before the first CI run.
-
-| Job | Tool | What it checks |
-|---|---|---|
-| `knip` | `bun-knip.yml` | Runs `mise run knip` |
-| `lighthouse` | `bun-lighthouse.yml` | Runs `mise run lighthouse` |
-| `bundle-size` | `bun-bundle-size.yml` | Disabled by default; enable after adding repo-specific `size-limit` config |
-
-## CodeQL
-
-The `codeql.yml` template analyzes `javascript-typescript` and `actions`.
-Unlike Go repos, web projects use `build-mode: none` (no manual build needed)
-and don't require `GH_PAT` (no private module access).
-
-For repos managed by `sync-codeql`, copy this template to `configs/codeqls/<repo-name>.yml`.
 
 ## Required Secrets
 
 | Secret | Used by | Required |
 |---|---|---|
-| `GH_PAT_READ_NICSDP` | release-please | Yes |
+| `GH_PAT_RELEASE_NICSDP` | release-please | Yes (creates release/tag and triggers downstream workflows) |
 | `GOOGLE_CHAT_WEBHOOK` | notify | Optional |
+
+## Related Files
+
+| File | Source | Purpose |
+|---|---|---|
+| `.prettierrc.json` | `configs/.prettierrc.json` | Prettier config |
+| `.prettierignore` | `configs/.prettierignore` | Prettier ignore patterns |
+| `eslint.config.js` | `configs/eslint.config.js` | ESLint flat config |
+| `vitest.config.ts` | `configs/vitest.config.ts` | Vitest config |
+| `.commitlintrc.yml` | `configs/.commitlintrc.yml` | Conventional commit message rules (synced via `sync-commitlintrc`) |
+| `renovate.json` | `configs/renovate.json` | Renovate preset + ignoreDeps (synced via `sync-renovate`) |
+| `knip.json` | `configs/knip.json` | Knip config (optional) |
+| `lighthouserc.json` | `configs/lighthouserc.json` | Lighthouse CI config (optional) |

--- a/web-templates/.github/workflows/codeql.yml
+++ b/web-templates/.github/workflows/codeql.yml
@@ -49,7 +49,7 @@ jobs:
           fetch-depth: 0
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@fb0994ef1c058010acf1efccff928b0a83b1ed54 # v4.32.6
+        uses: github/codeql-action/init@b1bff81932f5cdfc8695c7752dcee935dcd061c8 # v4.33.0
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
@@ -57,6 +57,6 @@ jobs:
           queries: security-extended,security-and-quality
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@fb0994ef1c058010acf1efccff928b0a83b1ed54 # v4.32.6
+        uses: github/codeql-action/analyze@b1bff81932f5cdfc8695c7752dcee935dcd061c8 # v4.33.0
         with:
           category: "/language:${{matrix.language}}"


### PR DESCRIPTION
## Summary

- Bump `github/codeql-action` v4.32.6 → v4.33.0 (18 files)
- Bump `semgrep/semgrep` container 1.155.0 → 1.156.0 (2 files)
- Narrow `GH_PAT` env variable from job-level to step-level in `go-lint`, `go-sec`, `go-vulncheck`, `go-release`, `trivy-license` — minimizes secret exposure to only the step that needs it
- Upgrade SBOM format from CycloneDX 1.5 → 1.6 (aligns actual behavior with existing docs)
- Separate `GH_PAT_READ_NICSDP` (CI/snapshot) vs `GH_PAT_RELEASE_NICSDP` (release-please/release) in templates
- Add missing permissions (`actions: read`, `issues: write`, `pull-requests: write`) in golang-templates
- Expand golang-templates and web-templates README with detailed workflow documentation

## Test plan

- [x] Verify `actionlint` passes on all workflow YAML files (meta CI)