### PR TITLE
release: v0.2.4.1

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,8 @@
+* @nics-dp/DP
+compose.yml @nics-dp/DP @charliie-dev
+Dockerfile @nics-dp/DP @charliie-dev
+mise.toml @nics-dp/DP @charliie-dev
+.mise/tasks/ @nics-dp/DP @charliie-dev
+renovate.json @nics-dp/DP @charliie-dev
+trivy.yaml @nics-dp/DP @charliie-dev
+.github/ @nics-dp/DP @charliie-dev

--- a/.github/workflows/codeql-reusable.yml
+++ b/.github/workflows/codeql-reusable.yml
@@ -48,7 +48,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           submodules: ${{ inputs.submodules }}
           # Use PAT only when checking out submodules (likely private nics-dp repos);
@@ -56,7 +56,7 @@ jobs:
           token: ${{ inputs.submodules != 'false' && secrets.GH_PAT_READ_NICSDP || github.token }}
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
+        uses: github/codeql-action/init@87557b9c84dde89fdd9b10e88954ac2f4248e463 # v4.36.1
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
@@ -95,6 +95,6 @@ jobs:
           git config --global --remove-section "url.https://${GH_PAT}@github.com/nics-dp/" 2>/dev/null || true
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
+        uses: github/codeql-action/analyze@87557b9c84dde89fdd9b10e88954ac2f4248e463 # v4.36.1
         with:
           category: "/language:${{matrix.language}}"

--- a/.github/workflows/codeql-reusable.yml
+++ b/.github/workflows/codeql-reusable.yml
@@ -56,7 +56,7 @@ jobs:
           token: ${{ inputs.submodules != 'false' && secrets.GH_PAT_READ_NICSDP || github.token }}
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@87557b9c84dde89fdd9b10e88954ac2f4248e463 # v4.36.1
+        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
@@ -95,6 +95,6 @@ jobs:
           git config --global --remove-section "url.https://${GH_PAT}@github.com/nics-dp/" 2>/dev/null || true
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@87557b9c84dde89fdd9b10e88954ac2f4248e463 # v4.36.1
+        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
         with:
           category: "/language:${{matrix.language}}"

--- a/.github/workflows/codeql-reusable.yml
+++ b/.github/workflows/codeql-reusable.yml
@@ -56,7 +56,7 @@ jobs:
           token: ${{ inputs.submodules != 'false' && secrets.GH_PAT_READ_NICSDP || github.token }}
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4.35.5
+        uses: github/codeql-action/init@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
@@ -95,6 +95,6 @@ jobs:
           git config --global --remove-section "url.https://${GH_PAT}@github.com/nics-dp/" 2>/dev/null || true
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4.35.5
+        uses: github/codeql-action/analyze@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
         with:
           category: "/language:${{matrix.language}}"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -31,7 +31,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4.35.5
+        uses: github/codeql-action/init@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
         with:
           languages: actions
           build-mode: none
@@ -39,6 +39,6 @@ jobs:
           queries: security-extended,security-and-quality
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4.35.5
+        uses: github/codeql-action/analyze@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
         with:
           category: "/language:actions"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -28,10 +28,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
+        uses: github/codeql-action/init@87557b9c84dde89fdd9b10e88954ac2f4248e463 # v4.36.1
         with:
           languages: actions
           build-mode: none
@@ -39,6 +39,6 @@ jobs:
           queries: security-extended,security-and-quality
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
+        uses: github/codeql-action/analyze@87557b9c84dde89fdd9b10e88954ac2f4248e463 # v4.36.1
         with:
           category: "/language:actions"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -31,7 +31,7 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@87557b9c84dde89fdd9b10e88954ac2f4248e463 # v4.36.1
+        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
         with:
           languages: actions
           build-mode: none
@@ -39,6 +39,6 @@ jobs:
           queries: security-extended,security-and-quality
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@87557b9c84dde89fdd9b10e88954ac2f4248e463 # v4.36.1
+        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
         with:
           category: "/language:actions"

--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -101,7 +101,7 @@ jobs:
       version: ${{ steps.version.outputs.version }}
       version_tag: ${{ steps.version.outputs.version_tag }}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ inputs.ref }}
           fetch-depth: 0
@@ -165,7 +165,7 @@ jobs:
     env:
       HAS_GH_PAT: ${{ secrets.gh_pat != '' }}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ inputs.ref }}
 
@@ -332,7 +332,7 @@ jobs:
       contents: write
       id-token: write
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ inputs.ref }}
 

--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -235,7 +235,7 @@ jobs:
           if [[ -n "$LDFLAGS_INPUT" ]]; then
             LDFLAGS="$LDFLAGS_INPUT"
           else
-            LDFLAGS="-s -w -X main.Version=v${VERSION} -X main.CommitSHA=$(git rev-parse HEAD) -X main.CommitDate=$(git log -1 --format=%cI)"
+            LDFLAGS="-s -w -X main.Version=v${VERSION} -X main.Commit=$(git rev-parse HEAD) -X main.BuildDate=$(git log -1 --format=%cI)"
           fi
 
           mkdir -p output

--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -235,7 +235,16 @@ jobs:
           if [[ -n "$LDFLAGS_INPUT" ]]; then
             LDFLAGS="$LDFLAGS_INPUT"
           else
