### PR TITLE
feat: Vue stack alignment, mise pinning, and workflow fixes

### DIFF
--- a/.github/workflows/go-lint.yml
+++ b/.github/workflows/go-lint.yml
@@ -47,6 +47,10 @@ jobs:
           cache: true
           experimental: true
           log_level: "info"
+          install: false
+
+      - name: Install required tools
+        run: mise install go golangci-lint
 
       - name: Initialize environment
         run: mise run init

--- a/.github/workflows/go-sec.yml
+++ b/.github/workflows/go-sec.yml
@@ -46,6 +46,10 @@ jobs:
           cache: true
           experimental: true
           log_level: "info"
+          install: false
+
+      - name: Install required tools
+        run: mise install go "aqua:securego/gosec"
 
       - name: Initialize environment
         run: mise run init

--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -56,6 +56,10 @@ jobs:
           cache: true
           experimental: true
           log_level: "info"
+          install: false
+
+      - name: Install required tools
+        run: mise install go
 
       - name: Initialize environment
         run: mise run init
@@ -111,6 +115,10 @@ jobs:
           cache: true
           experimental: true
           log_level: "info"
+          install: false
+
+      - name: Install required tools
+        run: mise install go
 
       - name: Initialize environment
         run: mise run init

--- a/.github/workflows/go-vulncheck.yml
+++ b/.github/workflows/go-vulncheck.yml
@@ -46,6 +46,10 @@ jobs:
           cache: true
           experimental: true
           log_level: "info"
+          install: false
+
+      - name: Install required tools
+        run: mise install go "go:golang.org/x/vuln/cmd/govulncheck"
 
       - name: Initialize environment
         run: mise run init

--- a/.github/workflows/trivy-license.yml
+++ b/.github/workflows/trivy-license.yml
@@ -49,6 +49,10 @@ jobs:
           cache: true
           experimental: true
           log_level: "info"
+          install: false
+
+      - name: Install required tools
+        run: mise install go
 
       - name: Initialize environment
         run: mise run init

--- a/mise.toml
+++ b/mise.toml
@@ -1,7 +1,7 @@
 [tools]
-actionlint = "latest"
-act = "latest"
-codeql = { version = "latest", bin_path = "codeql", platforms = """
+actionlint = "1.7.11"
+act = "0.2.85"
+codeql = { version = "2.24.3", bin_path = "codeql", platforms = """
 [linux-x64]
 asset_pattern = "codeql-linux64.zip"
 
@@ -15,7 +15,7 @@ asset_pattern = "codeql-osx64.zip"
 asset_pattern = "codeql-win64.zip"
 """ }
 
-bun = "latest"
+bun = "1.3.11"
 
 # ------------------------------------------------------------------------------
 # ==============================================================================

--- a/mise.toml
+++ b/mise.toml
@@ -21,6 +21,32 @@ bun = "1.3.11"
 # ==============================================================================
 #  Compile Ruler
 # ==============================================================================
-[tasks.ruler]  # command: mise run ruler
+[tasks.ruler] # command: mise run ruler
 description = "Compile ruler to AGENTS.md and CLAUDE.md"
 run = "bunx @intellectronica/ruler apply"
+
+# ==============================================================================
+#  Tool Management
+# ==============================================================================
+[tasks."tools:bump"]
+description = "Bump all tool versions to latest"
+raw = true
+run = '''
+echo "Checking for outdated tools..."
+echo ""
+mise outdated --bump
+echo ""
+read -p "Proceed with upgrade? (y/N) " confirm
+if [ "$confirm" = "y" ] || [ "$confirm" = "Y" ]; then
+    mise outdated --bump | grep -v '^name ' | awk 'NF>0 {print $1"@"$4}' | while IFS= read -r tool; do
+        echo "  -> mise use $tool"
+        mise use "$tool"
+    done
+    echo ""
+    mise install
+    echo ""
+    echo "Done! Run 'mise run ci' to verify compatibility."
+else
+    echo "Cancelled."
+fi
+'''

--- a/renovate-preset.json
+++ b/renovate-preset.json
@@ -40,6 +40,14 @@
       "automerge": false
     },
     {
+      "description": "Group mise dev tool updates",
+      "matchManagers": ["mise"],
+      "groupName": "mise dev tools",
+      "commitMessagePrefix": "chore(mise.deps):",
+      "labels": ["dependencies", "mise"],
+      "automerge": false
+    },
+    {
       "description": "Automerge patch updates",
       "matchUpdateTypes": ["patch"],
       "automerge": true,


### PR DESCRIPTION
## Summary

- **Vue stack alignment**: 更新 eslint、vitest 配置及 web-templates 文件，從 React 切換到 Vue
- **Mise tool pinning**: 固定工具版本、按 workflow 選擇性安裝、新增 `tools:bump` 互動式升級任務，並加入 Renovate 規則
- **Workflow fixes**: 限制 release-please 僅在 main 觸發、重命名 sync branch prefix (`ci/sync-` → `feature/sync-ci-`)、Go workflows 加入 mise 工具安裝

## Commits

- `fix: update vitest config to use vue plugin instead of react`
- `fix: update eslint config and docs to align with vue stack`
- `fix: add Vue devDependencies to web-templates README`
- `fix: update ci.yml comment from React to Vue`
- `fix(ci): rename sync branch prefix from ci/sync- to feature/sync-ci-`
- `fix: restrict release-please trigger to main branch only`
- `chore(mise): pin tool versions and add mise Renovate rule`
- `ci(mise): install only required tools per workflow`
- `feat(mise): add tools:bump task for interactive upgrades`

## Test plan

- [ ] 確認 actionlint CI 通過
- [ ] 確認 commitlint CI 通過
- [ ] 驗證 sync workflows 使用新的 branch prefix `feature/sync-ci-`