### PR TITLE
fix(config): disable body-max-line-length and enable CGO for libdcf

### DIFF
--- a/.commitlintrc.yml
+++ b/.commitlintrc.yml
@@ -24,3 +24,5 @@ rules:
     - 2
     - always
     - 100
+  body-max-line-length:
+    - 0

--- a/configs/.commitlintrc.yml
+++ b/configs/.commitlintrc.yml
@@ -24,3 +24,5 @@ rules:
     - 2
     - always
     - 100
+  body-max-line-length:
+    - 0

--- a/configs/codeqls/libdcf.yml
+++ b/configs/codeqls/libdcf.yml
@@ -81,7 +81,7 @@ jobs:
       - name: Manual Go build for CodeQL
         if: matrix.language == 'go'
         env:
-          CGO_ENABLED: "0"
+          CGO_ENABLED: "1"
           GOOS: linux
         run: |
           go mod vendor


### PR DESCRIPTION
## Summary
- Disable `body-max-line-length` rule in commitlint config (root + configs/)
- Set `CGO_ENABLED=1` in libdcf CodeQL workflow to support DuckDB driver

## Context
- commitlint CI in libdcf fails due to body-max-line-length on long commit bodies
- libdcf CodeQL build requires CGO for DuckDB driver support

Closes #116