### PR TITLE
fix: align configs with Vue stack and restrict release-please to main

### DIFF
--- a/.github/workflows/check-managed-files.yml
+++ b/.github/workflows/check-managed-files.yml
@@ -17,7 +17,7 @@ permissions:
 jobs:
   check:
     # Only check on PRs, skip sync PRs from meta repo
-    if: github.event_name == 'pull_request' && !startsWith(github.head_ref, 'ci/sync-')
+    if: github.event_name == 'pull_request' && !startsWith(github.head_ref, 'feature/sync-ci-')
     runs-on: ubuntu-latest
     steps:
       - name: Check for managed file changes

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -4,7 +4,7 @@ name: release-please
 
 on:
   push:
-    branches: [main, "release/**"]
+    branches: [main]
   workflow_call:
     inputs:
       release_type:

--- a/.github/workflows/sync-codeql.yml
+++ b/.github/workflows/sync-codeql.yml
@@ -100,7 +100,7 @@ jobs:
           body: |
             This is an automated pull request to sync the CodeQL config with the meta repository.
           base: ${{ steps.branch.outputs.target }}
-          branch: "ci/sync-codeql"
+          branch: "feature/sync-ci-codeql"
           delete-branch: true
           path: "${{ github.repository_owner }}/${{ inputs.repo_name }}"
           token: ${{ secrets.gh_token || secrets.GH_PAT_SYNC_NICSDP || github.token }}

--- a/.github/workflows/sync-commitlintrc.yml
+++ b/.github/workflows/sync-commitlintrc.yml
@@ -93,7 +93,7 @@ jobs:
           body: |
             This is an automated pull request to sync `.commitlintrc.yml` with the meta repository.
           base: ${{ steps.branch.outputs.target }}
-          branch: "ci/sync-commitlintrc"
+          branch: "feature/sync-ci-commitlintrc"
           delete-branch: true
           path: "${{ github.repository_owner }}/${{ inputs.repo_name }}"
           token: ${{ secrets.gh_token || secrets.GH_PAT_SYNC_NICSDP || github.token }}

--- a/.github/workflows/sync-eslint-config.yml
+++ b/.github/workflows/sync-eslint-config.yml
@@ -93,7 +93,7 @@ jobs:
           body: |
             This is an automated pull request to sync `eslint.config.js` with the meta repository.
           base: ${{ steps.branch.outputs.target }}
-          branch: "ci/sync-eslint-config"
+          branch: "feature/sync-ci-eslint-config"
           delete-branch: true
           path: "${{ github.repository_owner }}/${{ inputs.repo_name }}"
           token: ${{ secrets.gh_token || secrets.GH_PAT_SYNC_NICSDP || github.token }}

--- a/.github/workflows/sync-golangci.yml
+++ b/.github/workflows/sync-golangci.yml
@@ -93,7 +93,7 @@ jobs:
           body: |
             This is an automated pull request to sync `.golangci.yml` with the meta repository.
           base: ${{ steps.branch.outputs.target }}
-          branch: "ci/sync-golangci"
+          branch: "feature/sync-ci-golangci"
           delete-branch: true
           path: "${{ github.repository_owner }}/${{ inputs.repo_name }}"
           token: ${{ secrets.gh_token || secrets.GH_PAT_SYNC_NICSDP || github.token }}

--- a/.github/workflows/sync-knip.yml
+++ b/.github/workflows/sync-knip.yml
@@ -93,7 +93,7 @@ jobs:
           body: |
             This is an automated pull request to sync `knip.json` with the meta repository.
           base: ${{ steps.branch.outputs.target }}
-          branch: "ci/sync-knip"
+          branch: "feature/sync-ci-knip"
           delete-branch: true
           path: "${{ github.repository_owner }}/${{ inputs.repo_name }}"
           token: ${{ secrets.gh_token || secrets.GH_PAT_SYNC_NICSDP || github.token }}

--- a/.github/workflows/sync-lighthouserc.yml
+++ b/.github/workflows/sync-lighthouserc.yml
@@ -93,7 +93,7 @@ jobs:
           body: |
             This is an automated pull request to sync `lighthouserc.json` with the meta repository.
           base: ${{ steps.branch.outputs.target }}
-          branch: "ci/sync-lighthouserc"
+          branch: "feature/sync-ci-lighthouserc"
           delete-branch: true
           path: "${{ github.repository_owner }}/${{ inputs.repo_name }}"
           token: ${{ secrets.gh_token || secrets.GH_PAT_SYNC_NICSDP || github.token }}

