### PR TITLE
style(eslint): Format eslint config imports

### DIFF
--- a/configs/eslint.config.js
+++ b/configs/eslint.config.js
@@ -1,8 +1,5 @@
 import pluginVue from 'eslint-plugin-vue'
-import {
-  defineConfigWithVueTs,
-  vueTsConfigs,
-} from '@vue/eslint-config-typescript'
+import { defineConfigWithVueTs, vueTsConfigs } from '@vue/eslint-config-typescript'
 
 export default defineConfigWithVueTs(
   { ignores: ['dist/', 'node_modules/'] },
@@ -12,5 +9,5 @@ export default defineConfigWithVueTs(
     rules: {
       'vue/multi-word-component-names': 'off',
     },
-  },
+  }
 )


### PR DESCRIPTION
## Summary
- 將 `@vue/eslint-config-typescript` 的 multi-line import 壓回 single line
- 移除尾端 trailing comma


Closes #106