### PR TITLE
fix(ci): update mise tool config and CI secrets

### DIFF
--- a/.github/workflows/bun-audit.yml
+++ b/.github/workflows/bun-audit.yml
@@ -19,6 +19,9 @@ on:
       gh_pat:
         required: false
 
+env:
+  MISE_AUTO_INSTALL: "false"
+
 permissions:
   contents: read
 
@@ -40,10 +43,10 @@ jobs:
           install: false
 
       - name: Install required tools
-        run: MISE_AUTO_INSTALL=false mise install bun
+        run: mise install bun
 
       - name: Initialize environment
-        run: MISE_AUTO_INSTALL=false mise run init
+        run: mise run init
 
       - name: Run audit
         env:
@@ -53,5 +56,5 @@ jobs:
           if [ -n "$COMMAND" ]; then
             bash -euo pipefail -lc "$COMMAND"
           else
-            MISE_AUTO_INSTALL=false mise run "$TASK"
+            mise run "$TASK"
           fi

--- a/.github/workflows/bun-build.yml
+++ b/.github/workflows/bun-build.yml
@@ -19,6 +19,9 @@ on:
       gh_pat:
         required: false
 
+env:
+  MISE_AUTO_INSTALL: "false"
+
 permissions:
   contents: read
 
@@ -40,10 +43,10 @@ jobs:
           install: false
 
       - name: Install required tools
-        run: MISE_AUTO_INSTALL=false mise install bun
+        run: mise install bun
 
       - name: Initialize environment
-        run: MISE_AUTO_INSTALL=false mise run init
+        run: mise run init
 
       - name: Run build
         env:
@@ -53,5 +56,5 @@ jobs:
           if [ -n "$COMMAND" ]; then
             bash -euo pipefail -lc "$COMMAND"
           else
-            MISE_AUTO_INSTALL=false mise run "$TASK"
+            mise run "$TASK"
           fi

--- a/.github/workflows/bun-bundle-size.yml
+++ b/.github/workflows/bun-bundle-size.yml
@@ -19,6 +19,9 @@ on:
       gh_pat:
         required: false
 
+env:
+  MISE_AUTO_INSTALL: "false"
+
 permissions:
   contents: read
 
@@ -40,10 +43,10 @@ jobs:
           install: false
 
       - name: Install required tools
-        run: MISE_AUTO_INSTALL=false mise install bun
+        run: mise install bun
 
       - name: Initialize environment
-        run: MISE_AUTO_INSTALL=false mise run init
+        run: mise run init
 
       - name: Run bundle size check
         env:
@@ -53,5 +56,5 @@ jobs:
           if [ -n "$COMMAND" ]; then
             bash -euo pipefail -lc "$COMMAND"
           else
-            MISE_AUTO_INSTALL=false mise run "$TASK"
+            mise run "$TASK"
           fi

--- a/.github/workflows/bun-format-check.yml
+++ b/.github/workflows/bun-format-check.yml
@@ -19,6 +19,9 @@ on:
       gh_pat:
         required: false
 
+env:
+  MISE_AUTO_INSTALL: "false"
+
 permissions:
   contents: read
 
@@ -40,10 +43,10 @@ jobs:
           install: false
 
       - name: Install required tools
-        run: MISE_AUTO_INSTALL=false mise install bun
+        run: mise install bun
 
       - name: Initialize environment
-        run: MISE_AUTO_INSTALL=false mise run init
+        run: mise run init
 
       - name: Run format check
         env:
@@ -53,5 +56,5 @@ jobs:
           if [ -n "$COMMAND" ]; then
             bash -euo pipefail -lc "$COMMAND"
           else
-            MISE_AUTO_INSTALL=false mise run "$TASK"
+            mise run "$TASK"
           fi

--- a/.github/workflows/bun-knip.yml
+++ b/.github/workflows/bun-knip.yml
@@ -19,6 +19,9 @@ on:
       gh_pat:
         required: false
 
+env:
+  MISE_AUTO_INSTALL: "false"
+
 permissions:
   contents: read
 
@@ -40,10 +43,10 @@ jobs:
           install: false
 
       - name: Install required tools
-        run: MISE_AUTO_INSTALL=false mise install bun
+        run: mise install bun
 
       - name: Initialize environment
-        run: MISE_AUTO_INSTALL=false mise run init
+        run: mise run init
 
       - name: Run knip
         env:
@@ -53,5 +56,5 @@ jobs:
           if [ -n "$COMMAND" ]; then
             bash -euo pipefail -lc "$COMMAND"
           else
-            MISE_AUTO_INSTALL=false mise run "$TASK"
+            mise run "$TASK"
           fi

