### PR TITLE
revert: use default commit body length

### DIFF
--- a/.commitlintrc.yml
+++ b/.commitlintrc.yml
@@ -24,5 +24,3 @@ rules:
     - 2
     - always
     - 100
-  body-max-line-length:
-    - 0

--- a/configs/.commitlintrc.yml
+++ b/configs/.commitlintrc.yml
@@ -24,5 +24,3 @@ rules:
     - 2
     - always
     - 100
-  body-max-line-length:
-    - 0


### PR DESCRIPTION
as title