### PR TITLE
feat: migrate mise tasks to file-based tasks

### DIFF
--- a/.mise/tasks/ci/commitlint
+++ b/.mise/tasks/ci/commitlint
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+#MISE description="Run commitlint on recent commits"
+#MISE raw=true
+
+bunx commitlint --from HEAD~1 --to HEAD

--- a/.mise/tasks/ci/go-lint
+++ b/.mise/tasks/ci/go-lint
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+#MISE description="Run golangci-lint"
+#MISE raw=true
+
+golangci-lint run ./...

--- a/.mise/tasks/ci/go-sec
+++ b/.mise/tasks/ci/go-sec
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+#MISE description="Run gosec security scanner"
+#MISE raw=true
+
+gosec -quiet ./...

--- a/.mise/tasks/ci/go-vulncheck
+++ b/.mise/tasks/ci/go-vulncheck
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+#MISE description="Run govulncheck vulnerability check"
+#MISE raw=true
+
+govulncheck ./...

--- a/.mise/tasks/ci/hadolint
+++ b/.mise/tasks/ci/hadolint
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+#MISE description="Lint Dockerfiles with hadolint"
+#MISE raw=true
+
+hadolint Dockerfile*

--- a/.mise/tasks/ci/semgrep
+++ b/.mise/tasks/ci/semgrep
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+#MISE description="Run semgrep static analysis for Go"
+#MISE raw=true
+
+semgrep scan --error --enable-nosem --config p/golang .

--- a/.mise/tasks/ci/test
+++ b/.mise/tasks/ci/test
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+#MISE description="Run unit tests with coverage and generate report"
+
+go test -race -coverprofile=coverage.out ./...
+go tool cover -html=coverage.out -o coverage.html
+go tool cover -func=coverage.out > coverage.md

--- a/.mise/tasks/ci/trivy-iac
+++ b/.mise/tasks/ci/trivy-iac
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+#MISE description="Run Trivy IaC scan on Dockerfiles and compose files"
+#MISE raw=true
+
+trivy config --exit-code 0 .

--- a/.mise/tasks/ci/trivy-license
+++ b/.mise/tasks/ci/trivy-license
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+#MISE description="Run Trivy license compliance check"
+#MISE raw=true
+
+trivy fs --scanners license --exit-code 0 .

--- a/.mise/tasks/go/build
+++ b/.mise/tasks/go/build
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+#MISE description="Build a binary"
+#MISE hide=true
+#MISE raw=true
+#USAGE arg "<name>" help="Binary name"
+
+echo "Building ${usage_name?}..."
+go build -o "bin/${usage_name?}" ${EXTRA_BUILD_FLAGS} -ldflags "${LDFLAGS}" "./cmd/${usage_name?}/main.go"

--- a/.mise/tasks/go/mod
+++ b/.mise/tasks/go/mod
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+#MISE description="Go modules (tidy/download/vendor)"
+#MISE raw=true
+
+go mod tidy
+go mod vendor
+go mod download