-            LDFLAGS="-s -w -X main.Version=v${VERSION} -X main.Commit=$(git rev-parse HEAD) -X main.BuildDate=$(git log -1 --format=%cI)"
+            # Inject version vars into the same package the mise go:build/go:run
+            # tasks target (.mise/tasks/lib/go-version): <module>/internal/version
+            # when that dir exists, else main. Keep this detection in sync with
+            # that helper so local and release builds populate the same symbols.
+            VERSION_PKG="main"
+            MODULE=$(awk '/^module / {print $2; exit}' go.mod 2>/dev/null || echo "")
+            if [[ -n "$MODULE" && -d "internal/version" ]]; then
+              VERSION_PKG="${MODULE}/internal/version"
+            fi
+            LDFLAGS="-s -w -X ${VERSION_PKG}.Version=v${VERSION} -X ${VERSION_PKG}.Commit=$(git rev-parse HEAD) -X ${VERSION_PKG}.BuildDate=$(git log -1 --format=%cI)"
           fi
 
           mkdir -p output

--- a/.github/workflows/image-release.yml
+++ b/.github/workflows/image-release.yml
@@ -128,14 +128,14 @@ jobs:
 
     steps:
       - name: Log in to DockerHub Container Registry
-        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ${{ env.REGISTRY_DH }}
           username: ${{ secrets.dockerhub_username }}
           password: ${{ secrets.dockerhub_token }}
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ${{ env.REGISTRY_GHCR }}
           username: ${{ github.actor }}
@@ -354,11 +354,11 @@ jobs:
         uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
 
       - name: Set up Buildx
-        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
       - name: Extract metadata (tags, labels)
         id: meta
-        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
         with:
           images: |
             ${{ env.REGISTRY_DH }}/${{ env.DH_NAMESPACE }}/${{ env.IMAGE_NAME }}
@@ -376,7 +376,7 @@ jobs:
 
       - name: Build and push
         id: build-and-push
-        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           context: ${{ inputs.context }}
           # In external_repo mode the overlaid Dockerfile lives at

--- a/.github/workflows/image-release.yml
+++ b/.github/workflows/image-release.yml
@@ -154,7 +154,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ inputs.ref }}
           # No authenticated git is run against this checkout afterwards, and in
@@ -386,7 +386,7 @@ jobs:
       # github.event.pull_request.head.* into external_repo or external_ref.
       - name: Checkout external repo
         if: inputs.external_repo != ''
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           repository: ${{ inputs.external_repo }}
           ref: ${{ inputs.external_ref }}

--- a/.github/workflows/image-release.yml
+++ b/.github/workflows/image-release.yml
@@ -351,7 +351,7 @@ jobs:
           fi
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
+        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
 
       - name: Set up Buildx
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0

--- a/.github/workflows/image-release.yml
+++ b/.github/workflows/image-release.yml
@@ -169,14 +169,26 @@ jobs:
           DOCKERFILE_PATH: ${{ inputs.dockerfile_path }}
           EXTERNAL_REF: ${{ inputs.external_ref }}
         run: |
