### PR TITLE
ci(mise): install only required tools per workflow

### DIFF
--- a/.github/workflows/go-lint.yml
+++ b/.github/workflows/go-lint.yml
@@ -47,6 +47,10 @@ jobs:
           cache: true
           experimental: true
           log_level: "info"
+          install: false
+
+      - name: Install required tools
+        run: mise install go golangci-lint
 
       - name: Initialize environment
         run: mise run init

--- a/.github/workflows/go-sec.yml
+++ b/.github/workflows/go-sec.yml
@@ -46,6 +46,10 @@ jobs:
           cache: true
           experimental: true
           log_level: "info"
+          install: false
+
+      - name: Install required tools
+        run: mise install go "aqua:securego/gosec"
 
       - name: Initialize environment
         run: mise run init

--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -56,6 +56,10 @@ jobs:
           cache: true
           experimental: true
           log_level: "info"
+          install: false
+
+      - name: Install required tools
+        run: mise install go
 
       - name: Initialize environment
         run: mise run init
@@ -111,6 +115,10 @@ jobs:
           cache: true
           experimental: true
           log_level: "info"
+          install: false
+
+      - name: Install required tools
+        run: mise install go
 
       - name: Initialize environment
         run: mise run init

--- a/.github/workflows/go-vulncheck.yml
+++ b/.github/workflows/go-vulncheck.yml
@@ -46,6 +46,10 @@ jobs:
           cache: true
           experimental: true
           log_level: "info"
+          install: false
+
+      - name: Install required tools
+        run: mise install go "go:golang.org/x/vuln/cmd/govulncheck"
 
       - name: Initialize environment
         run: mise run init

--- a/.github/workflows/trivy-license.yml
+++ b/.github/workflows/trivy-license.yml
@@ -49,6 +49,10 @@ jobs:
           cache: true
           experimental: true
           log_level: "info"
+          install: false
+
+      - name: Install required tools
+        run: mise install go
 
       - name: Initialize environment
         run: mise run init


### PR DESCRIPTION
## Summary

- Use `install: false` in mise-action and selectively install only needed tools
- Each workflow now only installs what it actually uses instead of all ~15 tools from mise.toml

| Workflow | Tools installed |
|----------|---------------|
| go-lint | go, golangci-lint |
| go-sec | go, gosec |
| go-vulncheck | go, govulncheck |
| go-test | go |
| trivy-license | go (trivy from trivy-action) |

## Why

When CI runs multiple jobs in parallel, each job previously called `mise install` which installed ALL tools. This triggered GitHub API rate limiting (403 Forbidden) because resolving and downloading ~15 tools × 5 jobs = ~75 API calls sharing the same `GITHUB_TOKEN` quota.

With selective installation, total API calls drop to ~12, dramatically reducing rate limit risk.

## Test plan

- [ ] Verify all CI workflows still pass with selective tool installation
- [ ] Confirm no missing tool errors in any workflow