--- a/.github/workflows/bun-lighthouse.yml
+++ b/.github/workflows/bun-lighthouse.yml
@@ -19,6 +19,9 @@ on:
       gh_pat:
         required: false
 
+env:
+  MISE_AUTO_INSTALL: "false"
+
 permissions:
   contents: read
 
@@ -40,10 +43,10 @@ jobs:
           install: false
 
       - name: Install required tools
-        run: MISE_AUTO_INSTALL=false mise install bun
+        run: mise install bun
 
       - name: Initialize environment
-        run: MISE_AUTO_INSTALL=false mise run init
+        run: mise run init
 
       - name: Run Lighthouse CI
         env:
@@ -53,5 +56,5 @@ jobs:
           if [ -n "$COMMAND" ]; then
             bash -euo pipefail -lc "$COMMAND"
           else
-            MISE_AUTO_INSTALL=false mise run "$TASK"
+            mise run "$TASK"
           fi

--- a/.github/workflows/bun-lint.yml
+++ b/.github/workflows/bun-lint.yml
@@ -19,6 +19,9 @@ on:
       gh_pat:
         required: false
 
+env:
+  MISE_AUTO_INSTALL: "false"
+
 permissions:
   contents: read
 
@@ -40,10 +43,10 @@ jobs:
           install: false
 
       - name: Install required tools
-        run: MISE_AUTO_INSTALL=false mise install bun
+        run: mise install bun
 
       - name: Initialize environment
-        run: MISE_AUTO_INSTALL=false mise run init
+        run: mise run init
 
       - name: Run lint
         env:
@@ -53,5 +56,5 @@ jobs:
           if [ -n "$COMMAND" ]; then
             bash -euo pipefail -lc "$COMMAND"
           else
-            MISE_AUTO_INSTALL=false mise run "$TASK"
+            mise run "$TASK"
           fi

--- a/.github/workflows/bun-test.yml
+++ b/.github/workflows/bun-test.yml
@@ -19,6 +19,9 @@ on:
       gh_pat:
         required: false
 
+env:
+  MISE_AUTO_INSTALL: "false"
+
 permissions:
   contents: read
 
@@ -40,10 +43,10 @@ jobs:
           install: false
 
       - name: Install required tools
-        run: MISE_AUTO_INSTALL=false mise install bun
+        run: mise install bun
 
       - name: Initialize environment
-        run: MISE_AUTO_INSTALL=false mise run init
+        run: mise run init
 
       - name: Run tests
         env:
@@ -53,5 +56,5 @@ jobs:
           if [ -n "$COMMAND" ]; then
             bash -euo pipefail -lc "$COMMAND"
           else
-            MISE_AUTO_INSTALL=false mise run "$TASK"
+            mise run "$TASK"
           fi

--- a/.github/workflows/bun-typecheck.yml
+++ b/.github/workflows/bun-typecheck.yml
@@ -19,6 +19,9 @@ on:
       gh_pat:
         required: false
 
+env:
+  MISE_AUTO_INSTALL: "false"
+
 permissions:
   contents: read
 
@@ -40,10 +43,10 @@ jobs:
           install: false
 
       - name: Install required tools
-        run: MISE_AUTO_INSTALL=false mise install bun
+        run: mise install bun
 
       - name: Initialize environment
-        run: MISE_AUTO_INSTALL=false mise run init
+        run: mise run init
 
       - name: Run typecheck
         env:
@@ -53,5 +56,5 @@ jobs:
           if [ -n "$COMMAND" ]; then
             bash -euo pipefail -lc "$COMMAND"
           else
-            MISE_AUTO_INSTALL=false mise run "$TASK"
+            mise run "$TASK"
           fi

--- a/.github/workflows/go-lint.yml
+++ b/.github/workflows/go-lint.yml
@@ -66,6 +66,7 @@ jobs:
         uses: reviewdog/action-golangci-lint@c76cceaaab89abe74e649d2e34c6c9adc26662d2 # v2.10.0
         with:
           reporter: github-pr-check
+          go_version_file: "go.mod"
           filter_mode: added
           fail_level: warning
           golangci_lint_flags: "--config=.golangci.yml"

--- a/.github/workflows/go-lint.yml
+++ b/.github/workflows/go-lint.yml
@@ -14,6 +14,9 @@ on:
       gh_pat:
         required: false
 
+env:
+  MISE_AUTO_INSTALL: "false"
+
 permissions:
   contents: read
   checks: write
@@ -53,10 +56,10 @@ jobs:
           install: false
 
       - name: Install required tools