--- a/.mise/tasks/go/run
+++ b/.mise/tasks/go/run
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+#MISE description="Running golang script (usage: mise run go:run [name] -- --flag)"
+#MISE raw=true
+#USAGE arg "[name]" help="Script name to run (auto-detected if cmd/ has only one entry)"
+#USAGE arg "[args]" var=#true var_min=0 help="Arguments to pass to the script"
+
+if [ -z "$usage_name" ]; then
+  entries=(cmd/*/main.go)
+  if [ "${#entries[@]}" -eq 1 ]; then
+    usage_name=$(basename "$(dirname "${entries[0]}")")
+  else
+    echo "Multiple cmd entries found. Please specify one of:"
+    for e in "${entries[@]}"; do basename "$(dirname "$e")"; done
+    exit 1
+  fi
+fi
+if [ ! -f "cmd/$usage_name/main.go" ]; then
+  echo "Error: cmd/$usage_name/main.go not found"
+  exit 1
+fi
+go run -mod=vendor "./cmd/$usage_name/main.go" $usage_args

--- a/.mise/tasks/go/upgrade
+++ b/.mise/tasks/go/upgrade
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+#MISE description="Upgrading Golang dependencies"
+
+go get -u ./...
+go mod tidy
+go mod vendor

--- a/.mise/tasks/gs/clone
+++ b/.mise/tasks/gs/clone
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+#MISE description="Clone git submodules"
+#MISE raw=true
+
+git submodule update --init --recursive

--- a/.mise/tasks/gs/update
+++ b/.mise/tasks/gs/update
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+#MISE description="Update git submodules"
+#MISE raw=true
+
+git submodule update --remote --merge

--- a/.mise/tasks/ruler
+++ b/.mise/tasks/ruler
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+#MISE description="Compile ruler to AGENTS.md and CLAUDE.md"
+
+bunx @intellectronica/ruler apply

--- a/.mise/tasks/sbom/enrich
+++ b/.mise/tasks/sbom/enrich
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+#MISE description="Enrich SBOM with ecosystem metadata"
+#MISE depends=["sbom:source"]
+
+parlay ecosystems enrich sbom-source.cdx.json > enriched-source.cdx.json

--- a/.mise/tasks/sbom/grype
+++ b/.mise/tasks/sbom/grype
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+#MISE description="Scan SBOM for vulnerabilities with Grype"
+#MISE raw=true
+#MISE depends=["sbom:enrich"]
+
+grype sbom:enriched-source.cdx.json

--- a/.mise/tasks/sbom/source
+++ b/.mise/tasks/sbom/source
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+#MISE description="Generate CycloneDX SBOM for source"
+
+syft scan . -o cyclonedx-json=sbom-source.cdx.json

--- a/.mise/tasks/sbom/trivy
+++ b/.mise/tasks/sbom/trivy
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+#MISE description="Scan SBOM for vulnerabilities with Trivy"
+#MISE raw=true
+#MISE depends=["sbom:enrich"]
+
+trivy sbom enriched-source.cdx.json

--- a/mise.toml
+++ b/mise.toml
@@ -17,10 +17,23 @@ asset_pattern = "codeql-win64.zip"
 
 bun = "latest"
 
-# ------------------------------------------------------------------------------
 # ==============================================================================
-#  Compile Ruler
+#  Aggregator Tasks (cannot be file tasks — name conflicts with ci/ and sbom/ dirs)
 # ==============================================================================
-[tasks.ruler] # command: mise run ruler
-description = "Compile ruler to AGENTS.md and CLAUDE.md"
-run = "bunx @intellectronica/ruler apply"
+[tasks.ci]
+description = "Run all CI checks"
+depends = [
+  "ci:commitlint",
+  "ci:hadolint",
+  "ci:trivy-iac",
+  "ci:trivy-license",
+  "ci:go-lint",
+  "ci:go-sec",
+  "ci:go-vulncheck",
+  "ci:semgrep",
+  "ci:test",
+]
+
+[tasks.sbom]
+description = "Run full SBOM pipeline (generate, enrich, scan)"
+depends = ["sbom:trivy", "sbom:grype"]


### PR DESCRIPTION
## Summary
- Migrated shared Go tasks from inline mise.toml to file-based tasks in `.mise/tasks/`
- Tasks: CI (commitlint, hadolint, trivy, golangci-lint, gosec, govulncheck, semgrep, test), SBOM (source, enrich, trivy, grype), Go (mod, build, run, upgrade), git submodules (clone, update), ruler
- Aggregator tasks (ci, sbom) remain inline in mise.toml due to file/directory name conflict
- Consumer repos can include via `git::https://github.com/nics-dp/meta.git//.mise/tasks?ref=main`

## Test plan
- [ ] Verify `mise tasks ls` shows all tasks
- [ ] Verify `mise run ruler` works
- [ ] Test remote include from a consumer repo (platform)

Closes #119