### PR TITLE
feat(image-release): add external_repo / dockerfile_path inputs

### DIFF
--- a/.github/workflows/image-release.yml
+++ b/.github/workflows/image-release.yml
@@ -158,11 +158,17 @@ jobs:
           if [[ -z "$DOCKERFILE_PATH" ]]; then
             echo "::error::dockerfile_path is required when external_repo is set"
             fail=1
+          elif [[ "$DOCKERFILE_PATH" == /* ]]; then
+            echo "::error::dockerfile_path must be relative to the caller repository workspace, got '$DOCKERFILE_PATH'"
+            fail=1
+          elif [[ "$DOCKERFILE_PATH" == *..* ]]; then
+            echo "::error::dockerfile_path must not contain '..', got '$DOCKERFILE_PATH'"
+            fail=1
           elif [[ -L "$DOCKERFILE_PATH" ]]; then
             echo "::error::dockerfile_path '$DOCKERFILE_PATH' must be a regular file, not a symlink"
             fail=1
           elif [[ ! -f "$DOCKERFILE_PATH" ]]; then
-            echo "::error::dockerfile_path '$DOCKERFILE_PATH' not found in this repo"
+            echo "::error::dockerfile_path '$DOCKERFILE_PATH' not found in the caller repository workspace"
             fail=1
           fi
           if [[ -z "$EXTERNAL_PATH" ]]; then
@@ -214,8 +220,14 @@ jobs:
           DEST: ${{ inputs.external_path }}/Dockerfile
         run: |
           # Remove any existing DEST first so cp cannot follow a symlink the
-          # external repo may ship at that path.
+          # external repo may ship at that path. `rm -f` succeeds on missing
+          # paths but fails on directories under `set -e`; assert DEST is gone
+          # before writing so failures surface with a clear message.
           rm -f -- "$DEST"
+          if [[ -e "$DEST" || -L "$DEST" ]]; then
+            echo "::error::cannot overlay Dockerfile onto '$DEST': path still exists after rm (likely a directory)"
+            exit 1
+          fi
           cp -- "$SRC" "$DEST"
 
       - name: Prepare non-secret build args from env file
@@ -293,6 +305,11 @@ jobs:
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           context: ${{ inputs.context }}
+          # In external_repo mode the overlaid Dockerfile lives at
+          # external_path/Dockerfile, which may differ from context (e.g., when
+          # caller points context at a monorepo subpath). Pin file explicitly
+          # so build never silently picks up an upstream Dockerfile.
+          file: ${{ inputs.external_repo != '' && format('{0}/Dockerfile', inputs.external_path) || '' }}
           platforms: ${{ inputs.platforms }}
           push: true
           tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/image-release.yml
+++ b/.github/workflows/image-release.yml
@@ -318,7 +318,12 @@ jobs:
           # external_path/Dockerfile, which may differ from context (e.g., when
           # caller points context at a monorepo subpath). Pin file explicitly
           # so build never silently picks up an upstream Dockerfile.
-          file: ${{ inputs.external_repo != '' && format('{0}/Dockerfile', inputs.external_path) || '' }}
+          #
+          # When external_repo is not set, fall back to ${context}/Dockerfile,
+          # which matches build-push-action's documented default and keeps
+          # existing callers' behaviour identical (rather than relying on the
+          # implicit "empty string == unset" handling inside the action).
+          file: ${{ inputs.external_repo != '' && format('{0}/Dockerfile', inputs.external_path) || format('{0}/Dockerfile', inputs.context) }}
           platforms: ${{ inputs.platforms }}
           push: true
           tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/image-release.yml
+++ b/.github/workflows/image-release.yml
@@ -78,7 +78,7 @@ on:
         required: false
         type: string
         default: ""
-        description: "Optional external repo to checkout as the build context (e.g., 'patroni/patroni'). When set, the caller is expected to point `context` at `external_path`."
+        description: "Optional external repo to checkout as the build context (e.g., 'patroni/patroni'). When set, `context` must equal `external_path` or be a subpath of it."
       external_ref:
         required: false
         type: string
@@ -197,6 +197,10 @@ jobs:
                 fail=1
                 ;;
             esac
+            if [[ "$CONTEXT" == *..* ]]; then
+              echo "::error::context must not contain '..', got '$CONTEXT'"
+              fail=1
+            fi
           fi
           if [[ "$GO_VENDOR" == "true" ]]; then
             echo "::error::go_vendor is not supported with external_repo; the vendor step would run in the caller repo, leaving the external build context without vendor/"

--- a/.github/workflows/image-release.yml
+++ b/.github/workflows/image-release.yml
@@ -83,7 +83,7 @@ on:
         required: false
         type: string
         default: ""
-        description: "Ref (branch/tag/sha) to checkout from external_repo. Ignored when external_repo is empty."
+        description: "Ref (branch/tag/sha) to checkout from external_repo. Required when external_repo is set (empty would default to upstream's default branch and make builds non-reproducible). Ignored when external_repo is empty."
       external_path:
         required: false
         type: string
@@ -151,6 +151,7 @@ jobs:
         env:
           DOCKERFILE_PATH: ${{ inputs.dockerfile_path }}
           EXTERNAL_PATH: ${{ inputs.external_path }}
+          EXTERNAL_REF: ${{ inputs.external_ref }}
           CONTEXT: ${{ inputs.context }}
           GO_VENDOR: ${{ inputs.go_vendor }}
         run: |
@@ -159,32 +160,52 @@ jobs:
           # equivalent forms ("./external-src" and "external-src") validate
           # the same way. Error messages echo the caller's original value to
           # avoid confusion ("you wrote X but the tool says Y was rejected").
+          NORM_DOCKERFILE_PATH="${DOCKERFILE_PATH#./}"
           NORM_EXTERNAL_PATH="${EXTERNAL_PATH#./}"
           NORM_CONTEXT="${CONTEXT#./}"
-          if [[ -z "$DOCKERFILE_PATH" ]]; then
+
+          # has_dotdot <path> — true only when ".." appears as a full path
+          # component (i.e., "..", "../x", "x/..", or "x/../y"). Avoids
+          # rejecting legitimate names like "my..dir" that merely contain "..".
+          has_dotdot() {
+            case "$1" in
+              ..|../*|*/..|*/../*) return 0 ;;
+              *) return 1 ;;
+            esac
+          }
+
+          # external_ref must be non-empty: an empty ref makes builds
+          # non-reproducible by silently falling back to the default branch.
+          if [[ -z "$EXTERNAL_REF" ]]; then
+            echo "::error::external_ref is required when external_repo is set (empty ref would default to upstream's default branch, breaking reproducibility)"
+            fail=1
+          fi
+
+          if [[ -z "$NORM_DOCKERFILE_PATH" ]]; then
             echo "::error::dockerfile_path is required when external_repo is set"
             fail=1
-          elif [[ "$DOCKERFILE_PATH" == /* ]]; then
+          elif [[ "$NORM_DOCKERFILE_PATH" == /* ]]; then
             echo "::error::dockerfile_path must be relative to the caller repository workspace, got '$DOCKERFILE_PATH'"
             fail=1
-          elif [[ "$DOCKERFILE_PATH" == *..* ]]; then
-            echo "::error::dockerfile_path must not contain '..', got '$DOCKERFILE_PATH'"
+          elif has_dotdot "$NORM_DOCKERFILE_PATH"; then
+            echo "::error::dockerfile_path must not contain a '..' path component, got '$DOCKERFILE_PATH'"
             fail=1
-          elif [[ -L "$DOCKERFILE_PATH" ]]; then
+          elif [[ -L "$NORM_DOCKERFILE_PATH" ]]; then
             echo "::error::dockerfile_path '$DOCKERFILE_PATH' must be a regular file, not a symlink"
             fail=1
-          elif [[ ! -f "$DOCKERFILE_PATH" ]]; then
+          elif [[ ! -f "$NORM_DOCKERFILE_PATH" ]]; then
             echo "::error::dockerfile_path '$DOCKERFILE_PATH' not found in the caller repository workspace"
             fail=1
           fi
+
           if [[ -z "$NORM_EXTERNAL_PATH" || "$NORM_EXTERNAL_PATH" == "." ]]; then
             echo "::error::external_path must resolve to a directory under the workspace (not '.' / './' / empty), got '$EXTERNAL_PATH'"
             fail=1
           elif [[ "$NORM_EXTERNAL_PATH" == /* ]]; then
             echo "::error::external_path must be relative, got '$EXTERNAL_PATH'"
             fail=1
-          elif [[ "$NORM_EXTERNAL_PATH" == *..* ]]; then
-            echo "::error::external_path must not contain '..', got '$EXTERNAL_PATH'"
+          elif has_dotdot "$NORM_EXTERNAL_PATH"; then
+            echo "::error::external_path must not contain a '..' path component, got '$EXTERNAL_PATH'"
             fail=1
           elif [[ "$NORM_EXTERNAL_PATH" == */ ]]; then
             echo "::error::external_path must not end with '/', got '$EXTERNAL_PATH'"