+          # Escape a value before interpolating it into a ::error::/::warning::
+          # workflow command, matching the GitHub Actions toolkit escapeData
+          # (% -> %25, CR -> %0D, LF -> %0A; % first to avoid double-escaping).
+          # Without this, a caller value containing newlines/CR/% could inject
+          # additional workflow commands or truncate the message.
+          esc() {
+            local s=$1
+            s=${s//'%'/'%25'}
+            s=${s//$'\r'/'%0D'}
+            s=${s//$'\n'/'%0A'}
+            printf '%s' "$s"
+          }
           # dockerfile_path / external_ref only take effect alongside
           # external_repo; surface a warning so callers don't assume they were
           # silently honored.
           if [[ -n "$DOCKERFILE_PATH" ]]; then
-            echo "::warning::dockerfile_path ('$DOCKERFILE_PATH') was set without external_repo and will be ignored"
+            echo "::warning::dockerfile_path ('$(esc "$DOCKERFILE_PATH")') was set without external_repo and will be ignored"
           fi
           if [[ -n "$EXTERNAL_REF" ]]; then
-            echo "::warning::external_ref ('$EXTERNAL_REF') was set without external_repo and will be ignored"
+            echo "::warning::external_ref ('$(esc "$EXTERNAL_REF")') was set without external_repo and will be ignored"
           fi
 
       - name: Validate external_repo inputs
@@ -191,6 +203,19 @@ jobs:
           GO_VENDOR: ${{ inputs.go_vendor }}
         run: |
           fail=0
+          # Escape a value before interpolating it into a ::error::/::warning::
+          # workflow command, matching the GitHub Actions toolkit escapeData
+          # (% -> %25, CR -> %0D, LF -> %0A; % first to avoid double-escaping).
+          # All caller-supplied values below are echoed through esc() so a
+          # malformed/hostile value (newlines, CR, %) cannot inject additional
+          # workflow commands or truncate the message.
+          esc() {
+            local s=$1
+            s=${s//'%'/'%25'}
+            s=${s//$'\r'/'%0D'}
+            s=${s//$'\n'/'%0A'}
+            printf '%s' "$s"
+          }
           # Strip a single optional leading "./" for path comparison so
           # equivalent forms ("./external-src" and "external-src") validate
           # the same way. Error messages echo the caller's original value to
@@ -221,7 +246,7 @@ jobs:
           # guard against malformed/injected values; the allowlist below is the
           # actual trust boundary.
           if [[ ! "$EXTERNAL_REPO" =~ ^[A-Za-z0-9._-]+/[A-Za-z0-9._-]+$ ]]; then
-            echo "::error::external_repo must be a bare 'owner/repo' slug, got '$EXTERNAL_REPO'"
+            echo "::error::external_repo must be a bare 'owner/repo' slug, got '$(esc "$EXTERNAL_REPO")'"
             fail=1
           fi
 
@@ -229,7 +254,7 @@ jobs:
           # (Non-emptiness is enforced above; skip the charset check when empty
           # so the more specific "required" error is the one that surfaces.)
           if [[ -n "$EXTERNAL_REF" && ! "$EXTERNAL_REF" =~ ^[A-Za-z0-9._/-]+$ ]]; then
-            echo "::error::external_ref must contain only [A-Za-z0-9._/-], got '$EXTERNAL_REF'"
+            echo "::error::external_ref must contain only [A-Za-z0-9._/-], got '$(esc "$EXTERNAL_REF")'"
             fail=1
           fi
 
@@ -254,7 +279,7 @@ jobs:
               # entries with spaces or shell metacharacters) that would silently
               # match more than intended.
               if [[ ! "$entry" =~ ^[A-Za-z0-9._-]+/([A-Za-z0-9._-]+|\*)$ ]]; then
-                echo "::error::external_repo_allowlist entry '$entry' must be 'owner/repo' or 'owner/*'"
+                echo "::error::external_repo_allowlist entry '$(esc "$entry")' must be 'owner/repo' or 'owner/*'"
                 fail=1
                 continue
               fi
@@ -264,53 +289,53 @@ jobs:
               esac
             done <<< "$EXTERNAL_REPO_ALLOWLIST"
             if [[ "$allow_match" -ne 1 ]]; then
-              echo "::error::external_repo '$EXTERNAL_REPO' is not permitted by external_repo_allowlist"
+              echo "::error::external_repo '$(esc "$EXTERNAL_REPO")' is not permitted by external_repo_allowlist"
               fail=1
             fi
           else
-            echo "::warning::external_repo_allowlist is empty; external_repo ('$EXTERNAL_REPO') is unconstrained. Provide an allowlist and ensure callers never pass PR-event data to external_repo/external_ref."
+            echo "::warning::external_repo_allowlist is empty; external_repo ('$(esc "$EXTERNAL_REPO")') is unconstrained. Provide an allowlist and ensure callers never pass PR-event data to external_repo/external_ref."
           fi
 
           if [[ -z "$NORM_DOCKERFILE_PATH" ]]; then
             echo "::error::dockerfile_path is required when external_repo is set"
             fail=1
           elif [[ "$NORM_DOCKERFILE_PATH" == /* ]]; then
-            echo "::error::dockerfile_path must be relative to the caller repository workspace, got '$DOCKERFILE_PATH'"
+            echo "::error::dockerfile_path must be relative to the caller repository workspace, got '$(esc "$DOCKERFILE_PATH")'"
             fail=1
           elif has_dotdot "$NORM_DOCKERFILE_PATH"; then
-            echo "::error::dockerfile_path must not contain a '..' path component, got '$DOCKERFILE_PATH'"
+            echo "::error::dockerfile_path must not contain a '..' path component, got '$(esc "$DOCKERFILE_PATH")'"
             fail=1
           elif [[ "$NORM_DOCKERFILE_PATH" == *[*?\[]* ]]; then
-            echo "::error::dockerfile_path must not contain glob metacharacters (*, ?, [), got '$DOCKERFILE_PATH'"
+            echo "::error::dockerfile_path must not contain glob metacharacters (*, ?, [), got '$(esc "$DOCKERFILE_PATH")'"
             fail=1
           elif [[ -L "$NORM_DOCKERFILE_PATH" ]]; then
-            echo "::error::dockerfile_path '$DOCKERFILE_PATH' must be a regular file, not a symlink"
+            echo "::error::dockerfile_path '$(esc "$DOCKERFILE_PATH")' must be a regular file, not a symlink"
             fail=1
           elif [[ ! -f "$NORM_DOCKERFILE_PATH" ]]; then
-            echo "::error::dockerfile_path '$DOCKERFILE_PATH' not found in the caller repository workspace"
+            echo "::error::dockerfile_path '$(esc "$DOCKERFILE_PATH")' not found in the caller repository workspace"
             fail=1
           fi
 
           if [[ -z "$NORM_EXTERNAL_PATH" || "$NORM_EXTERNAL_PATH" == "." ]]; then
-            echo "::error::external_path must resolve to a directory under the workspace (not '.' / './' / empty), got '$EXTERNAL_PATH'"
+            echo "::error::external_path must resolve to a directory under the workspace (not '.' / './' / empty), got '$(esc "$EXTERNAL_PATH")'"
             fail=1
           elif [[ "$NORM_EXTERNAL_PATH" == /* ]]; then
-            echo "::error::external_path must be relative, got '$EXTERNAL_PATH'"
+            echo "::error::external_path must be relative, got '$(esc "$EXTERNAL_PATH")'"
             fail=1
           elif has_dotdot "$NORM_EXTERNAL_PATH"; then
-            echo "::error::external_path must not contain a '..' path component, got '$EXTERNAL_PATH'"
+            echo "::error::external_path must not contain a '..' path component, got '$(esc "$EXTERNAL_PATH")'"
             fail=1
           elif [[ "$NORM_EXTERNAL_PATH" == */ ]]; then
-            echo "::error::external_path must not end with '/', got '$EXTERNAL_PATH'"
+            echo "::error::external_path must not end with '/', got '$(esc "$EXTERNAL_PATH")'"
             fail=1
           elif [[ "$NORM_EXTERNAL_PATH" == *[*?\[]* ]]; then
-            echo "::error::external_path must not contain glob metacharacters (*, ?, [), got '$EXTERNAL_PATH'"
+            echo "::error::external_path must not contain glob metacharacters (*, ?, [), got '$(esc "$EXTERNAL_PATH")'"
             fail=1
           else
             case "$NORM_CONTEXT" in
               "$NORM_EXTERNAL_PATH"|"$NORM_EXTERNAL_PATH"/*) ;;
               *)
-                echo "::error::context must be '$EXTERNAL_PATH' or a subpath when external_repo is set, got '$CONTEXT'"
+                echo "::error::context must be '$(esc "$EXTERNAL_PATH")' or a subpath when external_repo is set, got '$(esc "$CONTEXT")'"
                 fail=1
                 ;;
             esac
@@ -320,11 +345,11 @@ jobs:
           # branches above so the more specific error still fires when
           # external_path itself fails validation.
           if has_dotdot "$NORM_CONTEXT"; then
-            echo "::error::context must not contain a '..' path component, got '$CONTEXT'"
+            echo "::error::context must not contain a '..' path component, got '$(esc "$CONTEXT")'"
             fail=1
           fi
           if [[ "$NORM_CONTEXT" == *[*?\[]* ]]; then
-            echo "::error::context must not contain glob metacharacters (*, ?, [), got '$CONTEXT'"
+            echo "::error::context must not contain glob metacharacters (*, ?, [), got '$(esc "$CONTEXT")'"
             fail=1
           fi
 
@@ -338,7 +363,7 @@ jobs:
           if [[ -n "$NORM_DOCKERFILE_PATH" && -n "$NORM_EXTERNAL_PATH" && "$NORM_EXTERNAL_PATH" != "." ]]; then
             case "$NORM_DOCKERFILE_PATH" in
               "$NORM_EXTERNAL_PATH"|"$NORM_EXTERNAL_PATH"/*)
-                echo "::error::dockerfile_path ('$DOCKERFILE_PATH') must not be inside external_path ('$EXTERNAL_PATH'); the external checkout would overwrite it before the overlay copy"
+                echo "::error::dockerfile_path ('$(esc "$DOCKERFILE_PATH")') must not be inside external_path ('$(esc "$EXTERNAL_PATH")'); the external checkout would overwrite it before the overlay copy"
                 fail=1
                 ;;
             esac

--- a/.github/workflows/image-release.yml
+++ b/.github/workflows/image-release.yml
@@ -94,6 +94,18 @@ on:
         type: string
         default: ""
         description: "Path (relative to the caller repository workspace) of the Dockerfile to copy into external_path/Dockerfile, overriding any Dockerfile the external repo ships with. Must be a regular file (symlinks are rejected). Required when external_repo is set; otherwise ignored."
+      external_repo_allowlist:
+        required: false
+        type: string
+        default: ""
+        description: >
+          Newline-separated allowlist of permitted external_repo values, each an
+          exact 'owner/repo' or an 'owner/*' glob. When non-empty, external_repo
+          must match an entry or the build fails. SECURITY: callers MUST pass only
+          static, maintainer-pinned literals to external_repo / external_ref and
+          MUST NOT wire in PR-event data (e.g. github.event.pull_request.head.*).
+          This allowlist is a defense-in-depth backstop for that caller contract,
+          not a replacement for it. Ignored when external_repo is empty.
     outputs:
       digest:
         description: "Image digest (sha256:...)"
@@ -168,6 +180,8 @@ jobs:
           DOCKERFILE_PATH: ${{ inputs.dockerfile_path }}
           EXTERNAL_PATH: ${{ inputs.external_path }}
           EXTERNAL_REF: ${{ inputs.external_ref }}
+          EXTERNAL_REPO: ${{ inputs.external_repo }}
+          EXTERNAL_REPO_ALLOWLIST: ${{ inputs.external_repo_allowlist }}
           CONTEXT: ${{ inputs.context }}
           GO_VENDOR: ${{ inputs.go_vendor }}
         run: |
@@ -195,6 +209,50 @@ jobs:
           if [[ -z "$EXTERNAL_REF" ]]; then
             echo "::error::external_ref is required when external_repo is set (empty ref would default to upstream's default branch, breaking reproducibility)"
             fail=1
+          fi
+
+          # external_repo must be a bare "owner/repo" slug: no whitespace, no
+          # shell metacharacters, no URL, no extra path segments. Structural
+          # guard against malformed/injected values; the allowlist below is the
+          # actual trust boundary.
+          if [[ ! "$EXTERNAL_REPO" =~ ^[A-Za-z0-9._-]+/[A-Za-z0-9._-]+$ ]]; then
+            echo "::error::external_repo must be a bare 'owner/repo' slug, got '$EXTERNAL_REPO'"
+            fail=1
+          fi
+
+          # external_ref must look like a git ref/sha: only [A-Za-z0-9._/-].
+          # (Non-emptiness is enforced above; skip the charset check when empty
+          # so the more specific "required" error is the one that surfaces.)
+          if [[ -n "$EXTERNAL_REF" && ! "$EXTERNAL_REF" =~ ^[A-Za-z0-9._/-]+$ ]]; then
+            echo "::error::external_ref must contain only [A-Za-z0-9._/-], got '$EXTERNAL_REF'"
+            fail=1
+          fi
+
+          # Defense-in-depth: when an allowlist is provided, external_repo must
+          # match one of its entries (exact 'owner/repo' or 'owner/*' glob). A
+          # trusted caller declares this allowlist as a literal, so PR-event data
+          # cannot satisfy it even if a privileged caller wired it into
+          # external_repo. When the allowlist is empty, external_repo is
+          # unconstrained and we only warn (back-compat for existing callers).
+          if [[ -n "$EXTERNAL_REPO_ALLOWLIST" ]]; then
+            allow_match=0
+            while IFS= read -r entry || [[ -n "$entry" ]]; do
+              entry="${entry%$'\r'}"
+              # trim surrounding whitespace
+              entry="${entry#"${entry%%[![:space:]]*}"}"
+              entry="${entry%"${entry##*[![:space:]]}"}"
+              [[ -z "$entry" || "$entry" == \#* ]] && continue
+              # shellcheck disable=SC2254 # intentional glob match against trusted allowlist entry
+              case "$EXTERNAL_REPO" in
+                $entry) allow_match=1; break ;;
+              esac
+            done <<< "$EXTERNAL_REPO_ALLOWLIST"
+            if [[ "$allow_match" -ne 1 ]]; then
+              echo "::error::external_repo '$EXTERNAL_REPO' is not permitted by external_repo_allowlist"
+              fail=1
+            fi
+          else
+            echo "::warning::external_repo_allowlist is empty; external_repo ('$EXTERNAL_REPO') is unconstrained. Provide an allowlist and ensure callers never pass PR-event data to external_repo/external_ref."
           fi
 
           if [[ -z "$NORM_DOCKERFILE_PATH" ]]; then
@@ -276,6 +334,15 @@ jobs:
           fi
           [[ "$fail" -eq 0 ]] || exit 1
 
+      # SECURITY (CodeQL actions/untrusted-checkout): this step checks out an
+      # external repo whose code is then executed by `docker build`, inside a
+      # job that holds registry secrets and write scopes. That is safe ONLY
+      # because external_repo/external_ref are maintainer-pinned inputs,
+      # validated above (bare 'owner/repo' slug, sane ref charset, optional
+      # allowlist), and callers are contractually required never to wire
+      # PR-event data into them. Do NOT call this reusable workflow from a
+      # pull_request_target / workflow_run caller that forwards
+      # github.event.pull_request.head.* into external_repo or external_ref.
       - name: Checkout external repo
         if: inputs.external_repo != ''
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/image-release.yml
+++ b/.github/workflows/image-release.yml
@@ -247,7 +247,18 @@ jobs:
               entry="${entry#"${entry%%[![:space:]]*}"}"
               entry="${entry%"${entry##*[![:space:]]}"}"
               [[ -z "$entry" || "$entry" == \#* ]] && continue
-              # shellcheck disable=SC2254 # intentional glob match against trusted allowlist entry
+              # Constrain each entry to the two documented forms before using it
+              # as a glob: an exact 'owner/repo' or an 'owner/*' wildcard. This
+              # keeps behaviour aligned with the input docs and rejects broader
+              # or malformed globs (e.g. '*/*', 'owner/re?o', 'owner/[ab]',
+              # entries with spaces or shell metacharacters) that would silently
+              # match more than intended.
+              if [[ ! "$entry" =~ ^[A-Za-z0-9._-]+/([A-Za-z0-9._-]+|\*)$ ]]; then
+                echo "::error::external_repo_allowlist entry '$entry' must be 'owner/repo' or 'owner/*'"
+                fail=1
+                continue
+              fi
+              # shellcheck disable=SC2254 # intentional glob match against validated allowlist entry
               case "$EXTERNAL_REPO" in
                 $entry) allow_match=1; break ;;
               esac

--- a/.github/workflows/image-release.yml
+++ b/.github/workflows/image-release.yml
@@ -157,6 +157,11 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ inputs.ref }}
+          # No authenticated git is run against this checkout afterwards, and in
+          # non-external mode the workspace root is the docker build context.
+          # Opt out of credential persistence (least privilege) so no token
+          # material lingers in or near the build context.
+          persist-credentials: false
 
       - name: Warn on orphan external_repo inputs
         if: inputs.external_repo == '' && (inputs.dockerfile_path != '' || inputs.external_ref != '')
@@ -351,6 +356,13 @@ jobs:
           ref: ${{ inputs.external_ref }}
           path: ${{ inputs.external_path }}
           token: ${{ secrets.gh_pat || github.token }}
+          # This checkout IS the docker build context. The token is still used
+          # for the initial fetch, but must not be persisted afterwards: never
+          # run authenticated git here, and keep credential material out of the
+          # build context. (checkout v6 stores creds under RUNNER_TEMP rather
+          # than .git/config, but opting out is the explicit least-privilege
+          # guarantee and is robust against version/behaviour changes.)
+          persist-credentials: false
 
       - name: Overlay Dockerfile onto external source
         if: inputs.external_repo != ''

--- a/.github/workflows/mise-task.yml
+++ b/.github/workflows/mise-task.yml
@@ -63,7 +63,7 @@ jobs:
     name: ${{ inputs.name != '' && inputs.name || inputs.task }}
     runs-on: ${{ fromJSON(inputs.runs_on) }}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: ${{ inputs.fetch-depth }}
 

--- a/.github/workflows/mise-task.yml
+++ b/.github/workflows/mise-task.yml
@@ -67,7 +67,7 @@ jobs:
         with:
           fetch-depth: ${{ inputs.fetch-depth }}
 
-      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+      - uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
         with:
           cache: true
 

--- a/.github/workflows/sbom-image.yml
+++ b/.github/workflows/sbom-image.yml
@@ -54,7 +54,7 @@ jobs:
           fetch-depth: 1
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ${{ env.REGISTRY_GHCR }}
           username: ${{ github.actor }}
@@ -109,7 +109,7 @@ jobs:
           mv trivy-image-fixed.sarif trivy-image.sarif
 
       - name: Upload Trivy SARIF to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4.35.5
+        uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
         with:
           sarif_file: trivy-image.sarif
           category: trivy-image
@@ -132,7 +132,7 @@ jobs:
           severity-cutoff: high
 
       - name: Upload Grype SARIF to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4.35.5
+        uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
         with:
           sarif_file: ${{ steps.grype-sarif.outputs.sarif }}
           category: grype-image

--- a/.github/workflows/sbom-image.yml
+++ b/.github/workflows/sbom-image.yml
@@ -109,7 +109,7 @@ jobs:
           mv trivy-image-fixed.sarif trivy-image.sarif
 
       - name: Upload Trivy SARIF to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@87557b9c84dde89fdd9b10e88954ac2f4248e463 # v4.36.1
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
         with:
           sarif_file: trivy-image.sarif
           category: trivy-image
@@ -132,7 +132,7 @@ jobs:
           severity-cutoff: high
 
       - name: Upload Grype SARIF to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@87557b9c84dde89fdd9b10e88954ac2f4248e463 # v4.36.1
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
         with:
           sarif_file: ${{ steps.grype-sarif.outputs.sarif }}
           category: grype-image

--- a/.github/workflows/sbom-image.yml
+++ b/.github/workflows/sbom-image.yml
@@ -48,7 +48,7 @@ jobs:
       security-events: write
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ inputs.ref }}
           fetch-depth: 1
@@ -109,7 +109,7 @@ jobs:
           mv trivy-image-fixed.sarif trivy-image.sarif
 
       - name: Upload Trivy SARIF to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
+        uses: github/codeql-action/upload-sarif@87557b9c84dde89fdd9b10e88954ac2f4248e463 # v4.36.1
         with:
           sarif_file: trivy-image.sarif
           category: trivy-image
@@ -132,7 +132,7 @@ jobs:
           severity-cutoff: high
 
       - name: Upload Grype SARIF to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
+        uses: github/codeql-action/upload-sarif@87557b9c84dde89fdd9b10e88954ac2f4248e463 # v4.36.1
         with:
           sarif_file: ${{ steps.grype-sarif.outputs.sarif }}
           category: grype-image

--- a/.github/workflows/sbom-source.yml
+++ b/.github/workflows/sbom-source.yml
@@ -109,7 +109,7 @@ jobs:
           mv trivy-source-fixed.sarif trivy-source.sarif
 
       - name: Upload Trivy SARIF to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4.35.5
+        uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
         with:
           sarif_file: trivy-source.sarif
           category: trivy-source
@@ -132,7 +132,7 @@ jobs:
           severity-cutoff: high
 
       - name: Upload Grype SARIF to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4.35.5
+        uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
         with:
           sarif_file: ${{ steps.grype-sarif.outputs.sarif }}
           category: grype-source

--- a/.github/workflows/sbom-source.yml
+++ b/.github/workflows/sbom-source.yml
@@ -109,7 +109,7 @@ jobs:
           mv trivy-source-fixed.sarif trivy-source.sarif
 
       - name: Upload Trivy SARIF to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@87557b9c84dde89fdd9b10e88954ac2f4248e463 # v4.36.1
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
         with:
           sarif_file: trivy-source.sarif
           category: trivy-source
@@ -132,7 +132,7 @@ jobs:
           severity-cutoff: high
 
       - name: Upload Grype SARIF to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@87557b9c84dde89fdd9b10e88954ac2f4248e463 # v4.36.1
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
         with:
           sarif_file: ${{ steps.grype-sarif.outputs.sarif }}
           category: grype-source

--- a/.github/workflows/sbom-source.yml
+++ b/.github/workflows/sbom-source.yml
@@ -46,7 +46,7 @@ jobs:
       security-events: write
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ inputs.ref }}
           fetch-depth: 1
