### PR TITLE
feat(mise): inject version ldflags in go:build and go:run

### DIFF
--- a/.mise/tasks/go/build
+++ b/.mise/tasks/go/build
@@ -6,13 +6,16 @@
 #USAGE arg "<name>" help="Binary name (auto-detected if cmd/ has only one entry)"
 # shellcheck disable=SC2154 # usage_name is set by mise USAGE
 
+# shellcheck disable=SC1091
+source "$(dirname "$0")/../lib/go-version"
+
 build_one() {
   echo "Building $1..."
   # Split EXTRA_BUILD_FLAGS into array to support multiple flags (e.g. "-race -v")
   # and avoid passing an empty "" argument when unset.
   # Using read -ra instead of bare expansion so shellharden won't re-quote it.
   IFS=' ' read -ra extra_flags <<< "${EXTRA_BUILD_FLAGS:-}"
-  go build -o "bin/$1" "${extra_flags[@]}" -ldflags "$LDFLAGS" "./cmd/$1"
+  go build -o "bin/$1" "${extra_flags[@]}" -ldflags "${LDFLAGS} ${VERSION_LDFLAGS}" "./cmd/$1"
 }
 
 if [ "$usage_name" = "" ]; then

--- a/.mise/tasks/go/run
+++ b/.mise/tasks/go/run
@@ -6,6 +6,9 @@
 #USAGE arg "[args]" var=#true var_min=0 help="Arguments to pass to the script"
 # shellcheck disable=SC2154 # usage_name, usage_args are set by mise USAGE
 