--- a/.github/workflows/sync-prettier.yml
+++ b/.github/workflows/sync-prettier.yml
@@ -94,7 +94,7 @@ jobs:
           body: |
             This is an automated pull request to sync `.prettierrc.json` and `.prettierignore` with the meta repository.
           base: ${{ steps.branch.outputs.target }}
-          branch: "ci/sync-prettier"
+          branch: "feature/sync-ci-prettier"
           delete-branch: true
           path: "${{ github.repository_owner }}/${{ inputs.repo_name }}"
           token: ${{ secrets.gh_token || secrets.GH_PAT_SYNC_NICSDP || github.token }}

--- a/.github/workflows/sync-vitest-config.yml
+++ b/.github/workflows/sync-vitest-config.yml
@@ -93,7 +93,7 @@ jobs:
           body: |
             This is an automated pull request to sync `vitest.config.ts` with the meta repository.
           base: ${{ steps.branch.outputs.target }}
-          branch: "ci/sync-vitest-config"
+          branch: "feature/sync-ci-vitest-config"
           delete-branch: true
           path: "${{ github.repository_owner }}/${{ inputs.repo_name }}"
           token: ${{ secrets.gh_token || secrets.GH_PAT_SYNC_NICSDP || github.token }}

--- a/configs/eslint.config.js
+++ b/configs/eslint.config.js
@@ -1,23 +1,16 @@
-import js from '@eslint/js'
-import globals from 'globals'
-import reactHooks from 'eslint-plugin-react-hooks'
-import reactRefresh from 'eslint-plugin-react-refresh'
-import tseslint from 'typescript-eslint'
-import { defineConfig, globalIgnores } from 'eslint/config'
+import pluginVue from 'eslint-plugin-vue'
+import {
+  defineConfigWithVueTs,
+  vueTsConfigs,
+} from '@vue/eslint-config-typescript'
 