@@ -109,7 +109,7 @@ jobs:
           mv trivy-source-fixed.sarif trivy-source.sarif
 
       - name: Upload Trivy SARIF to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
+        uses: github/codeql-action/upload-sarif@87557b9c84dde89fdd9b10e88954ac2f4248e463 # v4.36.1
         with:
           sarif_file: trivy-source.sarif
           category: trivy-source
@@ -132,7 +132,7 @@ jobs:
           severity-cutoff: high
 
       - name: Upload Grype SARIF to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
+        uses: github/codeql-action/upload-sarif@87557b9c84dde89fdd9b10e88954ac2f4248e463 # v4.36.1
         with:
           sarif_file: ${{ steps.grype-sarif.outputs.sarif }}
           category: grype-source

--- a/.mise/tasks/ci/semgrep
+++ b/.mise/tasks/ci/semgrep
@@ -2,7 +2,7 @@
 #MISE description="Run semgrep static analysis (p/ci baseline + lang packs)"
 #MISE hide=true
 #MISE raw=true
-#MISE tools={"pipx:semgrep"="latest"}
+#MISE tools={"pipx:semgrep"="latest","uv"="latest"}
 #USAGE arg "[packs]" var=#true var_min=0 help="Language packs (golang, python, typescript, javascript, ...). Stacked on top of p/ci baseline."
 #USAGE flag "--audit" help="Add p/default + p/security-audit + p/owasp-top-ten (deep scan, more FPs; nightly/manual use)"
 #USAGE flag "--rules <path>" help="Custom rules file (e.g., .semgrep/rules.yml). Stacked on top of packs." default=""

