### PR TITLE
ci: add submodules checkout and gh_pat for semgrep workflows

### DIFF
--- a/.github/workflows/bun-audit.yml
+++ b/.github/workflows/bun-audit.yml
@@ -15,6 +15,9 @@ on:
         type: string
         default: ""
         description: "Optional shell command override"
+    secrets:
+      gh_pat:
+        required: false
 
 permissions:
   contents: read
@@ -25,14 +28,22 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          submodules: recursive
+          token: ${{ secrets.gh_pat }}
+
       - uses: jdx/mise-action@c1ecc8f748cd28cdeabf76dab3cccde4ce692fe4 # v4.0.0
         with:
           cache: true
           experimental: true
           log_level: "info"
+          install: false
+
+      - name: Install required tools
+        run: mise install bun
 
       - name: Initialize environment
-        run: mise run init
+        run: MISE_AUTO_INSTALL=false mise run init
 
       - name: Run audit
         env:

--- a/.github/workflows/bun-build.yml
+++ b/.github/workflows/bun-build.yml
@@ -15,6 +15,9 @@ on:
         type: string
         default: ""
         description: "Optional shell command override"
+    secrets:
+      gh_pat:
+        required: false
 
 permissions:
   contents: read
@@ -25,14 +28,22 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          submodules: recursive
+          token: ${{ secrets.gh_pat }}
+
       - uses: jdx/mise-action@c1ecc8f748cd28cdeabf76dab3cccde4ce692fe4 # v4.0.0
         with:
           cache: true
           experimental: true
           log_level: "info"
+          install: false
+
+      - name: Install required tools
+        run: mise install bun
 
       - name: Initialize environment
-        run: mise run init
+        run: MISE_AUTO_INSTALL=false mise run init
 
       - name: Run build
         env:

--- a/.github/workflows/bun-bundle-size.yml
+++ b/.github/workflows/bun-bundle-size.yml
@@ -15,6 +15,9 @@ on:
         type: string
         default: ""
         description: "Optional shell command override"
+    secrets:
+      gh_pat:
+        required: false
 
 permissions:
   contents: read
@@ -25,14 +28,22 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          submodules: recursive
+          token: ${{ secrets.gh_pat }}
+
       - uses: jdx/mise-action@c1ecc8f748cd28cdeabf76dab3cccde4ce692fe4 # v4.0.0
         with:
           cache: true
           experimental: true
           log_level: "info"
+          install: false
+
+      - name: Install required tools
+        run: mise install bun
 
       - name: Initialize environment
-        run: mise run init
+        run: MISE_AUTO_INSTALL=false mise run init
 
       - name: Run bundle size check
         env:

--- a/.github/workflows/bun-format-check.yml
+++ b/.github/workflows/bun-format-check.yml
@@ -15,6 +15,9 @@ on:
         type: string
         default: ""
         description: "Optional shell command override"
+    secrets:
+      gh_pat:
+        required: false
 
 permissions:
   contents: read
@@ -25,14 +28,22 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          submodules: recursive
+          token: ${{ secrets.gh_pat }}
+
       - uses: jdx/mise-action@c1ecc8f748cd28cdeabf76dab3cccde4ce692fe4 # v4.0.0
         with:
           cache: true
           experimental: true
           log_level: "info"
+          install: false
+
+      - name: Install required tools
+        run: mise install bun
 
       - name: Initialize environment
-        run: mise run init
+        run: MISE_AUTO_INSTALL=false mise run init
 
       - name: Run format check
         env:

--- a/.github/workflows/bun-knip.yml
+++ b/.github/workflows/bun-knip.yml
@@ -15,6 +15,9 @@ on:
         type: string
         default: ""
         description: "Optional shell command override"
+    secrets:
+      gh_pat:
+        required: false
 
 permissions:
   contents: read
@@ -25,14 +28,22 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          submodules: recursive
+          token: ${{ secrets.gh_pat }}
+
       - uses: jdx/mise-action@c1ecc8f748cd28cdeabf76dab3cccde4ce692fe4 # v4.0.0
         with:
           cache: true
           experimental: true
           log_level: "info"
+          install: false
+
+      - name: Install required tools
+        run: mise install bun
 
       - name: Initialize environment
-        run: mise run init
+        run: MISE_AUTO_INSTALL=false mise run init
 
       - name: Run knip
         env:

--- a/.github/workflows/bun-lighthouse.yml
+++ b/.github/workflows/bun-lighthouse.yml
@@ -15,6 +15,9 @@ on:
         type: string
         default: ""
         description: "Optional shell command override"
