### PR TITLE
fix(ci): remove duplicate CI triggers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: ci
 
 on:
   push:
-    branches: [main, dev, "release/**", "feature/**"]
+    branches: [main, dev]
   pull_request:
     types: [opened, synchronize, reopened]
     branches: [main, dev, "release/**"]

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -3,8 +3,6 @@
 name: release-please
 
 on:
-  push:
-    branches: [main]
   workflow_call:
     inputs:
       release_type:


### PR DESCRIPTION
## Summary

- Remove `feature/**` from the `push` trigger in `ci.yml` — feature branches are already covered by `pull_request`, so push + PR causes duplicate runs
- Remove `push` trigger from `release-please.yml` — meta repo does not need releases; keep `workflow_call` only for consumer repos

## Test plan

- [ ] Verify push to a feature branch with an open PR triggers only one CI run
- [ ] Verify release-please does not trigger on push to main in meta repo

Closes #117