### PR TITLE
fix(ci): disable mise minimum_release_age to unbreak pipx tool installs

### DIFF
--- a/.github/workflows/mise-task.yml
+++ b/.github/workflows/mise-task.yml
@@ -62,6 +62,14 @@ jobs:
   run:
     name: ${{ inputs.name != '' && inputs.name || inputs.task }}
     runs-on: ${{ fromJSON(inputs.runs_on) }}
+    # The self-hosted runners export a minimum_release_age supply-chain control.
+    # mise 2026.6.3 forwards it to the pipx backend as a pip-only flag
+    # (--pip-args=--uploaded-prior-to=...), which the uv-backed pipx installer
+    # rejects ("Fatal error from uv"), breaking pipx tool installs such as
+    # semgrep. Neutralise it for CI tool installs until mise stops mixing the
+    # pip flag into the uv path.
+    env:
+      MISE_MINIMUM_RELEASE_AGE: "0"
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:


### PR DESCRIPTION
## 問題

所有 nics-dp repo 的 Semgrep CI job 持續失敗。經在 releasers runner 上實證重現，根因如下：

自架 runner 環境設了 `minimum_release_age`（供應鏈控制，`mise settings` 看不到，屬 runner env 來源）。mise 2026.6.3 會把它當成 pip 專屬 flag 透過 `--pip-args` 傳給 pipx backend：

```
$ pipx install semgrep==1.165.0 --pip-args=--uploaded-prior-to=2026-06-11T...
installing semgrep from spec 'semgrep==1.165.0'...
Fatal error from uv prevented installation.
```

pipx 現在用 uv 當安裝 backend，uv 不認得 pip 的 `--uploaded-prior-to` → fatal error，semgrep 還沒跑就掛。先前未裝 uv 時，是 pipx bootstrap 的舊 pip 拒絕同一個 flag（`no such option: --uploaded-prior-to`）—— 同源不同表象。

## 修法

在 `mise-task.yml` 的 job 層級設 `MISE_MINIMUM_RELEASE_AGE=0`，讓 mise-action 安裝與 `mise run` 期間的工具安裝不再注入這個不相容的 flag。

## 驗證

在 releasers runner 上實測 `MISE_MINIMUM_RELEASE_AGE=0 mise run ci:semgrep golang`：

```
pipx install semgrep==1.166.0          (乾淨指令，無 --uploaded-prior-to)
✓ installed
Ran 51 rules on 248 files: 0 findings.
```

## 取捨

此設定會關閉 CI 內所有 mise 工具安裝的 release-age 時間閘。考量該控制目前對 pipx 工具是全面壞掉（直接擋安裝、無實際防護效果），先恢復 CI 功能。若日後 mise 修正 pip-flag 混入 uv 路徑的行為，可再恢復。

## 影響範圍

所有透過 `mise-task.yml` 跑 CI 的 repo。

Generated with [Claude Code](https://claude.com/claude-code)