-        run: MISE_AUTO_INSTALL=false mise install go golangci-lint
+        run: mise install go golangci-lint
 
       - name: Initialize environment
-        run: MISE_AUTO_INSTALL=false mise run go:mod
+        run: mise run go:mod
 
       - name: Run lint (reviewdog)
         if: github.event_name == 'pull_request'
@@ -69,7 +72,7 @@ jobs:
 
       - name: Run lint
         if: github.event_name != 'pull_request'
-        run: MISE_AUTO_INSTALL=false mise run ci:go-lint
+        run: mise run ci:go-lint
 
       - name: Revoke private git repository access
         if: always() && env.HAS_GH_PAT == 'true'

--- a/.github/workflows/go-sec.yml
+++ b/.github/workflows/go-sec.yml
@@ -14,6 +14,9 @@ on:
       gh_pat:
         required: false
 
+env:
+  MISE_AUTO_INSTALL: "false"
+
 permissions:
   contents: read
   pull-requests: write
@@ -52,15 +55,15 @@ jobs:
           install: false
 
       - name: Install required tools
-        run: MISE_AUTO_INSTALL=false mise install go "aqua:securego/gosec"
+        run: mise install go "aqua:securego/gosec"
 
       - name: Initialize environment
-        run: MISE_AUTO_INSTALL=false mise run go:mod
+        run: mise run go:mod
 
       - name: Run security scan
         id: gosec
         run: |
-          MISE_AUTO_INSTALL=false mise run ci:go-sec 2>&1 | tee gosec-output.txt
+          mise run ci:go-sec 2>&1 | tee gosec-output.txt
           echo "exit_code=${PIPESTATUS[0]}" >> "$GITHUB_OUTPUT"
 
       - name: Write summary

--- a/.github/workflows/go-sec.yml
+++ b/.github/workflows/go-sec.yml
@@ -55,7 +55,10 @@ jobs:
           install: false
 
       - name: Install required tools
-        run: mise install go "aqua:securego/gosec"
+        run: mise install go
+
+      - name: Install gosec
+        run: go install github.com/securego/gosec/v2/cmd/gosec@latest
 
       - name: Initialize environment
         run: mise run go:mod
@@ -63,7 +66,7 @@ jobs:
       - name: Run security scan
         id: gosec
         run: |
-          mise run ci:go-sec 2>&1 | tee gosec-output.txt
+          gosec -quiet ./... 2>&1 | tee gosec-output.txt
           echo "exit_code=${PIPESTATUS[0]}" >> "$GITHUB_OUTPUT"
 
       - name: Write summary

--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -24,6 +24,9 @@ on:
       gh_pat:
         required: false
 
+env:
+  MISE_AUTO_INSTALL: "false"
+
 permissions:
   contents: read
   pull-requests: write
@@ -62,15 +65,14 @@ jobs:
           install: false
 
       - name: Install required tools
-        run: MISE_AUTO_INSTALL=false mise install go
+        run: mise install go
 
       - name: Initialize environment
-        run: MISE_AUTO_INSTALL=false mise run go:mod
+        run: mise run go:mod
 
       - name: Run unit tests
         env:
           TEST_COMMAND: ${{ inputs.test_command }}
-          MISE_AUTO_INSTALL: "false"
         run: |
           bash -euo pipefail -lc "$TEST_COMMAND"
 
@@ -125,10 +127,10 @@ jobs:
           install: false
 
       - name: Install required tools
-        run: MISE_AUTO_INSTALL=false mise install go
+        run: mise install go
 
       - name: Initialize environment
-        run: MISE_AUTO_INSTALL=false mise run go:mod
+        run: mise run go:mod
 
       - name: Download coverage data
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1

--- a/.github/workflows/go-vulncheck.yml
+++ b/.github/workflows/go-vulncheck.yml
@@ -14,6 +14,9 @@ on:
       gh_pat:
         required: false
 
+env:
+  MISE_AUTO_INSTALL: "false"
+
 permissions:
   contents: read
   pull-requests: write
@@ -52,15 +55,15 @@ jobs:
           install: false
 
       - name: Install required tools
-        run: MISE_AUTO_INSTALL=false mise install go "go:golang.org/x/vuln/cmd/govulncheck"
+        run: mise install go "go:golang.org/x/vuln/cmd/govulncheck"
 
       - name: Initialize environment
-        run: MISE_AUTO_INSTALL=false mise run go:mod
+        run: mise run go:mod
 
       - name: Run govulncheck
         id: vulncheck
         run: |
