### PR TITLE
fix(ci): config cleanups and CI optimizations

### DIFF
--- a/.commitlintrc.yml
+++ b/.commitlintrc.yml
@@ -24,3 +24,5 @@ rules:
     - 2
     - always
     - 100
+  body-max-line-length:
+    - 0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: ci
 
 on:
   push:
-    branches: [main, dev, "release/**", "feature/**"]
+    branches: [main, dev]
   pull_request:
     types: [opened, synchronize, reopened]
     branches: [main, dev, "release/**"]

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -13,13 +13,13 @@ permissions:
 
 env:
   # All DCF repos (commitlintrc)
-  ALL_REPOS: '["dcf-platform","dcf-access","dcf-service","dcf-access-cli","dcf-platform-cli","dcf-access-web","dcf-platform-web","libdcf","otel-bundle","test-repo","ZenQuery","patroni"]'
+  ALL_REPOS: '["dcf-platform","dcf-access","dcf-service","dcf-access-cli","dcf-platform-cli","dcf-access-web","dcf-platform-web","libdcf","otel-bundle","ZenQuery","patroni"]'
   # Go repos only (golangci-lint)
-  GO_REPOS: '["dcf-platform","dcf-access","dcf-service","dcf-access-cli","dcf-platform-cli","libdcf","otel-bundle","test-repo","ZenQuery"]'
+  GO_REPOS: '["dcf-platform","dcf-access","dcf-service","dcf-access-cli","dcf-platform-cli","libdcf","otel-bundle","ZenQuery"]'
   # Web repos only (prettier, eslint, vitest, knip, lighthouserc)
   WEB_REPOS: '["dcf-access-web","dcf-platform-web"]'
   # Repos with per-repo CodeQL configs in configs/codeqls/
-  CODEQL_REPOS: '["dcf-platform","dcf-access","dcf-service","dcf-access-cli","dcf-platform-cli","dcf-access-web","dcf-platform-web","libdcf","otel-bundle","test-repo","ZenQuery"]'
+  CODEQL_REPOS: '["dcf-platform","dcf-access","dcf-service","dcf-access-cli","dcf-platform-cli","dcf-access-web","dcf-platform-web","libdcf","otel-bundle","ZenQuery"]'
 
 jobs:
   setup:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -3,8 +3,6 @@
 name: release-please
 
 on:
-  push:
-    branches: [main]
   workflow_call:
     inputs:
       release_type:

--- a/configs/.commitlintrc.yml
+++ b/configs/.commitlintrc.yml
@@ -24,3 +24,5 @@ rules:
     - 2
     - always
     - 100
+  body-max-line-length:
+    - 0

--- a/configs/codeqls/ZenQuery.yml
+++ b/configs/codeqls/ZenQuery.yml
@@ -41,8 +41,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          fetch-depth: 0
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@38697555549f1db7851b81482ff19f1fa5c4fedc # v4.34.1

--- a/configs/codeqls/dcf-access-cli.yml
+++ b/configs/codeqls/dcf-access-cli.yml
@@ -41,8 +41,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          fetch-depth: 0
 
       - name: Initialize CodeQL
         if: env.HAS_GH_PAT != 'true'

--- a/configs/codeqls/dcf-access-web.yml
+++ b/configs/codeqls/dcf-access-web.yml
@@ -39,8 +39,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          fetch-depth: 0
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@38697555549f1db7851b81482ff19f1fa5c4fedc # v4.34.1

--- a/configs/codeqls/dcf-access.yml
+++ b/configs/codeqls/dcf-access.yml
@@ -41,8 +41,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          fetch-depth: 0
 
       - name: Initialize CodeQL
         if: env.HAS_GH_PAT != 'true'

--- a/configs/codeqls/dcf-platform-cli.yml
+++ b/configs/codeqls/dcf-platform-cli.yml
@@ -41,8 +41,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          fetch-depth: 0
 
       - name: Initialize CodeQL
         if: env.HAS_GH_PAT != 'true'

--- a/configs/codeqls/dcf-platform-web.yml
+++ b/configs/codeqls/dcf-platform-web.yml
@@ -39,8 +39,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          fetch-depth: 0
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@38697555549f1db7851b81482ff19f1fa5c4fedc # v4.34.1

--- a/configs/codeqls/dcf-platform.yml
+++ b/configs/codeqls/dcf-platform.yml
@@ -41,8 +41,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          fetch-depth: 0
 
       - name: Initialize CodeQL
         if: env.HAS_GH_PAT != 'true'

--- a/configs/codeqls/dcf-service.yml
+++ b/configs/codeqls/dcf-service.yml
@@ -41,8 +41,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          fetch-depth: 0
 
       - name: Initialize CodeQL
         if: env.HAS_GH_PAT != 'true'

--- a/configs/codeqls/libdcf.yml
+++ b/configs/codeqls/libdcf.yml
@@ -81,7 +81,7 @@ jobs:
       - name: Manual Go build for CodeQL
         if: matrix.language == 'go'
         env:
-          CGO_ENABLED: "0"
+          CGO_ENABLED: "1"
           GOOS: linux
         run: |
           go mod vendor

--- a/configs/codeqls/libdcf.yml
+++ b/configs/codeqls/libdcf.yml
@@ -43,8 +43,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          fetch-depth: 0
 
       - name: Initialize CodeQL
         if: env.HAS_GH_PAT != 'true'

--- a/configs/codeqls/otel-bundle.yml
+++ b/configs/codeqls/otel-bundle.yml
@@ -39,8 +39,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          fetch-depth: 0
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@38697555549f1db7851b81482ff19f1fa5c4fedc # v4.34.1

--- a/configs/codeqls/test-repo.yml
+++ b/configs/codeqls/test-repo.yml
@@ -41,8 +41,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          fetch-depth: 0
 
       - name: Initialize CodeQL
         if: env.HAS_GH_PAT != 'true'

--- a/golang-templates/.github/workflows/ci.yml
+++ b/golang-templates/.github/workflows/ci.yml
@@ -100,7 +100,6 @@ jobs:
       gh_pat: ${{ secrets.GH_PAT_READ_NICSDP }}
 
   go-test:
-    needs: [go-lint, go-sec]
     uses: nics-dp/meta/.github/workflows/go-test.yml@main
     permissions:
       contents: read


### PR DESCRIPTION
## Summary

- Disable `body-max-line-length` in commitlint config to allow longer commit bodies
- Enable `CGO_ENABLED=1` for libdcf CodeQL build (required for cgo-dependent code)
- Remove unnecessary `go-test` dependency on `go-lint` and `go-sec` in Go CI template
- Remove `fetch-depth: 0` from all CodeQL checkout steps (static analysis doesn't need full history)
- Remove `test-repo` from cron sync repo lists
- Remove `feature/**` from `ci.yml` push trigger to avoid duplicate CI runs
- Remove `push` trigger from `release-please.yml` (meta repo doesn't need releases)

## Test plan

- [ ] Verify commitlint no longer fails on long commit body lines
- [ ] Verify libdcf CodeQL workflow builds successfully with CGO enabled
- [ ] Verify go-test runs independently without waiting for go-lint/go-sec
- [ ] Verify CodeQL workflows still pass without full git history
- [ ] Verify push to a feature branch with an open PR triggers only one CI run