### PR TITLE
ci: add MISE_AUTO_INSTALL=false to all mise commands

### DIFF
--- a/.github/workflows/bun-audit.yml
+++ b/.github/workflows/bun-audit.yml
@@ -40,7 +40,7 @@ jobs:
           install: false
 
       - name: Install required tools
-        run: mise install bun
+        run: MISE_AUTO_INSTALL=false mise install bun
 
       - name: Initialize environment
         run: MISE_AUTO_INSTALL=false mise run init
@@ -53,5 +53,5 @@ jobs:
           if [ -n "$COMMAND" ]; then
             bash -euo pipefail -lc "$COMMAND"
           else
-            mise run "$TASK"
+            MISE_AUTO_INSTALL=false mise run "$TASK"
           fi

--- a/.github/workflows/bun-build.yml
+++ b/.github/workflows/bun-build.yml
@@ -40,7 +40,7 @@ jobs:
           install: false
 
       - name: Install required tools
-        run: mise install bun
+        run: MISE_AUTO_INSTALL=false mise install bun
 
       - name: Initialize environment
         run: MISE_AUTO_INSTALL=false mise run init
@@ -53,5 +53,5 @@ jobs:
           if [ -n "$COMMAND" ]; then
             bash -euo pipefail -lc "$COMMAND"
           else
-            mise run "$TASK"
+            MISE_AUTO_INSTALL=false mise run "$TASK"
           fi

--- a/.github/workflows/bun-bundle-size.yml
+++ b/.github/workflows/bun-bundle-size.yml
@@ -40,7 +40,7 @@ jobs:
           install: false
 
       - name: Install required tools
-        run: mise install bun
+        run: MISE_AUTO_INSTALL=false mise install bun
 
       - name: Initialize environment
         run: MISE_AUTO_INSTALL=false mise run init
@@ -53,5 +53,5 @@ jobs:
           if [ -n "$COMMAND" ]; then
             bash -euo pipefail -lc "$COMMAND"
           else
-            mise run "$TASK"
+            MISE_AUTO_INSTALL=false mise run "$TASK"
           fi

--- a/.github/workflows/bun-format-check.yml
+++ b/.github/workflows/bun-format-check.yml
@@ -40,7 +40,7 @@ jobs:
           install: false
 
       - name: Install required tools
-        run: mise install bun
+        run: MISE_AUTO_INSTALL=false mise install bun
 
       - name: Initialize environment
         run: MISE_AUTO_INSTALL=false mise run init
@@ -53,5 +53,5 @@ jobs:
           if [ -n "$COMMAND" ]; then
             bash -euo pipefail -lc "$COMMAND"
           else
-            mise run "$TASK"
+            MISE_AUTO_INSTALL=false mise run "$TASK"
           fi

--- a/.github/workflows/bun-knip.yml
+++ b/.github/workflows/bun-knip.yml
@@ -40,7 +40,7 @@ jobs:
           install: false
 
       - name: Install required tools
-        run: mise install bun
+        run: MISE_AUTO_INSTALL=false mise install bun
 
       - name: Initialize environment
         run: MISE_AUTO_INSTALL=false mise run init
@@ -53,5 +53,5 @@ jobs:
           if [ -n "$COMMAND" ]; then
             bash -euo pipefail -lc "$COMMAND"
           else
-            mise run "$TASK"
+            MISE_AUTO_INSTALL=false mise run "$TASK"
           fi

--- a/.github/workflows/bun-lighthouse.yml
+++ b/.github/workflows/bun-lighthouse.yml
@@ -40,7 +40,7 @@ jobs:
           install: false
 
       - name: Install required tools
-        run: mise install bun
+        run: MISE_AUTO_INSTALL=false mise install bun
 
       - name: Initialize environment
         run: MISE_AUTO_INSTALL=false mise run init
@@ -53,5 +53,5 @@ jobs:
           if [ -n "$COMMAND" ]; then
             bash -euo pipefail -lc "$COMMAND"
           else
-            mise run "$TASK"
+            MISE_AUTO_INSTALL=false mise run "$TASK"
           fi

--- a/.github/workflows/bun-lint.yml
+++ b/.github/workflows/bun-lint.yml
@@ -40,7 +40,7 @@ jobs:
           install: false
 
       - name: Install required tools
-        run: mise install bun
+        run: MISE_AUTO_INSTALL=false mise install bun
 
       - name: Initialize environment
         run: MISE_AUTO_INSTALL=false mise run init
@@ -53,5 +53,5 @@ jobs:
           if [ -n "$COMMAND" ]; then
             bash -euo pipefail -lc "$COMMAND"
           else
-            mise run "$TASK"
+            MISE_AUTO_INSTALL=false mise run "$TASK"
           fi

--- a/.github/workflows/bun-test.yml
+++ b/.github/workflows/bun-test.yml
@@ -40,7 +40,7 @@ jobs:
           install: false
 
       - name: Install required tools
-        run: mise install bun
+        run: MISE_AUTO_INSTALL=false mise install bun
 
       - name: Initialize environment
         run: MISE_AUTO_INSTALL=false mise run init
@@ -53,5 +53,5 @@ jobs:
           if [ -n "$COMMAND" ]; then
             bash -euo pipefail -lc "$COMMAND"
           else