-          MISE_AUTO_INSTALL=false mise run ci:go-vulncheck 2>&1 | tee vulncheck-output.txt
+          mise run ci:go-vulncheck 2>&1 | tee vulncheck-output.txt
           echo "exit_code=${PIPESTATUS[0]}" >> "$GITHUB_OUTPUT"
 
       - name: Write summary

--- a/.github/workflows/trivy-license.yml
+++ b/.github/workflows/trivy-license.yml
@@ -20,6 +20,7 @@ permissions:
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+  MISE_AUTO_INSTALL: "false"
 
 jobs:
   license:
@@ -55,10 +56,10 @@ jobs:
           install: false
 
       - name: Install required tools
-        run: MISE_AUTO_INSTALL=false mise install go
+        run: mise install go
 
       - name: Initialize environment
-        run: MISE_AUTO_INSTALL=false mise run go:mod
+        run: mise run go:mod
 
       - name: Run Trivy license scan (table)
         uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # 0.35.0

--- a/.ruler/AGENTS.md
+++ b/.ruler/AGENTS.md
@@ -1,5 +1,129 @@
 # AGENTS.md
 
+This file provides guidance to Codex (Codex.ai/code) when working with code in this repository.
+
+## Repository Purpose
+
+This is a **meta-configuration repository** for the nics-dp organization. It contains shared, reusable configuration files that are consumed by other nics-dp repositories:
+
+- **Reusable GitHub Actions workflows** (`.github/workflows/`) - called via `workflow_call`
+- **Shared config files** (`configs/`) - synced to consumer repos via sync workflows
+- **Per-repo CodeQL configs** (`configs/codeqls/`) - synced to repos via the sync-codeql workflow
+- **Project templates** (`golang-templates/`, `web-templates/`) - reference workflow files for new repos
+- **Renovate preset** (`renovate-preset.json`) - org-level Renovate configuration
+
+There is no buildable code in this repo. It is purely configuration and CI/CD infrastructure.
+
+## How Configs Are Consumed
+
+**GitHub Actions workflows**: Other repos call workflows via `uses`:
+```yaml
+jobs:
+  ci:
+    uses: nics-dp/meta/.github/workflows/go-lint.yml@main
+```
+
+**Centralized config sync**: Sync workflows copy config files from `configs/` to consumer repos via PRs. Triggered weekly by `cron.yml` via matrix strategy, with repo-type-specific lists (`ALL_REPOS`, `GO_REPOS`, `WEB_REPOS`, `CODEQL_REPOS`).
+
+**CodeQL config sync**: The `sync-codeql.yml` workflow copies `configs/codeqls/<github-repo-name>.yml` directly as the repo's `.github/workflows/codeql.yml`. File names must match the GitHub repo name (e.g. `dcf-platform.yml` for `nics-dp/dcf-platform`).
+
+**Renovate**: Consumer repos reference the org preset via `renovate.json`:
+```json
+{
+  "extends": ["github>nics-dp/meta:renovate-preset"],
+  "ignoreDeps": ["actions/checkout", "github/codeql-action"]
+}
+```
+`ignoreDeps` is set in downstream repos (not in the preset), because `actions/checkout` and `github/codeql-action` are centrally managed by sync-codeql. The 11 repos with synced codeql.yml need this setting; patroni does not (no codeql.yml).
+
+**PAT split**:
+- `GH_PAT_READ_NICSDP` is used for private module access, CodeQL private-repo access, and snapshot builds
+- `GH_PAT_RELEASE_NICSDP` is used by `release-please.yml` and release workflows so downstream release activity can be triggered
+- `GH_PAT_SYNC_NICSDP` is used by sync workflows (`cron.yml` + `sync-*.yml`) to create cross-repo PRs
+
+Key files:
+- `configs/codeqls/<repo-name>.yml` - Per-repo CodeQL workflow configs (synced to `.github/workflows/codeql.yml`)
+- `configs/.golangci.yml` - Shared golangci-lint v2 config (gofumpt + goimports formatting, extensive linter set)
+- `configs/.commitlintrc.yml` - Shared commitlint config (conventional commits)
+- `configs/renovate.json` - Consumer repo Renovate config (manually copied to new repos)
+- `configs/.prettierrc.json` + `configs/.prettierignore` - Shared Prettier config (web repos)
+- `configs/eslint.config.js` - Shared ESLint flat config (web repos)
+- `configs/vitest.config.ts` - Shared Vitest config (web repos)
+- `configs/knip.json` - Shared Knip config (web repos)
+- `configs/lighthouserc.json` - Shared Lighthouse CI config (web repos)
+- `renovate-preset.json` - Org-level Renovate preset (replaces Dependabot)
+- `mise.toml` - Tool version management (actionlint, act)
+
+## Workflow Architecture
+
+The reusable workflows in `.github/workflows/` accept inputs and secrets via `workflow_call`:
+
+### CI Pipeline (Go)
+- **`go-lint.yml`** - CI lint stage using mise + reviewdog (PR inline annotations via reviewdog/action-golangci-lint, falls back to `mise run ci:go-lint` on non-PR)
+- **`go-sec.yml`** - CI security scan using mise + sticky PR comment with results
+- **`go-vulncheck.yml`** - Go vulnerability check using mise + sticky PR comment (runs on all triggers, not just push)
+- **`go-test.yml`** - CI test + optional coverage report (two jobs: `test` and `report`, controlled by `run_report` input)
+- **`go-semgrep.yml`** - Semgrep static analysis for Go (`p/golang` ruleset, pinned container image)
+
+### CI Pipeline (Web / Bun)
+- **`bun-lint.yml`** - Web lint via ESLint (configurable command)
+- **`bun-typecheck.yml`** - TypeScript typecheck via tsc --noEmit (configurable command)
+- **`bun-build.yml`** - Web build via Vite (configurable command)
+- **`bun-audit.yml`** - Dependency audit via bun audit
+- **`bun-test.yml`** - Web unit tests via Vitest (configurable command)
+- **`bun-format-check.yml`** - Format check via Prettier (configurable command)
+- **`bun-knip.yml`** - Dead code detection via Knip (configurable command)
+- **`bun-lighthouse.yml`** - Lighthouse CI (configurable build command)
+- **`bun-bundle-size.yml`** - Bundle size check via size-limit (configurable build command)
+- **`bun-semgrep.yml`** - Semgrep static analysis for JS/TS (`p/javascript p/typescript` rulesets, pinned container image)
+
+### CI Pipeline (Shared)
+- **`hadolint.yml`** - Dockerfile linting via reviewdog/action-hadolint (auto-detects `Dockerfile*`, excludes `*.env`, PR-only, inline annotations). Trusted registries: docker.io, ghcr.io, dhi.io, gcr.io, quay.io
+- **`trivy-iac.yml`** - IaC security scanning (Dockerfile + compose files) via Trivy config scan -> SARIF + sticky PR comment
+- **`trivy-license.yml`** - License compliance checking via Trivy fs scan -> step summary + sticky PR comment
+- **`commitlint.yml`** - Commit message validation via wagoid/commitlint-github-action (PR-only, conventional commits)
+- **`actionlint.yml`** - Workflow YAML linting via reviewdog/action-actionlint (PR inline annotations, step summary on non-PR)
+- **`codeql.yml`** - CodeQL Advanced analysis with configurable language matrix and Go build
+- **`check-managed-files.yml`** - Blocks PRs that modify centrally-managed files (skips `feature/sync-ci-*` branches)
+
+### Release & Build
+- **`release-please.yml`** - Automated release management via googleapis/release-please-action (conventional commits -> Release PR with changelog -> GitHub Release + tag). Supports both `workflow_call` (reusable) and `push` (meta repo self-use); on push, `release_type` defaults to `simple` via event-name gating. Requires PAT (`gh_pat` or `GH_PAT_RELEASE_NICSDP` fallback) to trigger downstream workflows
+- **`go-release.yml`** - Go binary release pipeline (multi-arch cross-compile, cosign checksums, macOS notarize via quill, GitHub Release)
+- **`image-release.yml`** - Container image build with dual registry (DockerHub + GHCR), attestations, cosign image signing (keyless). Outputs `digest` for sbom-image
+- **`sbom-source.yml`** - Source code SBOM (CycloneDX 1.6 via anchore/sbom-action + parlay enrich) + Trivy + Grype vulnerability scan -> GitHub Release + Security tab
+- **`sbom-image.yml`** - Container image SBOM (CycloneDX 1.6 via anchore/sbom-action + parlay enrich) + Trivy + Grype vulnerability scan -> GitHub Release + Security tab
+
+### Sync Workflows
+- **`sync-codeql.yml`** - Syncs `configs/codeqls/<repo>.yml` -> `.github/workflows/codeql.yml`
+- **`sync-commitlintrc.yml`** - Syncs `configs/.commitlintrc.yml` -> `.commitlintrc.yml`
+- **`sync-golangci.yml`** - Syncs `configs/.golangci.yml` -> `.golangci.yml`
+- **`sync-prettier.yml`** - Syncs `configs/.prettierrc.json` + `configs/.prettierignore`
+- **`sync-eslint-config.yml`** - Syncs `configs/eslint.config.js` -> `eslint.config.js`
+- **`sync-vitest-config.yml`** - Syncs `configs/vitest.config.ts` -> `vitest.config.ts`
+- **`sync-knip.yml`** - Syncs `configs/knip.json` -> `knip.json`
+- **`sync-lighthouserc.yml`** - Syncs `configs/lighthouserc.json` -> `lighthouserc.json`
+
+### Utility
+- **`notify-gchat.yml`** - PR/push/release event notifications to Google Chat
+- **`check-upstream-release.yml`** - Checks upstream repo for new releases, creates bump PR
+- **`artifacts-comment.yml`** - Lists build artifacts and upserts a PR comment with nightly.link download URLs
+
+### Scheduling
+- **`cron.yml`** - Weekly matrix trigger for all sync workflows across repos (ALL_REPOS, GO_REPOS, WEB_REPOS, CODEQL_REPOS)
+
+### Meta CI
+- **`ci.yml`** - Meta repo's own CI: commitlint + actionlint for all workflow YAML files
+
+## Editing Guidelines
+
+- Config source files live in `configs/`; changes are synced to consumer repos via sync workflows + `cron.yml`
+- Per-repo CodeQL workflow configs live in `configs/codeqls/<github-repo-name>.yml` (must match GitHub repo name, e.g. `dcf-platform.yml`)
+- To add a new repo to sync, update the repo lists in `.github/workflows/cron.yml` (`ALL_REPOS`, `GO_REPOS`, `WEB_REPOS`, `CODEQL_REPOS`)
+- Project templates in `golang-templates/` and `web-templates/` are reference files for new repo setup
+- Renovate preset changes in `renovate-preset.json` automatically apply to all consumer repos; `ignoreDeps` is set in downstream repos, not in the preset
+- Consumer repos need `.commitlintrc.yml` and `renovate.json` copied from `configs/`
+
+
 Centralised AI agent instructions. Add coding guidelines, style guides, and project context here.
 
 Ruler concatenates all .md files in this directory (and subdirectories), starting with AGENTS.md (if present), then remaining files in sorted order.

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ secrets:
 
 ### go-sec.yml — 靜態安全掃描
 
