### PR TITLE
chore(mise): pin tool versions and add mise Renovate rule

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,7 +1,7 @@
 [tools]
-actionlint = "latest"
-act = "latest"
-codeql = { version = "latest", bin_path = "codeql", platforms = """
+actionlint = "1.7.11"
+act = "0.2.85"
+codeql = { version = "2.24.3", bin_path = "codeql", platforms = """
 [linux-x64]
 asset_pattern = "codeql-linux64.zip"
 
@@ -15,7 +15,7 @@ asset_pattern = "codeql-osx64.zip"
 asset_pattern = "codeql-win64.zip"
 """ }
 
-bun = "latest"
+bun = "1.3.11"
 
 # ------------------------------------------------------------------------------
 # ==============================================================================

--- a/renovate-preset.json
+++ b/renovate-preset.json
@@ -40,6 +40,14 @@
       "automerge": false
     },
     {
+      "description": "Group mise dev tool updates",
+      "matchManagers": ["mise"],
+      "groupName": "mise dev tools",
+      "commitMessagePrefix": "chore(mise.deps):",
+      "labels": ["dependencies", "mise"],
+      "automerge": false
+    },
+    {
       "description": "Automerge patch updates",
       "matchUpdateTypes": ["patch"],
       "automerge": true,


### PR DESCRIPTION
## Summary

- Pin all mise tool versions from `latest` to specific versions to reduce GitHub API calls in CI and avoid rate limiting.
- Add a `mise` packageRule to `renovate-preset.json` so Renovate automatically manages mise tool version updates across all repos using the org preset.

## Test plan

- [ ] Verify CI passes with pinned versions
- [ ] Confirm Renovate detects mise tool updates in repos using this preset