@@ -200,11 +221,16 @@ jobs:
                 fail=1
                 ;;
             esac
-            if [[ "$NORM_CONTEXT" == *..* ]]; then
-              echo "::error::context must not contain '..', got '$CONTEXT'"
-              fail=1
-            fi
           fi
+
+          # context '..' check runs independently of the external_path branches
+          # above so the more specific error still fires when external_path
+          # itself fails validation.
+          if has_dotdot "$NORM_CONTEXT"; then
+            echo "::error::context must not contain a '..' path component, got '$CONTEXT'"
+            fail=1
+          fi
+
           if [[ "$GO_VENDOR" == "true" ]]; then
             echo "::error::go_vendor is not supported with external_repo; the vendor step would run in the caller repo, leaving the external build context without vendor/"
             fail=1
@@ -319,10 +345,11 @@ jobs:
           # caller points context at a monorepo subpath). Pin file explicitly
           # so build never silently picks up an upstream Dockerfile.
           #
-          # When external_repo is not set, fall back to ${context}/Dockerfile,
-          # which matches build-push-action's documented default and keeps
-          # existing callers' behaviour identical (rather than relying on the
-          # implicit "empty string == unset" handling inside the action).
+          # When external_repo is not set, fall back to ${context}/Dockerfile.
+          # This is the path build-push-action would currently infer on its
+          # own, but setting it explicitly pins behaviour against future action
+          # changes and keeps existing callers identical regardless of how the
+          # action handles an empty `file:` input.
           file: ${{ inputs.external_repo != '' && format('{0}/Dockerfile', inputs.external_path) || format('{0}/Dockerfile', inputs.context) }}
           platforms: ${{ inputs.platforms }}
           push: true