-執行 `mise run ci:go-sec` (gosec)，結果以 sticky PR comment 回報。
+執行 gosec 靜態安全掃描，結果以 sticky PR comment 回報。
 
 ```yaml
 uses: nics-dp/meta/.github/workflows/go-sec.yml@main
@@ -193,7 +193,7 @@ uses: nics-dp/meta/.github/workflows/actionlint.yml@main
 
 ### check-managed-files.yml — 集中管理檔案保護
 
-檢查 PR 是否修改了由 meta 集中管理的檔案，若有則 CI 失敗。自動跳過 sync workflow 建立的 PR (`ci/sync-*` 分支)。
+檢查 PR 是否修改了由 meta 集中管理的檔案，若有則 CI 失敗。自動跳過 sync workflow 建立的 PR (`feature/sync-ci-*` 分支)。
 
 ```yaml
 uses: nics-dp/meta/.github/workflows/check-managed-files.yml@main
@@ -203,7 +203,7 @@ uses: nics-dp/meta/.github/workflows/check-managed-files.yml@main
 |------|------|--------|------|
 | `managed_files` | string | (見下方) | 逗號分隔的受保護檔案路徑 |
 
-預設受保護檔案: `.github/workflows/codeql.yml`, `.commitlintrc.yml`, `.golangci.yml`, `renovate.json`, `.prettierrc.json`, `.prettierignore`, `eslint.config.js`, `vitest.config.ts`, `knip.json`, `lighthouserc.json`
+預設受保護檔案: `.github/workflows/codeql.yml`, `.commitlintrc.yml`, `.golangci.yml`, `.prettierrc.json`, `.prettierignore`, `eslint.config.js`, `vitest.config.ts`, `knip.json`, `lighthouserc.json`
 
 ---
 
