### PR TITLE
chore(prettier): exclude YAML and JSON files from prettier formatting

### DIFF
--- a/configs/.prettierignore
+++ b/configs/.prettierignore
@@ -3,3 +3,5 @@ node_modules
 bun.lock
 *.min.js
 *.min.css
+*.yml
+*.json


### PR DESCRIPTION
## Summary
- 於 `configs/.prettierignore` 新增忽略 YAML (`*.yml`, `*.yaml`) 與 JSON (`*.json`) 檔案
- 避免 Prettier 的 `singleQuote` 設定將 `.commitlintrc.yml` 等設定檔中的雙引號改為單引號，導致與 meta 設定不一致而產生多餘 PR

Closes #71

## Test plan
- [x] 確認 `.prettierignore` 已排除 YAML / JSON 檔
- [x] 於下游 repo 執行 prettier 驗證 YAML / JSON 不再被修改