### PR TITLE
fix(image-release): harden external checkout against untrusted inputs

### DIFF
--- a/.github/workflows/image-release.yml
+++ b/.github/workflows/image-release.yml
@@ -169,14 +169,26 @@ jobs:
           DOCKERFILE_PATH: ${{ inputs.dockerfile_path }}
           EXTERNAL_REF: ${{ inputs.external_ref }}
         run: |
+          # Escape a value before interpolating it into a ::error::/::warning::
+          # workflow command, matching the GitHub Actions toolkit escapeData
+          # (% -> %25, CR -> %0D, LF -> %0A; % first to avoid double-escaping).
+          # Without this, a caller value containing newlines/CR/% could inject
+          # additional workflow commands or truncate the message.
+          esc() {
+            local s=$1
+            s=${s//'%'/'%25'}
+            s=${s//$'\r'/'%0D'}
+            s=${s//$'\n'/'%0A'}
+            printf '%s' "$s"
+          }
           # dockerfile_path / external_ref only take effect alongside
           # external_repo; surface a warning so callers don't assume they were
           # silently honored.
           if [[ -n "$DOCKERFILE_PATH" ]]; then
-            echo "::warning::dockerfile_path ('$DOCKERFILE_PATH') was set without external_repo and will be ignored"
+            echo "::warning::dockerfile_path ('$(esc "$DOCKERFILE_PATH")') was set without external_repo and will be ignored"
           fi
           if [[ -n "$EXTERNAL_REF" ]]; then
-            echo "::warning::external_ref ('$EXTERNAL_REF') was set without external_repo and will be ignored"
+            echo "::warning::external_ref ('$(esc "$EXTERNAL_REF")') was set without external_repo and will be ignored"
           fi
 
       - name: Validate external_repo inputs
@@ -191,6 +203,19 @@ jobs:
           GO_VENDOR: ${{ inputs.go_vendor }}
         run: |
           fail=0
+          # Escape a value before interpolating it into a ::error::/::warning::
+          # workflow command, matching the GitHub Actions toolkit escapeData
+          # (% -> %25, CR -> %0D, LF -> %0A; % first to avoid double-escaping).
+          # All caller-supplied values below are echoed through esc() so a
+          # malformed/hostile value (newlines, CR, %) cannot inject additional
+          # workflow commands or truncate the message.
+          esc() {
+            local s=$1
+            s=${s//'%'/'%25'}
+            s=${s//$'\r'/'%0D'}
+            s=${s//$'\n'/'%0A'}
+            printf '%s' "$s"
+          }
           # Strip a single optional leading "./" for path comparison so
           # equivalent forms ("./external-src" and "external-src") validate
           # the same way. Error messages echo the caller's original value to
@@ -221,7 +246,7 @@ jobs:
           # guard against malformed/injected values; the allowlist below is the
           # actual trust boundary.
           if [[ ! "$EXTERNAL_REPO" =~ ^[A-Za-z0-9._-]+/[A-Za-z0-9._-]+$ ]]; then
-            echo "::error::external_repo must be a bare 'owner/repo' slug, got '$EXTERNAL_REPO'"
+            echo "::error::external_repo must be a bare 'owner/repo' slug, got '$(esc "$EXTERNAL_REPO")'"
             fail=1
           fi
 
@@ -229,7 +254,7 @@ jobs:
           # (Non-emptiness is enforced above; skip the charset check when empty
           # so the more specific "required" error is the one that surfaces.)
           if [[ -n "$EXTERNAL_REF" && ! "$EXTERNAL_REF" =~ ^[A-Za-z0-9._/-]+$ ]]; then
-            echo "::error::external_ref must contain only [A-Za-z0-9._/-], got '$EXTERNAL_REF'"
+            echo "::error::external_ref must contain only [A-Za-z0-9._/-], got '$(esc "$EXTERNAL_REF")'"
             fail=1
           fi
 
@@ -254,7 +279,7 @@ jobs:
               # entries with spaces or shell metacharacters) that would silently
               # match more than intended.
               if [[ ! "$entry" =~ ^[A-Za-z0-9._-]+/([A-Za-z0-9._-]+|\*)$ ]]; then
-                echo "::error::external_repo_allowlist entry '$entry' must be 'owner/repo' or 'owner/*'"
+                echo "::error::external_repo_allowlist entry '$(esc "$entry")' must be 'owner/repo' or 'owner/*'"
                 fail=1
                 continue
               fi
@@ -264,53 +289,53 @@ jobs:
               esac
             done <<< "$EXTERNAL_REPO_ALLOWLIST"
             if [[ "$allow_match" -ne 1 ]]; then
-              echo "::error::external_repo '$EXTERNAL_REPO' is not permitted by external_repo_allowlist"
+              echo "::error::external_repo '$(esc "$EXTERNAL_REPO")' is not permitted by external_repo_allowlist"
               fail=1
             fi
           else
-            echo "::warning::external_repo_allowlist is empty; external_repo ('$EXTERNAL_REPO') is unconstrained. Provide an allowlist and ensure callers never pass PR-event data to external_repo/external_ref."
+            echo "::warning::external_repo_allowlist is empty; external_repo ('$(esc "$EXTERNAL_REPO")') is unconstrained. Provide an allowlist and ensure callers never pass PR-event data to external_repo/external_ref."
           fi
 
           if [[ -z "$NORM_DOCKERFILE_PATH" ]]; then
             echo "::error::dockerfile_path is required when external_repo is set"
             fail=1
           elif [[ "$NORM_DOCKERFILE_PATH" == /* ]]; then
-            echo "::error::dockerfile_path must be relative to the caller repository workspace, got '$DOCKERFILE_PATH'"
+            echo "::error::dockerfile_path must be relative to the caller repository workspace, got '$(esc "$DOCKERFILE_PATH")'"
             fail=1
           elif has_dotdot "$NORM_DOCKERFILE_PATH"; then
-            echo "::error::dockerfile_path must not contain a '..' path component, got '$DOCKERFILE_PATH'"
+            echo "::error::dockerfile_path must not contain a '..' path component, got '$(esc "$DOCKERFILE_PATH")'"
             fail=1
           elif [[ "$NORM_DOCKERFILE_PATH" == *[*?\[]* ]]; then
-            echo "::error::dockerfile_path must not contain glob metacharacters (*, ?, [), got '$DOCKERFILE_PATH'"
+            echo "::error::dockerfile_path must not contain glob metacharacters (*, ?, [), got '$(esc "$DOCKERFILE_PATH")'"
             fail=1
           elif [[ -L "$NORM_DOCKERFILE_PATH" ]]; then
-            echo "::error::dockerfile_path '$DOCKERFILE_PATH' must be a regular file, not a symlink"
+            echo "::error::dockerfile_path '$(esc "$DOCKERFILE_PATH")' must be a regular file, not a symlink"
             fail=1
           elif [[ ! -f "$NORM_DOCKERFILE_PATH" ]]; then
-            echo "::error::dockerfile_path '$DOCKERFILE_PATH' not found in the caller repository workspace"
+            echo "::error::dockerfile_path '$(esc "$DOCKERFILE_PATH")' not found in the caller repository workspace"
             fail=1
           fi
 
           if [[ -z "$NORM_EXTERNAL_PATH" || "$NORM_EXTERNAL_PATH" == "." ]]; then
-            echo "::error::external_path must resolve to a directory under the workspace (not '.' / './' / empty), got '$EXTERNAL_PATH'"
+            echo "::error::external_path must resolve to a directory under the workspace (not '.' / './' / empty), got '$(esc "$EXTERNAL_PATH")'"
             fail=1
           elif [[ "$NORM_EXTERNAL_PATH" == /* ]]; then
-            echo "::error::external_path must be relative, got '$EXTERNAL_PATH'"
+            echo "::error::external_path must be relative, got '$(esc "$EXTERNAL_PATH")'"
             fail=1
           elif has_dotdot "$NORM_EXTERNAL_PATH"; then
-            echo "::error::external_path must not contain a '..' path component, got '$EXTERNAL_PATH'"
+            echo "::error::external_path must not contain a '..' path component, got '$(esc "$EXTERNAL_PATH")'"
             fail=1
           elif [[ "$NORM_EXTERNAL_PATH" == */ ]]; then
-            echo "::error::external_path must not end with '/', got '$EXTERNAL_PATH'"
+            echo "::error::external_path must not end with '/', got '$(esc "$EXTERNAL_PATH")'"
             fail=1
           elif [[ "$NORM_EXTERNAL_PATH" == *[*?\[]* ]]; then
-            echo "::error::external_path must not contain glob metacharacters (*, ?, [), got '$EXTERNAL_PATH'"
+            echo "::error::external_path must not contain glob metacharacters (*, ?, [), got '$(esc "$EXTERNAL_PATH")'"
             fail=1
           else
             case "$NORM_CONTEXT" in
               "$NORM_EXTERNAL_PATH"|"$NORM_EXTERNAL_PATH"/*) ;;
               *)
-                echo "::error::context must be '$EXTERNAL_PATH' or a subpath when external_repo is set, got '$CONTEXT'"
+                echo "::error::context must be '$(esc "$EXTERNAL_PATH")' or a subpath when external_repo is set, got '$(esc "$CONTEXT")'"
                 fail=1
                 ;;
             esac
@@ -320,11 +345,11 @@ jobs:
           # branches above so the more specific error still fires when
           # external_path itself fails validation.
           if has_dotdot "$NORM_CONTEXT"; then
-            echo "::error::context must not contain a '..' path component, got '$CONTEXT'"
+            echo "::error::context must not contain a '..' path component, got '$(esc "$CONTEXT")'"
             fail=1
           fi
           if [[ "$NORM_CONTEXT" == *[*?\[]* ]]; then
-            echo "::error::context must not contain glob metacharacters (*, ?, [), got '$CONTEXT'"
+            echo "::error::context must not contain glob metacharacters (*, ?, [), got '$(esc "$CONTEXT")'"
             fail=1
           fi
 
@@ -338,7 +363,7 @@ jobs:
           if [[ -n "$NORM_DOCKERFILE_PATH" && -n "$NORM_EXTERNAL_PATH" && "$NORM_EXTERNAL_PATH" != "." ]]; then
             case "$NORM_DOCKERFILE_PATH" in
               "$NORM_EXTERNAL_PATH"|"$NORM_EXTERNAL_PATH"/*)
-                echo "::error::dockerfile_path ('$DOCKERFILE_PATH') must not be inside external_path ('$EXTERNAL_PATH'); the external checkout would overwrite it before the overlay copy"
+                echo "::error::dockerfile_path ('$(esc "$DOCKERFILE_PATH")') must not be inside external_path ('$(esc "$EXTERNAL_PATH")'); the external checkout would overwrite it before the overlay copy"
                 fail=1
                 ;;
             esac

--- a/.github/workflows/image-release.yml
+++ b/.github/workflows/image-release.yml
@@ -94,6 +94,18 @@ on:
         type: string
         default: ""
         description: "Path (relative to the caller repository workspace) of the Dockerfile to copy into external_path/Dockerfile, overriding any Dockerfile the external repo ships with. Must be a regular file (symlinks are rejected). Required when external_repo is set; otherwise ignored."
+      external_repo_allowlist:
+        required: false
+        type: string
+        default: ""
+        description: >
+          Newline-separated allowlist of permitted external_repo values, each an
+          exact 'owner/repo' or an 'owner/*' glob. When non-empty, external_repo
+          must match an entry or the build fails. SECURITY: callers MUST pass only
+          static, maintainer-pinned literals to external_repo / external_ref and
+          MUST NOT wire in PR-event data (e.g. github.event.pull_request.head.*).
+          This allowlist is a defense-in-depth backstop for that caller contract,
+          not a replacement for it. Ignored when external_repo is empty.
     outputs:
       digest:
         description: "Image digest (sha256:...)"
@@ -168,6 +180,8 @@ jobs:
           DOCKERFILE_PATH: ${{ inputs.dockerfile_path }}
           EXTERNAL_PATH: ${{ inputs.external_path }}
           EXTERNAL_REF: ${{ inputs.external_ref }}
+          EXTERNAL_REPO: ${{ inputs.external_repo }}
+          EXTERNAL_REPO_ALLOWLIST: ${{ inputs.external_repo_allowlist }}
           CONTEXT: ${{ inputs.context }}
           GO_VENDOR: ${{ inputs.go_vendor }}
         run: |
@@ -195,6 +209,50 @@ jobs:
           if [[ -z "$EXTERNAL_REF" ]]; then
             echo "::error::external_ref is required when external_repo is set (empty ref would default to upstream's default branch, breaking reproducibility)"
             fail=1
+          fi
+
+          # external_repo must be a bare "owner/repo" slug: no whitespace, no
+          # shell metacharacters, no URL, no extra path segments. Structural
+          # guard against malformed/injected values; the allowlist below is the
+          # actual trust boundary.
+          if [[ ! "$EXTERNAL_REPO" =~ ^[A-Za-z0-9._-]+/[A-Za-z0-9._-]+$ ]]; then
+            echo "::error::external_repo must be a bare 'owner/repo' slug, got '$EXTERNAL_REPO'"
+            fail=1
+          fi
+
+          # external_ref must look like a git ref/sha: only [A-Za-z0-9._/-].
+          # (Non-emptiness is enforced above; skip the charset check when empty
+          # so the more specific "required" error is the one that surfaces.)
+          if [[ -n "$EXTERNAL_REF" && ! "$EXTERNAL_REF" =~ ^[A-Za-z0-9._/-]+$ ]]; then
+            echo "::error::external_ref must contain only [A-Za-z0-9._/-], got '$EXTERNAL_REF'"
+            fail=1
+          fi
+
+          # Defense-in-depth: when an allowlist is provided, external_repo must
+          # match one of its entries (exact 'owner/repo' or 'owner/*' glob). A
+          # trusted caller declares this allowlist as a literal, so PR-event data
+          # cannot satisfy it even if a privileged caller wired it into
+          # external_repo. When the allowlist is empty, external_repo is
+          # unconstrained and we only warn (back-compat for existing callers).
+          if [[ -n "$EXTERNAL_REPO_ALLOWLIST" ]]; then
+            allow_match=0
+            while IFS= read -r entry || [[ -n "$entry" ]]; do
+              entry="${entry%$'\r'}"
+              # trim surrounding whitespace
+              entry="${entry#"${entry%%[![:space:]]*}"}"
+              entry="${entry%"${entry##*[![:space:]]}"}"
+              [[ -z "$entry" || "$entry" == \#* ]] && continue
+              # shellcheck disable=SC2254 # intentional glob match against trusted allowlist entry
+              case "$EXTERNAL_REPO" in
+                $entry) allow_match=1; break ;;
+              esac
+            done <<< "$EXTERNAL_REPO_ALLOWLIST"
+            if [[ "$allow_match" -ne 1 ]]; then
+              echo "::error::external_repo '$EXTERNAL_REPO' is not permitted by external_repo_allowlist"
+              fail=1
+            fi
+          else
+            echo "::warning::external_repo_allowlist is empty; external_repo ('$EXTERNAL_REPO') is unconstrained. Provide an allowlist and ensure callers never pass PR-event data to external_repo/external_ref."
           fi
 
           if [[ -z "$NORM_DOCKERFILE_PATH" ]]; then
@@ -276,6 +334,15 @@ jobs:
           fi
           [[ "$fail" -eq 0 ]] || exit 1
 
+      # SECURITY (CodeQL actions/untrusted-checkout): this step checks out an
+      # external repo whose code is then executed by `docker build`, inside a
+      # job that holds registry secrets and write scopes. That is safe ONLY
+      # because external_repo/external_ref are maintainer-pinned inputs,
+      # validated above (bare 'owner/repo' slug, sane ref charset, optional
+      # allowlist), and callers are contractually required never to wire
+      # PR-event data into them. Do NOT call this reusable workflow from a
+      # pull_request_target / workflow_run caller that forwards
+      # github.event.pull_request.head.* into external_repo or external_ref.
       - name: Checkout external repo
         if: inputs.external_repo != ''
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/image-release.yml
+++ b/.github/workflows/image-release.yml
@@ -247,7 +247,18 @@ jobs:
               entry="${entry#"${entry%%[![:space:]]*}"}"
               entry="${entry%"${entry##*[![:space:]]}"}"
               [[ -z "$entry" || "$entry" == \#* ]] && continue
-              # shellcheck disable=SC2254 # intentional glob match against trusted allowlist entry
+              # Constrain each entry to the two documented forms before using it
+              # as a glob: an exact 'owner/repo' or an 'owner/*' wildcard. This
+              # keeps behaviour aligned with the input docs and rejects broader
+              # or malformed globs (e.g. '*/*', 'owner/re?o', 'owner/[ab]',
+              # entries with spaces or shell metacharacters) that would silently
+              # match more than intended.
+              if [[ ! "$entry" =~ ^[A-Za-z0-9._-]+/([A-Za-z0-9._-]+|\*)$ ]]; then
+                echo "::error::external_repo_allowlist entry '$entry' must be 'owner/repo' or 'owner/*'"
+                fail=1
+                continue
+              fi
+              # shellcheck disable=SC2254 # intentional glob match against validated allowlist entry
               case "$EXTERNAL_REPO" in
                 $entry) allow_match=1; break ;;
               esac

--- a/.github/workflows/image-release.yml
+++ b/.github/workflows/image-release.yml
@@ -157,6 +157,11 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ inputs.ref }}
+          # No authenticated git is run against this checkout afterwards, and in
+          # non-external mode the workspace root is the docker build context.
+          # Opt out of credential persistence (least privilege) so no token
+          # material lingers in or near the build context.
+          persist-credentials: false
 
       - name: Warn on orphan external_repo inputs
         if: inputs.external_repo == '' && (inputs.dockerfile_path != '' || inputs.external_ref != '')
@@ -351,6 +356,13 @@ jobs:
           ref: ${{ inputs.external_ref }}
           path: ${{ inputs.external_path }}
           token: ${{ secrets.gh_pat || github.token }}
+          # This checkout IS the docker build context. The token is still used
+          # for the initial fetch, but must not be persisted afterwards: never
+          # run authenticated git here, and keep credential material out of the
+          # build context. (checkout v6 stores creds under RUNNER_TEMP rather
+          # than .git/config, but opting out is the explicit least-privilege
+          # guarantee and is robust against version/behaviour changes.)
+          persist-credentials: false
 
       - name: Overlay Dockerfile onto external source
         if: inputs.external_repo != ''


### PR DESCRIPTION
## What

Hardens the `external_repo` checkout path in `image-release.yml` against untrusted inputs, addressing **CodeQL code-scanning alert [#145](https://github.com/nics-dp/meta/security/code-scanning/145)** (`actions/untrusted-checkout/medium`).

The flagged step checks out an external repo whose code is then executed by `docker build`, inside a job holding registry secrets + `packages:write` / `attestations:write` / `id-token:write`. Safe only if `external_repo`/`external_ref` are maintainer-pinned — never PR-event data.

## Changes (all backward-compatible)

- **`external_repo` slug guard** — must be a bare `owner/repo` (blocks URLs, extra path segments, whitespace, shell metacharacters).
- **`external_ref` charset guard** — must match `[A-Za-z0-9._/-]` (blocks `$()`, spaces, etc.).
- **New optional input `external_repo_allowlist`** — when set, `external_repo` must match an entry (exact `owner/repo` or `owner/*` glob). Empty default → **warn-only**, so existing callers are unaffected.
- **Caller trust contract documented** in the input description + a `SECURITY` comment above the checkout step.

## Why an allowlist (defense-in-depth)

A trusted caller declares the allowlist as a **literal**, so PR-event data cannot satisfy it even if a privileged caller (`pull_request_target` / `workflow_run`) forwarded it into `external_repo`.

## Impact on callers

`patroni/release.yml` (only `external_repo` caller) passes `patroni/patroni` + `v4.1.3` + `Dockerfile` — all pass the new guards. It does not set `external_repo_allowlist`, so it sees a single new `::warning::` (cosmetic, build proceeds). A follow-up patroni PR adds the allowlist.

## Verification

- `actionlint` clean
- `bash -n` on the validate script clean
- allowlist / slug / ref guards exercised with pass + reject cases (patroni accepted; attacker fork + injected slug/ref rejected; empty allowlist warn-only)

## Note on the CodeQL alert

CodeQL does not reason about runtime allowlists/regex, so alert #145 will likely remain open after merge and needs a manual dismissal referencing this hardening + the documented caller contract.

Closes #100