@@ -570,7 +570,6 @@ Sync workflows 由 meta repo 的 `cron.yml` 統一排程觸發 (每週一 00:00 
 | 清單 | 說明 | 用於 |
 |------|------|------|
 | `ALL_REPOS` | 所有 DCF repos (含 patroni) | sync-commitlintrc |
-| `RENOVATE_SYNC_REPOS` | 需要同步 `renovate.json` 的 repos | sync-renovate |
 | `GO_REPOS` | Go repos (不含 web repos、patroni) | sync-golangci |
 | `WEB_REPOS` | Web repos | sync-prettier, sync-eslint-config, sync-vitest-config, sync-knip, sync-lighthouserc |
 | `CODEQL_REPOS` | 有 CodeQL 設定的 repos (不含 patroni) | sync-codeql |
@@ -580,12 +579,6 @@ Sync workflows 由 meta repo 的 `cron.yml` 統一排程觸發 (每週一 00:00 
 | Workflow | 來源 | 目標 |
 |----------|------|------|
 | `sync-commitlintrc.yml` | `configs/.commitlintrc.yml` | `.commitlintrc.yml` |
-
-### Renovate sync repos
-
-| Workflow | 來源 | 目標 |
-|----------|------|------|
-| `sync-renovate.yml` | `configs/renovate.json` | `renovate.json` |
 
 ### CodeQL repos
 
@@ -616,10 +609,10 @@ uses: nics-dp/meta/.github/workflows/sync-<name>.yml@main
 with:
   repo_name: <repo-name>  # 必要，不含 org prefix
 secrets:
-  gh_token: ${{ secrets.GH_PAT_READ_NICSDP }}
+  gh_token: ${{ secrets.GH_PAT_SYNC_NICSDP }}
 ```
 
-`workflow_dispatch` 手動執行時，若要同步到 private repo，需先在 meta repo 設定 repo-level `GH_PAT_READ_NICSDP`。
+`workflow_dispatch` 手動執行時，若要同步到 private repo，需先在 meta repo 設定 repo-level `GH_PAT_SYNC_NICSDP`。
 
 ---
 
@@ -698,7 +691,7 @@ secrets:
 |------|----------|------|
 | `configs/codeqls/<repo>.yml` | `.github/workflows/codeql.yml` | Per-repo |
 | `configs/.commitlintrc.yml` | `.commitlintrc.yml` | All repos |
-| `configs/renovate.json` | `renovate.json` | `RENOVATE_SYNC_REPOS` |
+| `configs/renovate.json` | `renovate.json` | 手動複製 |
 | `configs/.golangci.yml` | `.golangci.yml` | Go repos |
 | `configs/.prettierrc.json` | `.prettierrc.json` | Web repos |
 | `configs/.prettierignore` | `.prettierignore` | Web repos |
@@ -719,7 +712,7 @@ secrets:
 
 ### web-templates/ — Web 專案
 
-適用於 React + Vite + TypeScript + Bun 專案。包含 workflow templates 與 `mise.toml`。詳見 [`web-templates/.github/README.md`](web-templates/.github/README.md)。
+適用於 Vue + Vite + TypeScript + Bun 專案。包含 workflow templates 與 `mise.toml`。詳見 [`web-templates/.github/README.md`](web-templates/.github/README.md)。
 
 包含: CI (eslint, typecheck, build, audit；預設也啟用 vitest、prettier、semgrep、trivy-license、knip、lighthouse；有 Dockerfile 的 repo 還可保留 hadolint / trivy-iac), codeql, notify, release-please workflows + `mise.toml` + eslint, prettier, vitest, knip, lighthouse configs。`bundle-size` workflow 仍提供，但需 repo 自行補上 `size-limit` 設定後再啟用
 
@@ -733,7 +726,7 @@ secrets:
 2. 從 `configs/` 複製 `.golangci.yml`、`.commitlintrc.yml`、`renovate.json`
 3. 替換 `TODO` 標記 (`project_name`, `binary`, `image_name`)
 4. 新增 `configs/codeqls/<repo-name>.yml`，設定 CodeQL workflow
-5. 更新 `cron.yml` 的 repo 清單 (`CODEQL_REPOS`, `GO_REPOS`, `ALL_REPOS`, `RENOVATE_SYNC_REPOS`)
+5. 更新 `cron.yml` 的 repo 清單 (`CODEQL_REPOS`, `GO_REPOS`, `ALL_REPOS`)
 6. 確認 repo secrets:
    - `GH_PAT_READ_NICSDP` (私有 Go modules / release / snapshot / CodeQL 用)
    - `GH_PAT_RELEASE_NICSDP` (release-please 用)
@@ -746,7 +739,7 @@ secrets:
 3. 安裝 devDependencies (見 `web-templates/.github/README.md`)
 4. 若 repo 沒有 Dockerfile，先從 `web-templates/.github/workflows/ci.yml` 移除 `hadolint` 與 `trivy-iac` jobs；若不需要 `knip` / `lighthouse`，也可一併移除
 5. 新增 `configs/codeqls/<repo-name>.yml` (使用 `javascript-typescript` language)
-6. 更新 `cron.yml` 的 repo 清單 (`CODEQL_REPOS`, `WEB_REPOS`, `ALL_REPOS`, `RENOVATE_SYNC_REPOS`)
+6. 更新 `cron.yml` 的 repo 清單 (`CODEQL_REPOS`, `WEB_REPOS`, `ALL_REPOS`)
 7. 確認 repo secrets: `GH_PAT_RELEASE_NICSDP`
 
 ---

--- a/golang-templates/.github/README.md
+++ b/golang-templates/.github/README.md
@@ -217,4 +217,4 @@ The `codeql.yml` template is a starting point. For repos managed by `sync-codeql
 |---|---|---|
 | `.golangci.yml` | `configs/.golangci.yml` | golangci-lint v2 config (synced via `sync-golangci`) |
 | `.commitlintrc.yml` | `configs/.commitlintrc.yml` | Conventional commit message rules (synced via `sync-commitlintrc`) |
-| `renovate.json` | `configs/renovate.json` | Renovate preset + ignoreDeps (synced via `sync-renovate`) |
+| `renovate.json` | `configs/renovate.json` | Renovate preset + ignoreDeps (manually copied) |

--- a/golang-templates/.github/workflows/ci.yml
+++ b/golang-templates/.github/workflows/ci.yml
@@ -96,6 +96,8 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
+    secrets:
+      gh_pat: ${{ secrets.GH_PAT_READ_NICSDP }}
 
   go-test:
     needs: [go-lint, go-sec]

--- a/golang-templates/mise.toml
+++ b/golang-templates/mise.toml
@@ -2,7 +2,7 @@
 # Golang related
 go = "1.26.1"
 golangci-lint = "latest"
-"aqua:securego/gosec" = "latest"
+"github:securego/gosec" = "latest"
 "go:golang.org/x/vuln/cmd/govulncheck" = "latest"
 
 # Dockerfile lint

--- a/mise.toml
+++ b/mise.toml
@@ -1,7 +1,7 @@
 [tools]
-actionlint = "1.7.11"
-act = "0.2.85"
-codeql = { version = "2.24.3", bin_path = "codeql", platforms = """
+actionlint = "latest"
+act = "latest"
+codeql = { version = "latest", bin_path = "codeql", platforms = """
 [linux-x64]
 asset_pattern = "codeql-linux64.zip"
 
@@ -15,7 +15,7 @@ asset_pattern = "codeql-osx64.zip"
 asset_pattern = "codeql-win64.zip"
 """ }
 
-bun = "1.3.11"
+bun = "latest"
 
 # ------------------------------------------------------------------------------
 # ==============================================================================
@@ -24,29 +24,3 @@ bun = "1.3.11"
 [tasks.ruler] # command: mise run ruler
 description = "Compile ruler to AGENTS.md and CLAUDE.md"
 run = "bunx @intellectronica/ruler apply"
-
-# ==============================================================================
-#  Tool Management
-# ==============================================================================
-[tasks."tools:bump"]
-description = "Bump all tool versions to latest"
-raw = true
-run = '''
-echo "Checking for outdated tools..."
-echo ""
-mise outdated --bump
-echo ""
-read -p "Proceed with upgrade? (y/N) " confirm
-if [ "$confirm" = "y" ] || [ "$confirm" = "Y" ]; then
-    mise outdated --bump | grep -v '^name ' | awk 'NF>0 {print $1"@"$4}' | while IFS= read -r tool; do
-        echo "  -> mise use $tool"
-        mise use "$tool"
-    done
-    echo ""
-    mise install
-    echo ""
-    echo "Done! Run 'mise run ci' to verify compatibility."
-else
-    echo "Cancelled."
-fi
-'''

--- a/web-templates/.github/README.md
+++ b/web-templates/.github/README.md
@@ -213,6 +213,6 @@ Sends GitHub event notifications to Google Chat.
 | `eslint.config.js` | `configs/eslint.config.js` | ESLint flat config |
 | `vitest.config.ts` | `configs/vitest.config.ts` | Vitest config |
 | `.commitlintrc.yml` | `configs/.commitlintrc.yml` | Conventional commit message rules (synced via `sync-commitlintrc`) |
-| `renovate.json` | `configs/renovate.json` | Renovate preset + ignoreDeps (synced via `sync-renovate`) |
+| `renovate.json` | `configs/renovate.json` | Renovate preset + ignoreDeps (manually copied) |
 | `knip.json` | `configs/knip.json` | Knip config (optional) |
 | `lighthouserc.json` | `configs/lighthouserc.json` | Lighthouse CI config (optional) |


### PR DESCRIPTION
## Summary
- Pin all mise tool versions to `latest` (except go=1.26.1)
- Fix tool prefixes where needed
- Remove `tools:bump` task if present
- Add missing `secrets` to CI workflow jobs where applicable

## Test plan
- [ ] CI pipeline passes on this branch

Closes #121