--- a/.github/workflows/image-release.yml
+++ b/.github/workflows/image-release.yml
@@ -224,10 +224,12 @@ jobs:
           DEST: ${{ inputs.external_path }}/Dockerfile
         run: |
           # Remove any existing DEST first so cp cannot follow a symlink the
-          # external repo may ship at that path. `rm -f` succeeds on missing
-          # paths but fails on directories under `set -e`; assert DEST is gone
-          # before writing so failures surface with a clear message.
-          rm -f -- "$DEST"
+          # external repo may ship at that path. Tolerate rm's exit code with
+          # `|| true` so the `[[ -e ]]` check below can fire with a clear
+          # error message when DEST is a directory (rm -f fails on dirs, and
+          # without the `|| true` the step would abort on the bare rm error
+          # under `set -e`, never reaching this branch).
+          rm -f -- "$DEST" || true
           if [[ -e "$DEST" || -L "$DEST" ]]; then
             echo "::error::cannot overlay Dockerfile onto '$DEST': path still exists after rm (likely a directory)"
             exit 1

--- a/.github/workflows/image-release.yml
+++ b/.github/workflows/image-release.yml
@@ -74,6 +74,26 @@ on:
         type: string
         default: "stable"
         description: "Go version for vendor step (only used when go_vendor is true)"