--- a/.mise/tasks/go/build
+++ b/.mise/tasks/go/build
@@ -15,7 +15,10 @@ build_one() {
   # and avoid passing an empty "" argument when unset.
   # Using read -ra instead of bare expansion so shellharden won't re-quote it.
   IFS=' ' read -ra extra_flags <<< "${EXTRA_BUILD_FLAGS:-}"
-  go build -o "bin/$1" "${extra_flags[@]}" -ldflags "${LDFLAGS} ${VERSION_LDFLAGS}" "./cmd/$1"
+  # LDFLAGS is an optional caller override (unset for plain local builds); only
+  # prepend it (with a separating space) when non-empty so the ldflags string
+  # doesn't carry a stray leading space.
+  go build -o "bin/$1" "${extra_flags[@]}" -ldflags "${LDFLAGS:+$LDFLAGS }${VERSION_LDFLAGS}" "./cmd/$1"
 }
 
 if [ "$usage_name" = "" ]; then

--- a/.mise/tasks/go/run
+++ b/.mise/tasks/go/run
@@ -23,4 +23,7 @@ if [ ! -f "cmd/$usage_name/main.go" ]; then
   echo "Error: cmd/$usage_name/main.go not found"
   exit 1
 fi
-go run -mod=vendor -ldflags "${VERSION_LDFLAGS}" "./cmd/$usage_name" "$usage_args"
+# usage_args is a shell-escaped string for a variadic arg; eval into an array
+# so multiple args split correctly and zero args pass nothing (not an empty "").
+eval "args=(${usage_args:-})"
+go run -mod=vendor -ldflags "${VERSION_LDFLAGS}" "./cmd/$usage_name" "${args[@]}"