-export default defineConfig([
-  globalIgnores(['dist']),
+export default defineConfigWithVueTs(
+  { ignores: ['dist/', 'node_modules/'] },
+  pluginVue.configs['flat/essential'],
+  vueTsConfigs.recommended,
   {
-    files: ['**/*.{ts,tsx}'],
-    extends: [
-      js.configs.recommended,
-      tseslint.configs.recommended,
-      reactHooks.configs.flat.recommended,
-      reactRefresh.configs.vite,
-    ],
-    languageOptions: {
-      ecmaVersion: 2020,
-      globals: globals.browser,
+    rules: {
+      'vue/multi-word-component-names': 'off',
     },
   },
-])
+)

--- a/configs/vitest.config.ts
+++ b/configs/vitest.config.ts
@@ -1,9 +1,9 @@
 import { defineConfig } from 'vitest/config'
-import react from '@vitejs/plugin-react'
+import vue from '@vitejs/plugin-vue'
 import { fileURLToPath } from 'url'
 
 export default defineConfig({
-  plugins: [react()],
+  plugins: [vue()],
   resolve: {
     alias: {
       '@': fileURLToPath(new URL('./src', import.meta.url)),

--- a/golang-templates/.github/README.md
+++ b/golang-templates/.github/README.md
@@ -8,7 +8,7 @@ All workflows call reusable workflows from `nics-dp/meta`.
 | File | Purpose | Triggers |
 |---|---|---|
 | `ci.yml` | Managed file check, commitlint, hadolint, trivy-iac, trivy-license, lint, security scan, vulnerability check, Semgrep, test | push, PR, manual |
-| `release-please.yml` | Auto-create Release PR with changelog, then GitHub Release | push to main/release |
+| `release-please.yml` | Auto-create Release PR with changelog, then GitHub Release | push to main |
 | `release.yml` | Build Go binaries, Docker image, SBOMs, sign artifacts | release created, manual |
 | `snapshot.yml` | Build snapshot artifacts on PR, post artifact links via `artifacts-comment` | CI success on PR, manual |
 | `codeql.yml` | CodeQL security analysis (Go + Actions) | push, PR, weekly, manual |
@@ -59,7 +59,7 @@ go-semgrep ────┘ (independent)
 Auto-creates Release PRs with changelog based on conventional commits. After merge, creates GitHub Release + tag which triggers release.yml.
 
 **Triggers:**
-- Push to `main`, `release/**`
+- Push to `main`
 
 **Flow:**
 1. Detect conventional commits, calculate next semver version

--- a/golang-templates/.github/workflows/release-please.yml
+++ b/golang-templates/.github/workflows/release-please.yml
@@ -11,7 +11,7 @@ name: release-please
 
 on:
   push:
-    branches: [main, "release/**"]
+    branches: [main]
 
 permissions: {}
 

--- a/web-templates/.github/README.md
+++ b/web-templates/.github/README.md
@@ -8,7 +8,7 @@ All workflows call reusable workflows from `nics-dp/meta`, and CI tasks run thro
 | File | Purpose | Triggers |
 |---|---|---|
 | `ci.yml` | Lint, typecheck, build, audit, test, format check, Semgrep, trivy-license, hadolint, trivy-iac, knip, lighthouse | push, PR, manual |
-| `release-please.yml` | Automated release management | push to main/release |
+| `release-please.yml` | Automated release management | push to main |
 | `codeql.yml` | CodeQL security analysis (JS/TS + Actions) | push, PR, weekly, manual |
 | `notify.yml` | Google Chat notifications | PR, push, release, issue, CI events |
 
@@ -79,7 +79,7 @@ These jobs are enabled in the shipped `ci.yml` unless otherwise noted. Remove or
 Auto-creates Release PRs with changelog based on conventional commits. After merge, creates GitHub Release + tag.
 
 **Triggers:**
-- Push to `main`, `release/**`
+- Push to `main`
 
 **Flow:**
 1. Detect conventional commits, calculate next semver version

--- a/web-templates/.github/README.md
+++ b/web-templates/.github/README.md
@@ -181,7 +181,13 @@ Sends GitHub event notifications to Google Chat.
 
 7. Install devDependencies:
    ```bash
-   # Required
+   # Required (Vue + Vite + TypeScript)
+   bun add -d @vitejs/plugin-vue vue-tsc
+
+   # Required (ESLint)
+   bun add -d eslint-plugin-vue @vue/eslint-config-typescript
+
+   # Required (Prettier)
    bun add -d prettier prettier-plugin-tailwindcss
 
    # Required (ci.yml runs test by default)

--- a/web-templates/.github/README.md
+++ b/web-templates/.github/README.md
@@ -1,6 +1,6 @@
 # GitHub Workflows for Web Projects
 
-This directory contains workflow and config templates for React + Vite + TypeScript + Bun web projects.
+This directory contains workflow and config templates for Vue + Vite + TypeScript + Bun web projects.
 All workflows call reusable workflows from `nics-dp/meta`, and CI tasks run through `mise`.
 
 ## Workflows
@@ -164,10 +164,10 @@ Sends GitHub event notifications to Google Chat.
    {
      "scripts": {
        "dev": "vite",
-       "build": "tsc -b && vite build",
+       "build": "vue-tsc -b && vite build",
        "lint": "eslint .",
        "lint:fix": "eslint . --fix",
-       "typecheck": "tsc --noEmit",
+       "typecheck": "vue-tsc --noEmit",
        "format:check": "prettier --check .",
        "format": "prettier --write .",
        "test": "vitest run",

--- a/web-templates/.github/workflows/ci.yml
+++ b/web-templates/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
 #
 # Web CI workflow template
-# React + Vite + TypeScript + Bun
+# Vue + Vite + TypeScript + Bun
 #
 # All jobs call reusable workflows from nics-dp/meta.
 #

--- a/web-templates/.github/workflows/release-please.yml
+++ b/web-templates/.github/workflows/release-please.yml
@@ -10,7 +10,7 @@ name: release-please
 
 on:
   push:
-    branches: [main, "release/**"]
+    branches: [main]
 
 permissions: {}
 


### PR DESCRIPTION
## Summary
- 將 ESLint、Vitest 共用設定從 React 改為 Vue（eslint-plugin-vue、@vue/eslint-config-typescript、@vitejs/plugin-vue）
- 將 sync workflow 分支前綴從 `ci/sync-` 改為 `feature/sync-ci-`，同步更新 check-managed-files 跳過邏輯
- 限制 release-please 觸發條件僅 `main` 分支（移除 `release/**`）
- 更新 web-templates README 與 ci.yml 註解，反映 Vue stack

## Test plan
- [ ] 確認 sync workflows 使用新分支前綴 `feature/sync-ci-*` 正常建立 PR
- [ ] 確認 check-managed-files 正確跳過 `feature/sync-ci-*` 分支
- [ ] 確認 release-please 僅在 push to main 時觸發
- [ ] 確認 ESLint/Vitest 設定同步至 web repos 後可正常運作