### PR TITLE
feat(dc): make dc:clean target optional with gum fallback

### DIFF
--- a/.mise/tasks/dc/clean
+++ b/.mise/tasks/dc/clean
@@ -1,9 +1,13 @@
 #!/usr/bin/env bash
 #MISE description="Clean Docker Compose resources"
 #MISE raw=true
-#USAGE arg "<target>" help="Resource to clean: vol, img, net, all" {
+#USAGE arg "[target]" help="Resource to clean: vol, img, net, all" {
 #USAGE   choices "vol" "img" "net" "all"
 #USAGE }
+
+set -e
+
+target=${usage_target:-$(gum choose "vol" "img" "net" "all")}
 
 project=$(docker compose config --format json 2>/dev/null | grep -o '"name":"[^"]*"' | head -1 | cut -d'"' -f4)
 if [ -z "$project" ]; then
@@ -26,7 +30,7 @@ clean_networks() {
   docker network ls --filter "name=${project}" -q | xargs -r docker network rm 2>/dev/null || true
 }
 
-case "$usage_target" in
+case "$target" in
   vol) clean_volumes ;;
   img) clean_images ;;
   net) clean_networks ;;


### PR DESCRIPTION
## Summary
- Make `dc:clean` target argument optional (required → optional)
- When target is omitted, use `gum choose` for interactive selection
- Add `set -e` for consistent error handling

## Test plan
- [ ] Run `mise run dc:clean` without args — verify gum picker appears
- [ ] Run `mise run dc:clean vol` — verify it skips gum and cleans volumes directly
- [ ] Run `mise run dc:clean invalid` — verify choices validation rejects it