### PR TITLE
fix(ci): use mise github backend for gosec and remove redundant go:mod step

### DIFF
--- a/.github/workflows/go-sec.yml
+++ b/.github/workflows/go-sec.yml
@@ -55,13 +55,9 @@ jobs:
           install: false
 
       - name: Install required tools
-        run: mise install go
-
-      - name: Install gosec
-        run: go install github.com/securego/gosec/v2/cmd/gosec@latest
-
-      - name: Initialize environment
-        run: mise run go:mod
+        run: |
+          mise use -g "github:securego/gosec@latest"
+          mise install go
 
       - name: Run security scan
         id: gosec


### PR DESCRIPTION
## Summary
- Switch gosec installation from `go install` to mise's github backend for consistent tool management
- Remove redundant `go:mod` initialization step since gosec auto-fetches dependencies when Go modules are enabled

## Test plan
- [ ] Verify `go-sec.yml` workflow runs successfully on a Go repo PR
- [ ] Confirm gosec is correctly installed via mise github backend