--- a/.mise/tasks/go/run
+++ b/.mise/tasks/go/run
@@ -25,5 +25,10 @@ if [ ! -f "cmd/$usage_name/main.go" ]; then
 fi
 # usage_args is a shell-escaped string for a variadic arg; eval into an array
 # so multiple args split correctly and zero args pass nothing (not an empty "").
-eval "args=(${usage_args:-})"
+# Abort on eval failure: a malformed usage_args would otherwise leave args
+# stale/unset and silently run go with the wrong arguments.
+if ! eval "args=(${usage_args:-})"; then
+  echo "Error: failed to parse arguments: ${usage_args:-}" >&2
+  exit 1
+fi
 go run -mod=vendor -ldflags "${VERSION_LDFLAGS}" "./cmd/$usage_name" "${args[@]}"

--- a/.mise/tasks/lib/go-version
+++ b/.mise/tasks/lib/go-version
@@ -1,16 +1,29 @@
 #!/usr/bin/env bash
 # Sourced helper. Provides Go version info for ldflags injection.
 # Vars (override via env if needed):
-#   VERSION       from git describe --tags --always --dirty   default: dev
-#   COMMIT        full commit SHA                              default: unknown
-#   BUILD_DATE    ISO8601 commit timestamp from git log        default: <now>
-#   VERSION_PKG   package holding version vars                 default: main
+#   VERSION      from git describe --tags --always --dirty       default: dev
+#   COMMIT       full commit SHA                                  default: unknown
+#   BUILD_DATE   ISO8601 commit timestamp (fallback: date -u)     default: <now>
+#   VERSION_PKG  package holding version vars                     default: see below
+#
+# VERSION_PKG auto-detection (when unset):
+#   - <module>/internal/version  if  internal/version/  exists
+#   - main                       otherwise
 #
 # Exports:
 #   VERSION_LDFLAGS  -ldflags string injecting
 #                    ${VERSION_PKG}.Version, .Commit, .BuildDate
 
