### PR TITLE
feat(go): add coverage-report task and shared log lib

### DIFF
--- a/.mise/tasks/go/coverage-report
+++ b/.mise/tasks/go/coverage-report
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+#MISE description="Generate HTML + Markdown coverage reports from coverage.out"
+#MISE raw=true
+
+set -euo pipefail
+# shellcheck disable=SC1091
+source "$(dirname "$0")/../lib/logs"
+
+MERGED_COV="coverage.out"
+HTML_REPORT="coverage.html"
+MD_REPORT="coverage.md"
+
+if [ ! -f "$MERGED_COV" ]; then
+    log_warn "$MERGED_COV not found. Please run tests first."
+    exit 0
+fi
+
+log_step "Generating HTML report: $HTML_REPORT"
+go tool cover -html="$MERGED_COV" -o "$HTML_REPORT"
+
+# Cache func output once to avoid repeated parsing
+FUNC_OUTPUT=$(go tool cover -func="$MERGED_COV")
+FUNC_NO_TOTAL=$(echo "$FUNC_OUTPUT" | grep -v "total:")
+TOTAL_COV=$(echo "$FUNC_OUTPUT" | grep "total:" | awk '{print $NF}')
+
+# Generate component coverage data (TSV: component\tavg_coverage)
+COMP_DATA=$(echo "$FUNC_NO_TOTAL" | awk '
+{
+    coverage_str = $NF
+    gsub(/%/, "", coverage_str)
+    coverage = coverage_str + 0
+    split($1, parts, "/")
+    if (length(parts) >= 3) {
+        comp = parts[3]
+        if (!(comp in seen)) {
+            seen[comp] = 1
+            order[++comp_count] = comp
+        }
+        func_count[comp]++
+        coverage_sum[comp] += coverage
+    }
+}
+END {
+    for (i = 1; i <= comp_count; i++) {
+        comp = order[i]
+        printf "%s\t%.1f\n", comp, coverage_sum[comp] / func_count[comp]
+    }
+}
+')
+
+# Generate Markdown report
+{
+    echo "# Test Coverage Report"
+    echo ""
+    echo "## Summary"
+    echo ""
+    echo "**Total Project Coverage**: **$TOTAL_COV**"
+    echo ""
+    echo "### Component Coverage"
+    echo ""
+    echo "| Component | Coverage |"
+    echo "|---|---|"
+    echo "$COMP_DATA" | awk -F'\t' '{
+        if ($2 == "N/A") printf "| %s | N/A |\n", $1
+        else printf "| %s | %s%% |\n", $1, $2
+    }'
+    echo ""
+    echo "## Details"
+    echo "| File | Coverage |"
+    echo "|---|---|"
+    echo "$FUNC_NO_TOTAL" | awk '{printf "| %s | %s |\n", $1, $NF}'
+} > "$MD_REPORT"
+
+# Print terminal summary
+echo ""
+echo "=== Coverage Summary ==="
+echo "Total: $TOTAL_COV"
+echo "$COMP_DATA" | awk -F'\t' '{
+    if ($2 == "N/A") printf "  %-16s N/A\n", $1
+    else printf "  %-16s %s%%\n", $1, $2
+}'
+echo "========================"

--- a/.mise/tasks/lib/logs
+++ b/.mise/tasks/lib/logs
@@ -1,0 +1,9 @@
+# Shared log functions — sourced by mise tasks, not executable
+# Requires gum (install via mise.toml tools).
+
+log_step() { gum log --level info "$1"; }
+log_info() { gum log --level info "$1"; }
+log_warn() { gum log --level warn "$1"; }
+log_error() { gum log --level error "$1"; }
+
+# vim: ft=sh

--- a/README.md
+++ b/README.md
@@ -43,9 +43,10 @@ includes = ["git::https://github.com/nics-dp/meta.git//.mise/tasks?ref=main"]
 | -------- | -------------------------------------------------------------------------------------- | ----------------------------------- |
 | `ci:*`   | commitlint, go-lint, go-sec, go-vulncheck, hadolint, semgrep, trivy-iac, trivy-license | CI 檢查                             |
 | `dc:*`   | clean, down, pull, rec, up                                                             | Docker Compose 生命週期管理         |
-| `go:*`   | build, local, mod, remote, run, upgrade                                                | Go 建置與模組管理                   |
+| `go:*`   | build, coverage-report, local, mod, remote, run, upgrade                               | Go 建置與模組管理                   |
 | `gs:*`   | clone, update                                                                          | Git submodules                      |
 | `sbom:*` | source, enrich, trivy, grype                                                           | SBOM 產生與漏洞掃描                 |
+| `lib/*`  | logs                                                                                   | 共用函式庫 (供 tasks source 使用)   |
 | `ruler`  | —                                                                                      | 編譯 ruler 至 AGENTS.md / CLAUDE.md |
 
 Consumer repos 可在自己的 `mise.toml` 中定義同名 task 來覆寫或擴充。


### PR DESCRIPTION
## Summary
- Add `lib/logs` shared gum-based log library for mise tasks to source
- Add `go:coverage-report` file-based task (migrated from otel-bundle `scripts/gen_html_markdown_report.sh`)
- Update README task table with new entries

## Test plan
- [ ] Verify `mise run go:coverage-report` works in consumer repo with `coverage.out` present