-            mise run "$TASK"
+            MISE_AUTO_INSTALL=false mise run "$TASK"
           fi

--- a/.github/workflows/bun-typecheck.yml
+++ b/.github/workflows/bun-typecheck.yml
@@ -40,7 +40,7 @@ jobs:
           install: false
 
       - name: Install required tools
-        run: mise install bun
+        run: MISE_AUTO_INSTALL=false mise install bun
 
       - name: Initialize environment
         run: MISE_AUTO_INSTALL=false mise run init
@@ -53,5 +53,5 @@ jobs:
           if [ -n "$COMMAND" ]; then
             bash -euo pipefail -lc "$COMMAND"
           else
-            mise run "$TASK"
+            MISE_AUTO_INSTALL=false mise run "$TASK"
           fi

--- a/.github/workflows/go-lint.yml
+++ b/.github/workflows/go-lint.yml
@@ -53,7 +53,7 @@ jobs:
           install: false
 
       - name: Install required tools
-        run: mise install go golangci-lint
+        run: MISE_AUTO_INSTALL=false mise install go golangci-lint
 
       - name: Initialize environment
         run: MISE_AUTO_INSTALL=false mise run go:mod
@@ -69,7 +69,7 @@ jobs:
 
       - name: Run lint
         if: github.event_name != 'pull_request'
-        run: mise run ci:go-lint
+        run: MISE_AUTO_INSTALL=false mise run ci:go-lint
 
       - name: Revoke private git repository access
         if: always() && env.HAS_GH_PAT == 'true'

--- a/.github/workflows/go-sec.yml
+++ b/.github/workflows/go-sec.yml
@@ -52,7 +52,7 @@ jobs:
           install: false
 
       - name: Install required tools
-        run: mise install go "aqua:securego/gosec"
+        run: MISE_AUTO_INSTALL=false mise install go "aqua:securego/gosec"
 
       - name: Initialize environment
         run: MISE_AUTO_INSTALL=false mise run go:mod
@@ -60,7 +60,7 @@ jobs:
       - name: Run security scan
         id: gosec
         run: |
-          mise run ci:go-sec 2>&1 | tee gosec-output.txt
+          MISE_AUTO_INSTALL=false mise run ci:go-sec 2>&1 | tee gosec-output.txt
           echo "exit_code=${PIPESTATUS[0]}" >> "$GITHUB_OUTPUT"
 
       - name: Write summary

--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -62,7 +62,7 @@ jobs:
           install: false
 
       - name: Install required tools
-        run: mise install go
+        run: MISE_AUTO_INSTALL=false mise install go
 
       - name: Initialize environment
         run: MISE_AUTO_INSTALL=false mise run go:mod
@@ -70,6 +70,7 @@ jobs:
       - name: Run unit tests
         env:
           TEST_COMMAND: ${{ inputs.test_command }}
+          MISE_AUTO_INSTALL: "false"
         run: |
           bash -euo pipefail -lc "$TEST_COMMAND"
 
@@ -124,7 +125,7 @@ jobs:
           install: false
 
       - name: Install required tools
-        run: mise install go
+        run: MISE_AUTO_INSTALL=false mise install go
 
       - name: Initialize environment
         run: MISE_AUTO_INSTALL=false mise run go:mod

--- a/.github/workflows/go-vulncheck.yml
+++ b/.github/workflows/go-vulncheck.yml
@@ -52,7 +52,7 @@ jobs:
           install: false
 
       - name: Install required tools
-        run: mise install go "go:golang.org/x/vuln/cmd/govulncheck"
+        run: MISE_AUTO_INSTALL=false mise install go "go:golang.org/x/vuln/cmd/govulncheck"
 
       - name: Initialize environment
         run: MISE_AUTO_INSTALL=false mise run go:mod
@@ -60,7 +60,7 @@ jobs:
       - name: Run govulncheck
         id: vulncheck
         run: |
-          mise run ci:go-vulncheck 2>&1 | tee vulncheck-output.txt
+          MISE_AUTO_INSTALL=false mise run ci:go-vulncheck 2>&1 | tee vulncheck-output.txt
           echo "exit_code=${PIPESTATUS[0]}" >> "$GITHUB_OUTPUT"
 
       - name: Write summary

--- a/.github/workflows/trivy-license.yml
+++ b/.github/workflows/trivy-license.yml
@@ -55,7 +55,7 @@ jobs:
           install: false
 
       - name: Install required tools
-        run: mise install go
+        run: MISE_AUTO_INSTALL=false mise install go
 
       - name: Initialize environment
         run: MISE_AUTO_INSTALL=false mise run go:mod


### PR DESCRIPTION
## Summary
- Add `MISE_AUTO_INSTALL=false` to all mise commands in Go and Bun reusable workflows
- Prevents mise from auto-installing tools during CI runs, ensuring deterministic behavior

## Test plan
- [ ] Verify Go CI workflows (lint, sec, vulncheck, test) pass with the env var set
- [ ] Verify Bun CI workflows (audit, build, bundle-size, format-check, knip, lighthouse, lint, test, typecheck) pass with the env var set

Closes #131