+      external_repo:
+        required: false
+        type: string
+        default: ""
+        description: "Optional external repo to checkout as the build context (e.g., 'patroni/patroni'). When set, the caller is expected to point `context` at `external_path`."
+      external_ref:
+        required: false
+        type: string
+        default: ""
+        description: "Ref (branch/tag/sha) to checkout from external_repo. Ignored when external_repo is empty."
+      external_path:
+        required: false
+        type: string
+        default: "external-src"
+        description: "Local path under the workspace where external_repo is checked out. Ignored when external_repo is empty."
+      dockerfile_path:
+        required: false
+        type: string
+        default: ""
+        description: "Path (relative to this repo) of the Dockerfile to copy into external_path/Dockerfile, overriding any Dockerfile the external repo ships with. Required when external_repo is set; otherwise ignored."
     outputs:
       digest:
         description: "Image digest (sha256:...)"
@@ -125,6 +145,35 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ inputs.ref }}
+
+      - name: Validate external_repo inputs
+        if: inputs.external_repo != ''
+        env:
+          DOCKERFILE_PATH: ${{ inputs.dockerfile_path }}
+        run: |
+          if [[ -z "$DOCKERFILE_PATH" ]]; then
+            echo "::error::dockerfile_path is required when external_repo is set"
+            exit 1
+          fi
+          if [[ ! -f "$DOCKERFILE_PATH" ]]; then
+            echo "::error::dockerfile_path '$DOCKERFILE_PATH' not found in this repo"
+            exit 1
+          fi
+
+      - name: Checkout external repo
+        if: inputs.external_repo != ''
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: ${{ inputs.external_repo }}
+          ref: ${{ inputs.external_ref }}
+          path: ${{ inputs.external_path }}
+
+      - name: Overlay Dockerfile onto external source
+        if: inputs.external_repo != ''
+        env:
+          SRC: ${{ inputs.dockerfile_path }}
+          DEST: ${{ inputs.external_path }}/Dockerfile
+        run: cp "$SRC" "$DEST"
 
       - name: Prepare non-secret build args from env file
         id: env-args

--- a/.github/workflows/image-release.yml
+++ b/.github/workflows/image-release.yml
@@ -93,7 +93,7 @@ on:
         required: false
         type: string
         default: ""
-        description: "Path (relative to this repo) of the Dockerfile to copy into external_path/Dockerfile, overriding any Dockerfile the external repo ships with. Required when external_repo is set; otherwise ignored."
+        description: "Path (relative to the caller repository workspace) of the Dockerfile to copy into external_path/Dockerfile, overriding any Dockerfile the external repo ships with. Must be a regular file (symlinks are rejected). Required when external_repo is set; otherwise ignored."
     outputs:
       digest:
         description: "Image digest (sha256:...)"
@@ -158,6 +158,9 @@ jobs:
           if [[ -z "$DOCKERFILE_PATH" ]]; then
             echo "::error::dockerfile_path is required when external_repo is set"
             fail=1
+          elif [[ -L "$DOCKERFILE_PATH" ]]; then
+            echo "::error::dockerfile_path '$DOCKERFILE_PATH' must be a regular file, not a symlink"
+            fail=1
           elif [[ ! -f "$DOCKERFILE_PATH" ]]; then
             echo "::error::dockerfile_path '$DOCKERFILE_PATH' not found in this repo"
             fail=1