+# shellcheck disable=SC1091
+source "$(dirname "$0")/../lib/go-version"
+
 if [ "$usage_name" = "" ]; then
   entries=(cmd/*/main.go)
   if [ "${#entries[@]}" -eq 1 ]; then
@@ -20,4 +23,4 @@ if [ ! -f "cmd/$usage_name/main.go" ]; then
   echo "Error: cmd/$usage_name/main.go not found"
   exit 1
 fi
-go run -mod=vendor "./cmd/$usage_name" "$usage_args"
+go run -mod=vendor -ldflags "${VERSION_LDFLAGS}" "./cmd/$usage_name" "$usage_args"

--- a/.mise/tasks/lib/go-version
+++ b/.mise/tasks/lib/go-version
@@ -19,9 +19,11 @@
 # Reject whitespace and quote characters in values to prevent ldflags
 # injection — Go's -ldflags parser splits on whitespace, so a value
 # containing a space would be parsed as an extra linker flag.
+# Don't echo the offending value: env vars may carry sensitive data
+# and the error lands in CI logs.
 for _v in VERSION_PKG VERSION COMMIT COMMIT_DATE; do
   if [[ "${!_v}" =~ [[:space:]\"\'] ]]; then
-    echo "Error: $_v contains invalid characters (whitespace or quotes): ${!_v}" >&2
+    echo "Error: $_v contains invalid characters (whitespace or quotes)" >&2
     exit 1
   fi
 done

--- a/.mise/tasks/lib/go-version
+++ b/.mise/tasks/lib/go-version
@@ -2,18 +2,19 @@
 # Sourced helper. Provides Go version info for ldflags injection.
 # Vars (override via env if needed):
 #   VERSION       from git describe --tags --always --dirty   default: dev
-#   COMMIT        short commit SHA                            default: unknown
-#   BUILD_DATE    ISO8601 UTC timestamp                       default: <now>
-#   VERSION_PKG   package holding version vars                default: main
+#   COMMIT        full commit SHA                              default: unknown
+#   BUILD_DATE    ISO8601 UTC timestamp                        default: <now>
+#   VERSION_PKG   package holding version vars                 default: main
 #
 # Exports:
-#   VERSION_LDFLAGS  ready-to-append ldflags string injecting
-#                    ${VERSION_PKG}.version, .commit, .buildDate
+#   VERSION_LDFLAGS  -ldflags string injecting
+#                    ${VERSION_PKG}.Version, .CommitSHA, .CommitDate
+#                    (matches the go-release workflow naming convention)
 
 : "${VERSION_PKG:=main}"
 : "${VERSION:=$(git describe --tags --always --dirty 2>/dev/null || echo dev)}"
-: "${COMMIT:=$(git rev-parse --short HEAD 2>/dev/null || echo unknown)}"
+: "${COMMIT:=$(git rev-parse HEAD 2>/dev/null || echo unknown)}"
 : "${BUILD_DATE:=$(date -u +%Y-%m-%dT%H:%M:%SZ)}"
 
 # shellcheck disable=SC2034 # consumed by sourcing script (go/build, go/run)
-VERSION_LDFLAGS="-X ${VERSION_PKG}.version=${VERSION} -X ${VERSION_PKG}.commit=${COMMIT} -X ${VERSION_PKG}.buildDate=${BUILD_DATE}"
+VERSION_LDFLAGS="-X ${VERSION_PKG}.Version=${VERSION} -X ${VERSION_PKG}.CommitSHA=${COMMIT} -X ${VERSION_PKG}.CommitDate=${BUILD_DATE}"

--- a/.mise/tasks/lib/go-version
+++ b/.mise/tasks/lib/go-version
@@ -16,5 +16,16 @@
 : "${COMMIT:=$(git rev-parse HEAD 2>/dev/null || echo unknown)}"
 : "${BUILD_DATE:=$(date -u +%Y-%m-%dT%H:%M:%SZ)}"
 
+# Reject whitespace and quote characters in values to prevent ldflags
+# injection — Go's -ldflags parser splits on whitespace, so a value
+# containing a space would be parsed as an extra linker flag.
+for _v in VERSION_PKG VERSION COMMIT BUILD_DATE; do
+  if [[ "${!_v}" =~ [[:space:]\"\'] ]]; then
+    echo "Error: $_v contains invalid characters (whitespace or quotes): ${!_v}" >&2
+    exit 1
+  fi
+done
+unset _v
+
 # shellcheck disable=SC2034 # consumed by sourcing script (go/build, go/run)
 VERSION_LDFLAGS="-X ${VERSION_PKG}.Version=${VERSION} -X ${VERSION_PKG}.CommitSHA=${COMMIT} -X ${VERSION_PKG}.CommitDate=${BUILD_DATE}"

--- a/.mise/tasks/lib/go-version
+++ b/.mise/tasks/lib/go-version
@@ -3,7 +3,7 @@
 # Vars (override via env if needed):
 #   VERSION       from git describe --tags --always --dirty   default: dev
 #   COMMIT        full commit SHA                              default: unknown
-#   BUILD_DATE    ISO8601 UTC timestamp                        default: <now>
+#   COMMIT_DATE   ISO8601 commit timestamp from git log        default: <now>
 #   VERSION_PKG   package holding version vars                 default: main
 #
 # Exports:
@@ -14,12 +14,12 @@
 : "${VERSION_PKG:=main}"
 : "${VERSION:=$(git describe --tags --always --dirty 2>/dev/null || echo dev)}"
 : "${COMMIT:=$(git rev-parse HEAD 2>/dev/null || echo unknown)}"
-: "${BUILD_DATE:=$(date -u +%Y-%m-%dT%H:%M:%SZ)}"
+: "${COMMIT_DATE:=$(git log -1 --format=%cI 2>/dev/null || date -u +%Y-%m-%dT%H:%M:%SZ)}"
 
 # Reject whitespace and quote characters in values to prevent ldflags
 # injection — Go's -ldflags parser splits on whitespace, so a value
 # containing a space would be parsed as an extra linker flag.
-for _v in VERSION_PKG VERSION COMMIT BUILD_DATE; do
+for _v in VERSION_PKG VERSION COMMIT COMMIT_DATE; do
   if [[ "${!_v}" =~ [[:space:]\"\'] ]]; then
     echo "Error: $_v contains invalid characters (whitespace or quotes): ${!_v}" >&2
     exit 1
@@ -28,4 +28,4 @@ done
 unset _v
 
 # shellcheck disable=SC2034 # consumed by sourcing script (go/build, go/run)
-VERSION_LDFLAGS="-X ${VERSION_PKG}.Version=${VERSION} -X ${VERSION_PKG}.CommitSHA=${COMMIT} -X ${VERSION_PKG}.CommitDate=${BUILD_DATE}"
+VERSION_LDFLAGS="-X ${VERSION_PKG}.Version=${VERSION} -X ${VERSION_PKG}.CommitSHA=${COMMIT} -X ${VERSION_PKG}.CommitDate=${COMMIT_DATE}"

--- a/.mise/tasks/lib/go-version
+++ b/.mise/tasks/lib/go-version
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Sourced helper. Provides Go version info for ldflags injection.
+# Vars (override via env if needed):
+#   VERSION       from git describe --tags --always --dirty   default: dev
+#   COMMIT        short commit SHA                            default: unknown
+#   BUILD_DATE    ISO8601 UTC timestamp                       default: <now>
+#   VERSION_PKG   package holding version vars                default: main
+#
+# Exports:
+#   VERSION_LDFLAGS  ready-to-append ldflags string injecting
+#                    ${VERSION_PKG}.version, .commit, .buildDate
+
+: "${VERSION_PKG:=main}"
+: "${VERSION:=$(git describe --tags --always --dirty 2>/dev/null || echo dev)}"
+: "${COMMIT:=$(git rev-parse --short HEAD 2>/dev/null || echo unknown)}"
+: "${BUILD_DATE:=$(date -u +%Y-%m-%dT%H:%M:%SZ)}"
+
+# shellcheck disable=SC2034 # consumed by sourcing script (go/build, go/run)
+VERSION_LDFLAGS="-X ${VERSION_PKG}.version=${VERSION} -X ${VERSION_PKG}.commit=${COMMIT} -X ${VERSION_PKG}.buildDate=${BUILD_DATE}"


### PR DESCRIPTION
## Summary
- Add `lib/go-version` helper that emits `-ldflags` for injecting version metadata
- Wire the helper into `go:build` and `go:run` so binaries embed version info by default

## Injected symbols
The helper exports `VERSION_LDFLAGS` which sets these Go linker `-X` values (names mirror the `go-release.yml` workflow so the same `main` variables work across both build paths):

- `${VERSION_PKG}.Version`   — `git describe --tags --always --dirty`, or `dev`
- `${VERSION_PKG}.CommitSHA` — full HEAD SHA, or `unknown`
- `${VERSION_PKG}.CommitDate` — ISO8601 commit timestamp from `git log -1 --format=%cI`

`VERSION_PKG` defaults to `main`; override via env if your version vars live elsewhere. `VERSION`, `COMMIT`, `COMMIT_DATE` can also be overridden, but values containing whitespace or quote characters are rejected to prevent ldflags injection.

Consumer programs must declare matching `main.Version`, `main.CommitSHA`, `main.CommitDate` (or pkg-prefixed equivalents) for the values to land — Go silently ignores `-X` for unknown symbols.

## Test plan
- [ ] `mise run go:build` produces a binary with version metadata populated
- [ ] `mise run go:run` injects version metadata at runtime
- [ ] Existing consumers continue to work without additional configuration