### PR TITLE
fix(ci): install uv for semgrep task to bypass pipx pip failure

### DIFF
--- a/.mise/tasks/ci/semgrep
+++ b/.mise/tasks/ci/semgrep
@@ -2,7 +2,7 @@
 #MISE description="Run semgrep static analysis (p/ci baseline + lang packs)"
 #MISE hide=true
 #MISE raw=true
-#MISE tools={"pipx:semgrep"="latest"}
+#MISE tools={"pipx:semgrep"="latest","uv"="latest"}
 #USAGE arg "[packs]" var=#true var_min=0 help="Language packs (golang, python, typescript, javascript, ...). Stacked on top of p/ci baseline."
 #USAGE flag "--audit" help="Add p/default + p/security-audit + p/owasp-top-ten (deep scan, more FPs; nightly/manual use)"
 #USAGE flag "--rules <path>" help="Custom rules file (e.g., .semgrep/rules.yml). Stacked on top of packs." default=""


### PR DESCRIPTION
## 問題

所有 nics-dp repo 的 Semgrep CI job 從 2026-06-11 起失敗，但不是 semgrep 掃出 finding，而是 semgrep 根本沒裝起來。

失敗鏈：

1. `mise-task.yml` 用 `jdx/mise-action@v4.1.0` 未鎖 mise 版本，CI 抓到 mise 2026.6.3（2026-06-11 釋出）
2. 該版預設啟用 `minimum_release_age` 供應鏈防護，安裝時對 pipx backend 的 pip 注入 `--uploaded-prior-to=<timestamp>`
3. 該 flag 需要 pip 版本不低於 26.0，但 pipx 共享環境的 bootstrap pip 較舊，回報 `no such option: --uploaded-prior-to`
4. `pipx:semgrep` 安裝失敗，task exit 1

log 片段：

```
no such option: --uploaded-prior-to
Failed to upgrade shared libraries
mise ERROR Failed to install pipx:semgrep@latest: pipx exited with non-zero status: exit code 1
```

## 修法

在 `ci/semgrep` task 宣告 `uv` 為工具。mise pipx backend 偵測到 uv 時會改走 uvx，由 uv 以原生 `--exclude-newer` 處理 release-age 限制，完全避開壞掉的舊 pip 路徑，且保留供應鏈防護。

semgrep 是 meta 唯一使用 pipx backend 的工具（其餘 py 系列 task 已直接用 uv/uvx），故單點修復即可。

## 影響範圍

所有透過 `ci:semgrep` 跑的 repo（dcf-platform-cli 等）。

Generated with [Claude Code](https://claude.com/claude-code)
