### PR TITLE
fix: remove unnecessary go-test dependency on go-lint/go-sec

### DIFF
--- a/golang-templates/.github/workflows/ci.yml
+++ b/golang-templates/.github/workflows/ci.yml
@@ -100,7 +100,6 @@ jobs:
       gh_pat: ${{ secrets.GH_PAT_READ_NICSDP }}
 
   go-test:
-    needs: [go-lint, go-sec]
     uses: nics-dp/meta/.github/workflows/go-test.yml@main
     permissions:
       contents: read


### PR DESCRIPTION
## Summary
- Removed `needs: [go-lint, go-sec]` from `go-test` job in golang CI template
- These are independent checks that should run in parallel
- Previously: lint failure → test skipped (lost test feedback) + serial wait time
- Now: all three run in parallel, faster CI, full feedback regardless of lint status

Closes #118