### PR TITLE
feat(mise): rename ldflags fields and auto-detect VERSION_PKG

### DIFF
--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -235,7 +235,7 @@ jobs:
           if [[ -n "$LDFLAGS_INPUT" ]]; then
             LDFLAGS="$LDFLAGS_INPUT"
           else
-            LDFLAGS="-s -w -X main.Version=v${VERSION} -X main.CommitSHA=$(git rev-parse HEAD) -X main.CommitDate=$(git log -1 --format=%cI)"
+            LDFLAGS="-s -w -X main.Version=v${VERSION} -X main.Commit=$(git rev-parse HEAD) -X main.BuildDate=$(git log -1 --format=%cI)"
           fi
 
           mkdir -p output

--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -235,7 +235,16 @@ jobs:
           if [[ -n "$LDFLAGS_INPUT" ]]; then
             LDFLAGS="$LDFLAGS_INPUT"
           else
-            LDFLAGS="-s -w -X main.Version=v${VERSION} -X main.Commit=$(git rev-parse HEAD) -X main.BuildDate=$(git log -1 --format=%cI)"
+            # Inject version vars into the same package the mise go:build/go:run
+            # tasks target (.mise/tasks/lib/go-version): <module>/internal/version
+            # when that dir exists, else main. Keep this detection in sync with
+            # that helper so local and release builds populate the same symbols.
+            VERSION_PKG="main"
+            MODULE=$(awk '/^module / {print $2; exit}' go.mod 2>/dev/null || echo "")
+            if [[ -n "$MODULE" && -d "internal/version" ]]; then
+              VERSION_PKG="${MODULE}/internal/version"
+            fi
+            LDFLAGS="-s -w -X ${VERSION_PKG}.Version=v${VERSION} -X ${VERSION_PKG}.Commit=$(git rev-parse HEAD) -X ${VERSION_PKG}.BuildDate=$(git log -1 --format=%cI)"
           fi
 
           mkdir -p output

--- a/.mise/tasks/go/build
+++ b/.mise/tasks/go/build
@@ -15,7 +15,10 @@ build_one() {
   # and avoid passing an empty "" argument when unset.
   # Using read -ra instead of bare expansion so shellharden won't re-quote it.
   IFS=' ' read -ra extra_flags <<< "${EXTRA_BUILD_FLAGS:-}"
-  go build -o "bin/$1" "${extra_flags[@]}" -ldflags "${LDFLAGS} ${VERSION_LDFLAGS}" "./cmd/$1"
+  # LDFLAGS is an optional caller override (unset for plain local builds); only
+  # prepend it (with a separating space) when non-empty so the ldflags string
+  # doesn't carry a stray leading space.
+  go build -o "bin/$1" "${extra_flags[@]}" -ldflags "${LDFLAGS:+$LDFLAGS }${VERSION_LDFLAGS}" "./cmd/$1"
 }
 
 if [ "$usage_name" = "" ]; then

--- a/.mise/tasks/go/run
+++ b/.mise/tasks/go/run
@@ -23,4 +23,7 @@ if [ ! -f "cmd/$usage_name/main.go" ]; then
   echo "Error: cmd/$usage_name/main.go not found"
   exit 1
 fi
-go run -mod=vendor -ldflags "${VERSION_LDFLAGS}" "./cmd/$usage_name" "$usage_args"
+# usage_args is a shell-escaped string for a variadic arg; eval into an array
+# so multiple args split correctly and zero args pass nothing (not an empty "").
+eval "args=(${usage_args:-})"
+go run -mod=vendor -ldflags "${VERSION_LDFLAGS}" "./cmd/$usage_name" "${args[@]}"

--- a/.mise/tasks/go/run
+++ b/.mise/tasks/go/run
@@ -25,5 +25,10 @@ if [ ! -f "cmd/$usage_name/main.go" ]; then
 fi
 # usage_args is a shell-escaped string for a variadic arg; eval into an array
 # so multiple args split correctly and zero args pass nothing (not an empty "").
-eval "args=(${usage_args:-})"
+# Abort on eval failure: a malformed usage_args would otherwise leave args
+# stale/unset and silently run go with the wrong arguments.
+if ! eval "args=(${usage_args:-})"; then
+  echo "Error: failed to parse arguments: ${usage_args:-}" >&2
+  exit 1
+fi
 go run -mod=vendor -ldflags "${VERSION_LDFLAGS}" "./cmd/$usage_name" "${args[@]}"