+    secrets:
+      gh_pat:
+        required: false
 
 permissions:
   contents: read
@@ -25,14 +28,22 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          submodules: recursive
+          token: ${{ secrets.gh_pat }}
+
       - uses: jdx/mise-action@c1ecc8f748cd28cdeabf76dab3cccde4ce692fe4 # v4.0.0
         with:
           cache: true
           experimental: true
           log_level: "info"
+          install: false
+
+      - name: Install required tools
+        run: mise install bun
 
       - name: Initialize environment
-        run: mise run init
+        run: MISE_AUTO_INSTALL=false mise run init
 
       - name: Run Lighthouse CI
         env:

--- a/.github/workflows/bun-lint.yml
+++ b/.github/workflows/bun-lint.yml
@@ -15,6 +15,9 @@ on:
         type: string
         default: ""
         description: "Optional shell command override"
+    secrets:
+      gh_pat:
+        required: false
 
 permissions:
   contents: read
@@ -25,14 +28,22 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          submodules: recursive
+          token: ${{ secrets.gh_pat }}
+
       - uses: jdx/mise-action@c1ecc8f748cd28cdeabf76dab3cccde4ce692fe4 # v4.0.0
         with:
           cache: true
           experimental: true
           log_level: "info"
+          install: false
+
+      - name: Install required tools
+        run: mise install bun
 
       - name: Initialize environment
-        run: mise run init
+        run: MISE_AUTO_INSTALL=false mise run init
 
       - name: Run lint
         env:

--- a/.github/workflows/bun-semgrep.yml
+++ b/.github/workflows/bun-semgrep.yml
@@ -10,6 +10,9 @@ on:
         type: string
         default: "p/javascript p/typescript"
         description: "Semgrep config/ruleset (space-separated, e.g., p/javascript p/typescript p/react)"
+    secrets:
+      gh_pat:
+        required: false
 
 permissions:
   contents: read
@@ -23,6 +26,9 @@ jobs:
       image: semgrep/semgrep:1.156.0
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          submodules: recursive
+          token: ${{ secrets.gh_pat }}
 
       - name: Run semgrep
         id: semgrep

--- a/.github/workflows/bun-test.yml
+++ b/.github/workflows/bun-test.yml
@@ -15,6 +15,9 @@ on:
         type: string
         default: ""
         description: "Optional shell command override"
+    secrets:
+      gh_pat:
+        required: false
 
 permissions:
   contents: read
@@ -25,14 +28,22 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          submodules: recursive
+          token: ${{ secrets.gh_pat }}
+
       - uses: jdx/mise-action@c1ecc8f748cd28cdeabf76dab3cccde4ce692fe4 # v4.0.0
         with:
           cache: true
           experimental: true
           log_level: "info"
+          install: false
+
+      - name: Install required tools
+        run: mise install bun
 
       - name: Initialize environment
-        run: mise run init
+        run: MISE_AUTO_INSTALL=false mise run init
 
       - name: Run tests
         env:

--- a/.github/workflows/bun-typecheck.yml
+++ b/.github/workflows/bun-typecheck.yml
@@ -15,6 +15,9 @@ on:
         type: string
         default: ""
         description: "Optional shell command override"
+    secrets:
+      gh_pat:
+        required: false
 
 permissions:
   contents: read
@@ -25,14 +28,22 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          submodules: recursive
+          token: ${{ secrets.gh_pat }}
+
       - uses: jdx/mise-action@c1ecc8f748cd28cdeabf76dab3cccde4ce692fe4 # v4.0.0
         with:
           cache: true
           experimental: true
           log_level: "info"
+          install: false
+
+      - name: Install required tools
+        run: mise install bun
 
       - name: Initialize environment
-        run: mise run init
+        run: MISE_AUTO_INSTALL=false mise run init
 
       - name: Run typecheck
         env:

--- a/.github/workflows/go-lint.yml
+++ b/.github/workflows/go-lint.yml
@@ -27,6 +27,9 @@ jobs:
       HAS_GH_PAT: ${{ secrets.gh_pat != '' }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          submodules: recursive
+          token: ${{ secrets.gh_pat }}
 
       - name: Configure private git repository
         if: env.HAS_GH_PAT == 'true'
@@ -53,7 +56,7 @@ jobs:
         run: mise install go golangci-lint
 
       - name: Initialize environment
-        run: mise run init
+        run: MISE_AUTO_INSTALL=false mise run go:mod
 
       - name: Run lint (reviewdog)
         if: github.event_name == 'pull_request'

--- a/.github/workflows/go-sec.yml
+++ b/.github/workflows/go-sec.yml
@@ -26,6 +26,9 @@ jobs:
       HAS_GH_PAT: ${{ secrets.gh_pat != '' }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          submodules: recursive
+          token: ${{ secrets.gh_pat }}
 
       - name: Configure private git repository
         if: env.HAS_GH_PAT == 'true'
@@ -52,7 +55,7 @@ jobs:
         run: mise install go "aqua:securego/gosec"
 
       - name: Initialize environment
-        run: mise run init
+        run: MISE_AUTO_INSTALL=false mise run go:mod
 
       - name: Run security scan
         id: gosec

--- a/.github/workflows/go-semgrep.yml
+++ b/.github/workflows/go-semgrep.yml
@@ -10,6 +10,9 @@ on:
         type: string
         default: "p/golang"
         description: "Semgrep config/ruleset (e.g., p/golang, path to rules file)"
+    secrets:
+      gh_pat:
+        required: false
 
 permissions:
   contents: read
@@ -23,6 +26,9 @@ jobs:
       image: semgrep/semgrep:1.156.0
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          submodules: recursive
+          token: ${{ secrets.gh_pat }}
 
       - name: Run semgrep
         id: semgrep

--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -36,6 +36,9 @@ jobs:
       HAS_GH_PAT: ${{ secrets.gh_pat != '' }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          submodules: recursive
+          token: ${{ secrets.gh_pat }}
 
       - name: Configure private git repository
         if: env.HAS_GH_PAT == 'true'
@@ -62,7 +65,7 @@ jobs:
         run: mise install go
 
       - name: Initialize environment
-        run: mise run init
+        run: MISE_AUTO_INSTALL=false mise run go:mod
 
       - name: Run unit tests
         env:
@@ -95,6 +98,9 @@ jobs:
       HAS_GH_PAT: ${{ secrets.gh_pat != '' }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          submodules: recursive
+          token: ${{ secrets.gh_pat }}
 
       - name: Configure private git repository
         if: env.HAS_GH_PAT == 'true'
@@ -121,7 +127,7 @@ jobs:
         run: mise install go
 
       - name: Initialize environment
-        run: mise run init
+        run: MISE_AUTO_INSTALL=false mise run go:mod
 
       - name: Download coverage data
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1

--- a/.github/workflows/go-vulncheck.yml
+++ b/.github/workflows/go-vulncheck.yml
@@ -26,6 +26,9 @@ jobs:
       HAS_GH_PAT: ${{ secrets.gh_pat != '' }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          submodules: recursive
+          token: ${{ secrets.gh_pat }}
 
       - name: Configure private git repository
         if: env.HAS_GH_PAT == 'true'
@@ -52,7 +55,7 @@ jobs:
         run: mise install go "go:golang.org/x/vuln/cmd/govulncheck"
 
       - name: Initialize environment
-        run: mise run init
+        run: MISE_AUTO_INSTALL=false mise run go:mod
 
       - name: Run govulncheck
         id: vulncheck

--- a/.github/workflows/trivy-license.yml
+++ b/.github/workflows/trivy-license.yml
@@ -29,6 +29,9 @@ jobs:
       HAS_GH_PAT: ${{ secrets.gh_pat != '' }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          submodules: recursive
+          token: ${{ secrets.gh_pat }}
 
       - name: Configure private git repository
         if: env.HAS_GH_PAT == 'true'
@@ -55,7 +58,7 @@ jobs:
         run: mise install go
 
       - name: Initialize environment
-        run: mise run init
+        run: MISE_AUTO_INSTALL=false mise run go:mod
 
       - name: Run Trivy license scan (table)
         uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # 0.35.0


### PR DESCRIPTION
## Summary
- Add `gh_pat` secret and `actions/checkout` with submodules for Go and Bun semgrep workflows to support private repo scanning
- Replace `mise run init` with `go:mod` and add submodule checkout in Go CI workflows
- Add selective `mise install`, disable `auto-install`, and checkout with submodules in Bun CI workflows

## Test plan
- [ ] Verify semgrep workflows can access private submodules with `gh_pat`
- [ ] Confirm Go CI workflows function correctly with `go:mod` instead of `init`
- [ ] Confirm Bun CI workflows install only required tools

Closes #136