-: "${VERSION_PKG:=main}"
+if [ -z "${VERSION_PKG:-}" ]; then
+  _module=$(awk '/^module / {print $2; exit}' go.mod 2>/dev/null || echo "")
+  if [ -n "$_module" ] && [ -d "internal/version" ]; then
+    VERSION_PKG="${_module}/internal/version"
+  else
+    VERSION_PKG="main"
+  fi
+  unset _module
+fi
+
 : "${VERSION:=$(git describe --tags --always --dirty 2>/dev/null || echo dev)}"
 : "${COMMIT:=$(git rev-parse HEAD 2>/dev/null || echo unknown)}"
 : "${BUILD_DATE:=$(git log -1 --format=%cI 2>/dev/null || date -u +%Y-%m-%dT%H:%M:%SZ)}"

--- a/.mise/tasks/lib/go-version
+++ b/.mise/tasks/lib/go-version
@@ -27,7 +27,7 @@ fi
 # Detect renamed env var (COMMIT_DATE → BUILD_DATE) to fail loud instead of
 # silently ignoring stale CI / mise configs that still set the old name.
 if [ -n "${COMMIT_DATE:-}" ]; then
-  echo "Error: COMMIT_DATE was renamed to BUILD_DATE (meta PR #93). Update your env." >&2
+  echo "Error: COMMIT_DATE was renamed to BUILD_DATE; set BUILD_DATE (or unset COMMIT_DATE)." >&2
   exit 1
 fi
 

--- a/.mise/tasks/lib/go-version
+++ b/.mise/tasks/lib/go-version
@@ -26,7 +26,9 @@ fi
 
 # Detect renamed env var (COMMIT_DATE → BUILD_DATE) to fail loud instead of
 # silently ignoring stale CI / mise configs that still set the old name.
-if [ -n "${COMMIT_DATE:-}" ]; then
+# Use ${VAR+x} (not ${VAR:-}) so an explicitly-set-but-empty COMMIT_DATE
+# still trips the guard — being set at all signals a stale config.
+if [ -n "${COMMIT_DATE+x}" ]; then
   echo "Error: COMMIT_DATE was renamed to BUILD_DATE; set BUILD_DATE (or unset COMMIT_DATE)." >&2
   exit 1
 fi

--- a/.mise/tasks/lib/go-version
+++ b/.mise/tasks/lib/go-version
@@ -3,25 +3,24 @@
 # Vars (override via env if needed):
 #   VERSION       from git describe --tags --always --dirty   default: dev
 #   COMMIT        full commit SHA                              default: unknown