@@ -170,6 +173,15 @@ jobs:
             fail=1
           elif [[ "$EXTERNAL_PATH" == *..* ]]; then
             echo "::error::external_path must not contain '..', got '$EXTERNAL_PATH'"
+            fail=1
+          elif [[ "$EXTERNAL_PATH" == "." || "$EXTERNAL_PATH" == ./* ]]; then
+            echo "::error::external_path must not be '.' or start with './' (would overwrite caller repo), got '$EXTERNAL_PATH'"
+            fail=1
+          elif [[ "$EXTERNAL_PATH" == */ ]]; then
+            echo "::error::external_path must not end with '/', got '$EXTERNAL_PATH'"
+            fail=1
+          elif [[ "$EXTERNAL_PATH" == *[*?\[]* ]]; then
+            echo "::error::external_path must not contain glob metacharacters (*, ?, [), got '$EXTERNAL_PATH'"
             fail=1
           else
             case "$CONTEXT" in
@@ -200,7 +212,11 @@ jobs:
         env:
           SRC: ${{ inputs.dockerfile_path }}
           DEST: ${{ inputs.external_path }}/Dockerfile
-        run: cp "$SRC" "$DEST"
+        run: |
+          # Remove any existing DEST first so cp cannot follow a symlink the
+          # external repo may ship at that path.
+          rm -f -- "$DEST"
+          cp -- "$SRC" "$DEST"
 
       - name: Prepare non-secret build args from env file
         id: env-args

--- a/.github/workflows/image-release.yml
+++ b/.github/workflows/image-release.yml
@@ -146,6 +146,22 @@ jobs:
         with:
           ref: ${{ inputs.ref }}
 
+      - name: Warn on orphan external_repo inputs
+        if: inputs.external_repo == '' && (inputs.dockerfile_path != '' || inputs.external_ref != '')
+        env:
+          DOCKERFILE_PATH: ${{ inputs.dockerfile_path }}
+          EXTERNAL_REF: ${{ inputs.external_ref }}
+        run: |
+          # dockerfile_path / external_ref only take effect alongside
+          # external_repo; surface a warning so callers don't assume they were
+          # silently honored.
+          if [[ -n "$DOCKERFILE_PATH" ]]; then
+            echo "::warning::dockerfile_path ('$DOCKERFILE_PATH') was set without external_repo and will be ignored"
+          fi
+          if [[ -n "$EXTERNAL_REF" ]]; then
+            echo "::warning::external_ref ('$EXTERNAL_REF') was set without external_repo and will be ignored"
+          fi
+
       - name: Validate external_repo inputs
         if: inputs.external_repo != ''
         env:

--- a/.github/workflows/image-release.yml
+++ b/.github/workflows/image-release.yml
@@ -155,6 +155,12 @@ jobs:
           GO_VENDOR: ${{ inputs.go_vendor }}
         run: |
           fail=0
+          # Strip a single optional leading "./" for path comparison so
+          # equivalent forms ("./external-src" and "external-src") validate
+          # the same way. Error messages echo the caller's original value to
+          # avoid confusion ("you wrote X but the tool says Y was rejected").
+          NORM_EXTERNAL_PATH="${EXTERNAL_PATH#./}"
+          NORM_CONTEXT="${CONTEXT#./}"
           if [[ -z "$DOCKERFILE_PATH" ]]; then
             echo "::error::dockerfile_path is required when external_repo is set"
             fail=1
@@ -171,33 +177,30 @@ jobs:
             echo "::error::dockerfile_path '$DOCKERFILE_PATH' not found in the caller repository workspace"
             fail=1
           fi
-          if [[ -z "$EXTERNAL_PATH" ]]; then
-            echo "::error::external_path must not be empty"
+          if [[ -z "$NORM_EXTERNAL_PATH" || "$NORM_EXTERNAL_PATH" == "." ]]; then
+            echo "::error::external_path must resolve to a directory under the workspace (not '.' / './' / empty), got '$EXTERNAL_PATH'"
             fail=1
-          elif [[ "$EXTERNAL_PATH" == /* ]]; then
+          elif [[ "$NORM_EXTERNAL_PATH" == /* ]]; then
             echo "::error::external_path must be relative, got '$EXTERNAL_PATH'"
             fail=1
-          elif [[ "$EXTERNAL_PATH" == *..* ]]; then
+          elif [[ "$NORM_EXTERNAL_PATH" == *..* ]]; then
             echo "::error::external_path must not contain '..', got '$EXTERNAL_PATH'"
             fail=1
-          elif [[ "$EXTERNAL_PATH" == "." || "$EXTERNAL_PATH" == ./* ]]; then
-            echo "::error::external_path must not be '.' or start with './' (would overwrite caller repo), got '$EXTERNAL_PATH'"
-            fail=1
-          elif [[ "$EXTERNAL_PATH" == */ ]]; then
+          elif [[ "$NORM_EXTERNAL_PATH" == */ ]]; then
             echo "::error::external_path must not end with '/', got '$EXTERNAL_PATH'"
             fail=1
-          elif [[ "$EXTERNAL_PATH" == *[*?\[]* ]]; then
+          elif [[ "$NORM_EXTERNAL_PATH" == *[*?\[]* ]]; then
             echo "::error::external_path must not contain glob metacharacters (*, ?, [), got '$EXTERNAL_PATH'"
             fail=1
           else
-            case "$CONTEXT" in
-              "$EXTERNAL_PATH"|"$EXTERNAL_PATH"/*) ;;
+            case "$NORM_CONTEXT" in
+              "$NORM_EXTERNAL_PATH"|"$NORM_EXTERNAL_PATH"/*) ;;
               *)
                 echo "::error::context must be '$EXTERNAL_PATH' or a subpath when external_repo is set, got '$CONTEXT'"
                 fail=1
                 ;;
             esac
-            if [[ "$CONTEXT" == *..* ]]; then
+            if [[ "$NORM_CONTEXT" == *..* ]]; then
               echo "::error::context must not contain '..', got '$CONTEXT'"
               fail=1
             fi

--- a/.github/workflows/image-release.yml
+++ b/.github/workflows/image-release.yml
@@ -190,6 +190,9 @@ jobs:
           elif has_dotdot "$NORM_DOCKERFILE_PATH"; then
             echo "::error::dockerfile_path must not contain a '..' path component, got '$DOCKERFILE_PATH'"
             fail=1
+          elif [[ "$NORM_DOCKERFILE_PATH" == *[*?\[]* ]]; then
+            echo "::error::dockerfile_path must not contain glob metacharacters (*, ?, [), got '$DOCKERFILE_PATH'"
+            fail=1
           elif [[ -L "$NORM_DOCKERFILE_PATH" ]]; then
             echo "::error::dockerfile_path '$DOCKERFILE_PATH' must be a regular file, not a symlink"
             fail=1
@@ -223,11 +226,15 @@ jobs:
             esac
           fi
 
-          # context '..' check runs independently of the external_path branches
-          # above so the more specific error still fires when external_path
-          # itself fails validation.
+          # context '..' and glob checks run independently of the external_path
+          # branches above so the more specific error still fires when
+          # external_path itself fails validation.
           if has_dotdot "$NORM_CONTEXT"; then
             echo "::error::context must not contain a '..' path component, got '$CONTEXT'"
+            fail=1
+          fi
+          if [[ "$NORM_CONTEXT" == *[*?\[]* ]]; then
+            echo "::error::context must not contain glob metacharacters (*, ?, [), got '$CONTEXT'"
             fail=1
           fi
 

--- a/.github/workflows/image-release.yml
+++ b/.github/workflows/image-release.yml
@@ -150,15 +150,41 @@ jobs:
         if: inputs.external_repo != ''
         env:
           DOCKERFILE_PATH: ${{ inputs.dockerfile_path }}
+          EXTERNAL_PATH: ${{ inputs.external_path }}
+          CONTEXT: ${{ inputs.context }}
+          GO_VENDOR: ${{ inputs.go_vendor }}
         run: |
+          fail=0
           if [[ -z "$DOCKERFILE_PATH" ]]; then
             echo "::error::dockerfile_path is required when external_repo is set"
-            exit 1
-          fi
-          if [[ ! -f "$DOCKERFILE_PATH" ]]; then
+            fail=1
+          elif [[ ! -f "$DOCKERFILE_PATH" ]]; then
             echo "::error::dockerfile_path '$DOCKERFILE_PATH' not found in this repo"
-            exit 1
+            fail=1
           fi
+          if [[ -z "$EXTERNAL_PATH" ]]; then
+            echo "::error::external_path must not be empty"
+            fail=1
+          elif [[ "$EXTERNAL_PATH" == /* ]]; then
+            echo "::error::external_path must be relative, got '$EXTERNAL_PATH'"
+            fail=1
+          elif [[ "$EXTERNAL_PATH" == *..* ]]; then
+            echo "::error::external_path must not contain '..', got '$EXTERNAL_PATH'"
+            fail=1
+          else
+            case "$CONTEXT" in
+              "$EXTERNAL_PATH"|"$EXTERNAL_PATH"/*) ;;
+              *)
+                echo "::error::context must be '$EXTERNAL_PATH' or a subpath when external_repo is set, got '$CONTEXT'"
+                fail=1
+                ;;
+            esac
+          fi
+          if [[ "$GO_VENDOR" == "true" ]]; then
+            echo "::error::go_vendor is not supported with external_repo; the vendor step would run in the caller repo, leaving the external build context without vendor/"
+            fail=1
+          fi
+          [[ "$fail" -eq 0 ]] || exit 1
 
       - name: Checkout external repo
         if: inputs.external_repo != ''
@@ -167,6 +193,7 @@ jobs:
           repository: ${{ inputs.external_repo }}
           ref: ${{ inputs.external_ref }}
           path: ${{ inputs.external_path }}
+          token: ${{ secrets.gh_pat || github.token }}
 
       - name: Overlay Dockerfile onto external source
         if: inputs.external_repo != ''

--- a/.github/workflows/image-release.yml
+++ b/.github/workflows/image-release.yml
@@ -254,6 +254,22 @@ jobs:
             fail=1
           fi
 
+          # Reject dockerfile_path that lives under external_path. The external
+          # checkout step clones into external_path with clean=true, removing
+          # the caller's Dockerfile before the overlay cp reads it. In the
+          # degenerate case where the external repo ships a file at the same
+          # relative path, cp would silently use the external repo's content
+          # as the overlay source - defeating the whole point of the overlay.
+          # Only runs when both paths passed their own non-emptiness checks.
+          if [[ -n "$NORM_DOCKERFILE_PATH" && -n "$NORM_EXTERNAL_PATH" && "$NORM_EXTERNAL_PATH" != "." ]]; then
+            case "$NORM_DOCKERFILE_PATH" in
+              "$NORM_EXTERNAL_PATH"|"$NORM_EXTERNAL_PATH"/*)
+                echo "::error::dockerfile_path ('$DOCKERFILE_PATH') must not be inside external_path ('$EXTERNAL_PATH'); the external checkout would overwrite it before the overlay copy"
+                fail=1
+                ;;
+            esac
+          fi
+
           if [[ "$GO_VENDOR" == "true" ]]; then
             echo "::error::go_vendor is not supported with external_repo; the vendor step would run in the caller repo, leaving the external build context without vendor/"
             fail=1

--- a/.mise/tasks/lib/py-env
+++ b/.mise/tasks/lib/py-env
@@ -22,6 +22,8 @@ if [ -z "${PY_TEST_PATHS:-}" ]; then
   fi
 fi
 
-# Split runner into array for safe expansion
-# shellcheck disable=SC2206
+# Split runner into array for safe expansion. SC2034 suppresses the
+# "appears unused" warning when shellcheck lints this helper in isolation;
+# the array is consumed by downstream tasks that source this file.
+# shellcheck disable=SC2206,SC2034
 PY_RUNNER_ARR=($PY_RUNNER)

--- a/.mise/tasks/py/typecheck
+++ b/.mise/tasks/py/typecheck
@@ -10,7 +10,9 @@ source "$(dirname "$0")/../lib/py-env"
 
 # shellcheck disable=SC2154
 if [ "${usage_pyrefly:-false}" = "true" ]; then
-  uvx pyrefly check "$PY_LINT_PATHS"
+  # Pyrefly resolves scope from project-includes/project-excludes in
+  # pyproject.toml; passing paths on the CLI bypasses project-excludes.
+  uvx pyrefly check
 else
   uvx ty check "$PY_LINT_PATHS"
 fi

--- a/.mise/tasks/py/typecheck
+++ b/.mise/tasks/py/typecheck
@@ -8,11 +8,15 @@ set -euo pipefail
 # shellcheck disable=SC1091
 source "$(dirname "$0")/../lib/py-env"
 
+# Both checkers resolve scope from pyproject.toml (pyrefly: project-includes/
+# project-excludes; ty: [tool.ty.src]). Passing positional paths bypasses
+# project-excludes in both tools (ty requires --force-exclude to honor them),
+# so we invoke without paths and let project config drive scope. Standalone
+# `mise run py:typecheck` from a fresh checkout works because uvx provisions
+# the checker in an ephemeral environment; no `uv sync` is needed here.
 # shellcheck disable=SC2154
 if [ "${usage_pyrefly:-false}" = "true" ]; then
-  # Pyrefly resolves scope from project-includes/project-excludes in
-  # pyproject.toml; passing paths on the CLI bypasses project-excludes.
   uvx pyrefly check
 else
-  uvx ty check "$PY_LINT_PATHS"
+  uvx ty check
 fi


### PR DESCRIPTION
## Summary

支援 build context 位於外部 repo (例如 patroni/patroni) 而非 caller 自身的場景

新增 4 個 optional input 到 image-release.yml:
- external_repo: 要 checkout 的外部 repo (例如 patroni/patroni)
- external_ref: 該 repo 的 ref (branch / tag / sha)
- external_path: 外部 repo 在 workspace 的本地路徑，預設 external-src
- dockerfile_path: caller repo 內的 Dockerfile 路徑，會覆蓋到 external_path/Dockerfile

當 external_repo 為空時行為完全不變，現有 caller 不受影響

## Motivation

nics-dp/patroni 是個 Dockerfile-only repo，build context 必須是 checkout 過的上游 patroni/patroni source 再蓋上自家 Dockerfile，目前 release.yml 必須 inline 跑 build-and-push，無法用 image-release.yml，擴充後 patroni 可改成只剩 prep + image-build (call) + sbom-image 三個 job

## Usage example (caller side)

\`\`\`yaml
image-build:
  uses: nics-dp/meta/.github/workflows/image-release.yml@dev
  with:
    image_name: patroni
    external_repo: patroni/patroni
    external_ref: \${{ needs.prep.outputs.patroni_version }}
    dockerfile_path: Dockerfile
    context: external-src
    build_args: |
      PG_MAJOR=\${{ needs.prep.outputs.pg_major }}
  secrets:
    dockerhub_username: \${{ secrets.DOCKERHUB_USERNAME }}
    dockerhub_token: \${{ secrets.DOCKERHUB_TOKEN }}
\`\`\`

## Test plan

- [ ] Meta CI 全綠
- [ ] 後續 patroni 改用此 input 後第一次 release 推出正常的 multi-arch image (digest 比對 inline build 結果應一致)

Closes #103