### PR TITLE
Release/v0.2.3

### DIFF
--- a/.github/workflows/bun-semgrep.yml
+++ b/.github/workflows/bun-semgrep.yml
@@ -23,7 +23,7 @@ jobs:
     name: Semgrep (Web)
     runs-on: ubuntu-latest
     container:
-      image: semgrep/semgrep:1.160.0
+      image: semgrep/semgrep:1.161.0
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/go-semgrep.yml
+++ b/.github/workflows/go-semgrep.yml
@@ -23,7 +23,7 @@ jobs:
     name: Semgrep (Go)
     runs-on: ubuntu-latest
     container:
-      image: semgrep/semgrep:1.160.0
+      image: semgrep/semgrep:1.161.0
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/sbom-image.yml
+++ b/.github/workflows/sbom-image.yml
@@ -95,7 +95,7 @@ jobs:
 
       - name: Scan SBOM with Trivy (SARIF)
         if: always()
-        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # 0.35.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           scan-type: sbom
           scan-ref: enriched-image.cdx.json
@@ -115,7 +115,7 @@ jobs:
           category: trivy-image
 
       - name: Scan SBOM with Trivy (JSON)
-        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # 0.35.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           scan-type: sbom
           scan-ref: enriched-image.cdx.json

--- a/.github/workflows/sbom-source.yml
+++ b/.github/workflows/sbom-source.yml
@@ -82,7 +82,7 @@ jobs:
 
       - name: Scan SBOM with Trivy (SARIF)
         if: always()
-        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # 0.35.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           scan-type: sbom
           scan-ref: enriched-source.cdx.json
@@ -102,7 +102,7 @@ jobs:
           category: trivy-source
 
       - name: Scan SBOM with Trivy (JSON)
-        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # 0.35.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           scan-type: sbom
           scan-ref: enriched-source.cdx.json

--- a/.github/workflows/trivy-iac.yml
+++ b/.github/workflows/trivy-iac.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Run Trivy IaC scan (SARIF)
-        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # 0.35.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           scan-type: config
           scan-ref: .
@@ -38,7 +38,7 @@ jobs:
 
       - name: Run Trivy IaC scan (JSON)
         if: github.event_name == 'pull_request'
-        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # 0.35.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           scan-type: config
           scan-ref: .

--- a/.github/workflows/trivy-license.yml
+++ b/.github/workflows/trivy-license.yml
@@ -62,7 +62,7 @@ jobs:
         run: mise run go:mod
 
       - name: Run Trivy license scan (table)
-        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # 0.35.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           scan-type: fs
           scanners: license
@@ -71,7 +71,7 @@ jobs:
           exit-code: "0"
 
       - name: Run Trivy license scan (JSON)
-        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # 0.35.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           scan-type: fs
           scanners: license


### PR DESCRIPTION
This pull request updates several GitHub Actions workflows to use the latest versions of the Semgrep and Trivy tools. These upgrades ensure that our CI pipelines benefit from the latest features, bug fixes, and security improvements provided by these tools.

Dependency version upgrades:

**Semgrep:**
- Updated the Semgrep container image from `1.160.0` to `1.161.0` in both `.github/workflows/bun-semgrep.yml` and `.github/workflows/go-semgrep.yml`. [[1]](diffhunk://#diff-e637e287975e3ce25af91a75fd59d1c21083be0fa2fd4806c8145516fcbe96dfL26-R26) [[2]](diffhunk://#diff-f0e2c56c9395ee460a91ff677e13b67ec75cd082ed3f0738b78678df0d7727caL26-R26)

**Trivy:**
- Upgraded `aquasecurity/trivy-action` from `0.35.0` to `v0.36.0` in the following workflows:
  - `.github/workflows/sbom-image.yml` for both SARIF and JSON SBOM scans. [[1]](diffhunk://#diff-2f13a196ea4fa17083747fef960c92083ca3ce0761b8417de5dbfdf040347a5dL98-R98) [[2]](diffhunk://#diff-2f13a196ea4fa17083747fef960c92083ca3ce0761b8417de5dbfdf040347a5dL118-R118)
  - `.github/workflows/sbom-source.yml` for both SARIF and JSON SBOM scans. [[1]](diffhunk://#diff-99830d7b07ae035592f18b2d549a3ed7180b64b67f6d77d73ca6f105229a38a5L85-R85) [[2]](diffhunk://#diff-99830d7b07ae035592f18b2d549a3ed7180b64b67f6d77d73ca6f105229a38a5L105-R105)
  - `.github/workflows/trivy-iac.yml` for both SARIF and JSON IaC scans. [[1]](diffhunk://#diff-c8e3f37df57cc6bbca9b6e2d8308fca72e1a0a264a3048e7e51925c432a2c8adL25-R25) [[2]](diffhunk://#diff-c8e3f37df57cc6bbca9b6e2d8308fca72e1a0a264a3048e7e51925c432a2c8adL41-R41)
  - `.github/workflows/trivy-license.yml` for both table and JSON license scans. [[1]](diffhunk://#diff-ab423972f80e906406b817dc964c878238adaa182fa22dac7259dcd87f0166afL65-R65) [[2]](diffhunk://#diff-ab423972f80e906406b817dc964c878238adaa182fa22dac7259dcd87f0166afL74-R74)