-#   COMMIT_DATE   ISO8601 commit timestamp from git log        default: <now>
+#   BUILD_DATE    ISO8601 commit timestamp from git log        default: <now>
 #   VERSION_PKG   package holding version vars                 default: main
 #
 # Exports:
 #   VERSION_LDFLAGS  -ldflags string injecting
-#                    ${VERSION_PKG}.Version, .CommitSHA, .CommitDate
-#                    (matches the go-release workflow naming convention)
+#                    ${VERSION_PKG}.Version, .Commit, .BuildDate
 
 : "${VERSION_PKG:=main}"
 : "${VERSION:=$(git describe --tags --always --dirty 2>/dev/null || echo dev)}"
 : "${COMMIT:=$(git rev-parse HEAD 2>/dev/null || echo unknown)}"
-: "${COMMIT_DATE:=$(git log -1 --format=%cI 2>/dev/null || date -u +%Y-%m-%dT%H:%M:%SZ)}"
+: "${BUILD_DATE:=$(git log -1 --format=%cI 2>/dev/null || date -u +%Y-%m-%dT%H:%M:%SZ)}"
 
 # Reject whitespace and quote characters in values to prevent ldflags
 # injection — Go's -ldflags parser splits on whitespace, so a value
 # containing a space would be parsed as an extra linker flag.
 # Don't echo the offending value: env vars may carry sensitive data
 # and the error lands in CI logs.
-for _v in VERSION_PKG VERSION COMMIT COMMIT_DATE; do
+for _v in VERSION_PKG VERSION COMMIT BUILD_DATE; do
   if [[ "${!_v}" =~ [[:space:]\"\'] ]]; then
     echo "Error: $_v contains invalid characters (whitespace or quotes)" >&2
     exit 1
@@ -30,4 +29,4 @@ done
 unset _v
 
 # shellcheck disable=SC2034 # consumed by sourcing script (go/build, go/run)
-VERSION_LDFLAGS="-X ${VERSION_PKG}.Version=${VERSION} -X ${VERSION_PKG}.CommitSHA=${COMMIT} -X ${VERSION_PKG}.CommitDate=${COMMIT_DATE}"
+VERSION_LDFLAGS="-X ${VERSION_PKG}.Version=${VERSION} -X ${VERSION_PKG}.Commit=${COMMIT} -X ${VERSION_PKG}.BuildDate=${BUILD_DATE}"

--- a/.mise/tasks/lib/go-version
+++ b/.mise/tasks/lib/go-version
@@ -24,6 +24,13 @@ if [ -z "${VERSION_PKG:-}" ]; then
   unset _module
 fi
 
+# Detect renamed env var (COMMIT_DATE → BUILD_DATE) to fail loud instead of
+# silently ignoring stale CI / mise configs that still set the old name.
+if [ -n "${COMMIT_DATE:-}" ]; then
+  echo "Error: COMMIT_DATE was renamed to BUILD_DATE (meta PR #93). Update your env." >&2
+  exit 1
+fi
+
 : "${VERSION:=$(git describe --tags --always --dirty 2>/dev/null || echo dev)}"
 : "${COMMIT:=$(git rev-parse HEAD 2>/dev/null || echo unknown)}"
 : "${BUILD_DATE:=$(git log -1 --format=%cI 2>/dev/null || date -u +%Y-%m-%dT%H:%M:%SZ)}"

--- a/.mise/tasks/node/sast
+++ b/.mise/tasks/node/sast
@@ -3,6 +3,10 @@
 #MISE hide=true
 #MISE raw=true
 #MISE tools={uv="latest"}
+# FIX: njsscan depends on semgrep -> pydantic 2.8.2 -> pydantic-core 2.20.1 whose
+# bundled PyO3 0.22 caps at Python 3.13. Pin uv to 3.13 so the wheel build
+# (triggered when no prebuilt wheel matches) doesn't hit the 3.14 cap.
+#MISE env={UV_PYTHON="3.13"}
 #USAGE flag "--json" help="Emit JSON output to njsscan-report.json"
 
 # shellcheck disable=SC2154

--- a/templates/facades/mise.go-lib.toml
+++ b/templates/facades/mise.go-lib.toml
@@ -8,7 +8,7 @@ unix_default_inline_shell_args = "bash -c"
 # ------------------------------------------------------------------------------
 [tools]
 # Go toolchain
-go = "1.26.3"
+go = "1.26.4"
 
 [env]
 # Override meta config base if forking nics-dp/meta

--- a/templates/facades/mise.go-service.toml
+++ b/templates/facades/mise.go-service.toml
@@ -9,7 +9,7 @@ unix_default_inline_shell_args = "bash -c"
 # ------------------------------------------------------------------------------
 [tools]
 # Go toolchain
-go = "1.26.3"
+go = "1.26.4"
 
 [env]
 # Override meta config base if forking nics-dp/meta


### PR DESCRIPTION
Release v0.2.4.1 (dev to main)。

## 主要變更

- **fix(ci)**: 在 semgrep task 安裝 uv，繞過 mise 2026.6.3 + pipx 舊 pip 的安裝失敗（修復所有 repo 的 Semgrep CI）
- **fix(image-release)**: 強化外部 checkout、跳脫 caller 輸入、停用憑證持久化、驗證 allowlist
- **fix(mise)**: 修正 go:run 參數轉發、COMMIT_DATE 空值偵測、release ldflags 對齊
- **feat(mise)**: 自動偵測 VERSION_PKG、注入版本 ldflags
- **chore**: 更新 github-actions 依賴、mise dev tools (go 1.26.4)、新增 CODEOWNERS

完整 commit 見下方 Files changed。

Generated with [Claude Code](https://claude.com/claude-code)