--- a/.mise/tasks/lib/go-version
+++ b/.mise/tasks/lib/go-version
@@ -1,16 +1,29 @@
 #!/usr/bin/env bash
 # Sourced helper. Provides Go version info for ldflags injection.
 # Vars (override via env if needed):
-#   VERSION       from git describe --tags --always --dirty   default: dev
-#   COMMIT        full commit SHA                              default: unknown
-#   BUILD_DATE    ISO8601 commit timestamp from git log        default: <now>
-#   VERSION_PKG   package holding version vars                 default: main
+#   VERSION      from git describe --tags --always --dirty       default: dev
+#   COMMIT       full commit SHA                                  default: unknown
+#   BUILD_DATE   ISO8601 commit timestamp (fallback: date -u)     default: <now>
+#   VERSION_PKG  package holding version vars                     default: see below
+#
+# VERSION_PKG auto-detection (when unset):
+#   - <module>/internal/version  if  internal/version/  exists
+#   - main                       otherwise
 #
 # Exports:
 #   VERSION_LDFLAGS  -ldflags string injecting
 #                    ${VERSION_PKG}.Version, .Commit, .BuildDate
 
-: "${VERSION_PKG:=main}"
+if [ -z "${VERSION_PKG:-}" ]; then
+  _module=$(awk '/^module / {print $2; exit}' go.mod 2>/dev/null || echo "")
+  if [ -n "$_module" ] && [ -d "internal/version" ]; then
+    VERSION_PKG="${_module}/internal/version"
+  else
+    VERSION_PKG="main"
+  fi
+  unset _module
+fi
+
 : "${VERSION:=$(git describe --tags --always --dirty 2>/dev/null || echo dev)}"
 : "${COMMIT:=$(git rev-parse HEAD 2>/dev/null || echo unknown)}"
 : "${BUILD_DATE:=$(git log -1 --format=%cI 2>/dev/null || date -u +%Y-%m-%dT%H:%M:%SZ)}"

--- a/.mise/tasks/lib/go-version
+++ b/.mise/tasks/lib/go-version
@@ -27,7 +27,7 @@ fi
 # Detect renamed env var (COMMIT_DATE → BUILD_DATE) to fail loud instead of
 # silently ignoring stale CI / mise configs that still set the old name.
 if [ -n "${COMMIT_DATE:-}" ]; then
-  echo "Error: COMMIT_DATE was renamed to BUILD_DATE (meta PR #93). Update your env." >&2
+  echo "Error: COMMIT_DATE was renamed to BUILD_DATE; set BUILD_DATE (or unset COMMIT_DATE)." >&2
   exit 1
 fi
 

--- a/.mise/tasks/lib/go-version
+++ b/.mise/tasks/lib/go-version
@@ -26,7 +26,9 @@ fi
 
 # Detect renamed env var (COMMIT_DATE → BUILD_DATE) to fail loud instead of
 # silently ignoring stale CI / mise configs that still set the old name.
-if [ -n "${COMMIT_DATE:-}" ]; then
+# Use ${VAR+x} (not ${VAR:-}) so an explicitly-set-but-empty COMMIT_DATE
+# still trips the guard — being set at all signals a stale config.
+if [ -n "${COMMIT_DATE+x}" ]; then
   echo "Error: COMMIT_DATE was renamed to BUILD_DATE; set BUILD_DATE (or unset COMMIT_DATE)." >&2
   exit 1
 fi

--- a/.mise/tasks/lib/go-version
+++ b/.mise/tasks/lib/go-version
@@ -3,25 +3,24 @@
 # Vars (override via env if needed):
 #   VERSION       from git describe --tags --always --dirty   default: dev
 #   COMMIT        full commit SHA                              default: unknown
-#   COMMIT_DATE   ISO8601 commit timestamp from git log        default: <now>
+#   BUILD_DATE    ISO8601 commit timestamp from git log        default: <now>
 #   VERSION_PKG   package holding version vars                 default: main
 #
 # Exports:
 #   VERSION_LDFLAGS  -ldflags string injecting
-#                    ${VERSION_PKG}.Version, .CommitSHA, .CommitDate
-#                    (matches the go-release workflow naming convention)
+#                    ${VERSION_PKG}.Version, .Commit, .BuildDate
 
 : "${VERSION_PKG:=main}"
 : "${VERSION:=$(git describe --tags --always --dirty 2>/dev/null || echo dev)}"
 : "${COMMIT:=$(git rev-parse HEAD 2>/dev/null || echo unknown)}"
-: "${COMMIT_DATE:=$(git log -1 --format=%cI 2>/dev/null || date -u +%Y-%m-%dT%H:%M:%SZ)}"
+: "${BUILD_DATE:=$(git log -1 --format=%cI 2>/dev/null || date -u +%Y-%m-%dT%H:%M:%SZ)}"
 
 # Reject whitespace and quote characters in values to prevent ldflags
 # injection — Go's -ldflags parser splits on whitespace, so a value
 # containing a space would be parsed as an extra linker flag.
 # Don't echo the offending value: env vars may carry sensitive data
 # and the error lands in CI logs.
-for _v in VERSION_PKG VERSION COMMIT COMMIT_DATE; do
+for _v in VERSION_PKG VERSION COMMIT BUILD_DATE; do
   if [[ "${!_v}" =~ [[:space:]\"\'] ]]; then
     echo "Error: $_v contains invalid characters (whitespace or quotes)" >&2
     exit 1
@@ -30,4 +29,4 @@ done
 unset _v
 
 # shellcheck disable=SC2034 # consumed by sourcing script (go/build, go/run)
-VERSION_LDFLAGS="-X ${VERSION_PKG}.Version=${VERSION} -X ${VERSION_PKG}.CommitSHA=${COMMIT} -X ${VERSION_PKG}.CommitDate=${COMMIT_DATE}"
+VERSION_LDFLAGS="-X ${VERSION_PKG}.Version=${VERSION} -X ${VERSION_PKG}.Commit=${COMMIT} -X ${VERSION_PKG}.BuildDate=${BUILD_DATE}"

--- a/.mise/tasks/lib/go-version
+++ b/.mise/tasks/lib/go-version
@@ -24,6 +24,13 @@ if [ -z "${VERSION_PKG:-}" ]; then
   unset _module
 fi
 
+# Detect renamed env var (COMMIT_DATE → BUILD_DATE) to fail loud instead of
+# silently ignoring stale CI / mise configs that still set the old name.
+if [ -n "${COMMIT_DATE:-}" ]; then
+  echo "Error: COMMIT_DATE was renamed to BUILD_DATE (meta PR #93). Update your env." >&2
+  exit 1
+fi
+
 : "${VERSION:=$(git describe --tags --always --dirty 2>/dev/null || echo dev)}"
 : "${COMMIT:=$(git rev-parse HEAD 2>/dev/null || echo unknown)}"
 : "${BUILD_DATE:=$(git log -1 --format=%cI 2>/dev/null || date -u +%Y-%m-%dT%H:%M:%SZ)}"


### PR DESCRIPTION
## Summary

Two follow-ups to PR #91:

1. **Rename injected fields** to `Version` / `Commit` / `BuildDate` (was `Version` / `CommitSHA` / `CommitDate`).
   - Matches the naming downstream Go consumers prefer (idiomatic Go convention; `runtime/debug.BuildInfo.Settings` uses `vcs.revision` so `Commit` reads naturally).
   - Env var also renamed: `COMMIT_DATE` → `BUILD_DATE`.

2. **Auto-detect `VERSION_PKG`** from `go.mod` + `internal/version/` (mirrors the `_module` / `GO_COVERPKG` auto-detection pattern in `lib/go-env`).
   - If `internal/version/` exists → `VERSION_PKG="<module>/internal/version"`.
   - Otherwise → `VERSION_PKG="main"` (the original default).
   - Consumers following the convention get zero-config injection; non-conventional repos can still override via env.

## Downstream consumers

- libdcf [nics-dp/libdcf#150](https://github.com/nics-dp/libdcf/pull/150) — adds the `version` package whose `Info` struct uses these field names.
- dcf-access [nics-dp/dcf-access#123](https://github.com/nics-dp/dcf-access/pull/123) — adds `internal/version` with `var Version, Commit, BuildDate`; relies on this PR's auto-detection so no `VERSION_PKG` is set in its `mise.toml`.

## Compatibility

- `bash 3.2` (macOS default) and `bash 4+/5+` (Linux) both verified.
- Only POSIX `awk` / `date` / `git` flags used.

## Test plan

- [ ] `mise run build` in a repo with `internal/version/` correctly injects the three fields
- [ ] `mise run build` in a repo without `internal/version/` falls back to `VERSION_PKG=main` (no regression vs. PR #91 behaviour when `main` had the vars)

Closes #101