### PR TITLE
release: v0.2.4.2

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -9,7 +9,6 @@ on:
       - "**/*.md"
       - "**/*.txt"
   pull_request:
-    branches: ["main"]
     paths-ignore:
       - "**/*.md"
       - "**/*.txt"

--- a/.github/workflows/mise-task.yml
+++ b/.github/workflows/mise-task.yml
@@ -62,6 +62,23 @@ jobs:
   run:
     name: ${{ inputs.name != '' && inputs.name || inputs.task }}
     runs-on: ${{ fromJSON(inputs.runs_on) }}
+    # mise's minimum_release_age supply-chain control is forwarded to the pipx
+    # backend as a pip-only flag (--pip-args=--uploaded-prior-to=...), which the
+    # uv-backed pipx installer rejects ("Fatal error from uv"), breaking pipx
+    # tool installs such as semgrep. Setting the age to 0 disables that
+    # injection. "0" requires mise >= 2026.6.3 (older mise rejects it as an
+    # invalid duration), and the self-hosted pool reuses cached mise binaries
+    # of mixed versions, so the action below pins mise to 2026.6.3.
+    #
+    # MISE_USE_VERSIONS_HOST=false: mise-versions.jdx.dev (the CDN that caches
+    # version listings) frequently 403s, spamming "outcome=failed status=403
+    # fallback=true" warnings even though the source-direct fallback already
+    # succeeds. Disabling the host makes mise resolve versions straight from
+    # each backend's source, so `latest` keeps working without the noise.
+    # Trade-off: a few more direct GitHub/aqua calls on version lookup.
+    env:
+      MISE_MINIMUM_RELEASE_AGE: "0"
+      MISE_USE_VERSIONS_HOST: "false"
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -69,6 +86,7 @@ jobs:
 
       - uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
         with:
+          version: "2026.6.3"
           cache: true
 
       - name: Configure git for private modules

--- a/renovate.json
+++ b/renovate.json
@@ -8,9 +8,7 @@
     {
       "customType": "regex",
       "description": "Update quill version in go-release workflow",
-      "managerFilePatterns": [
-        "/^\\.github/workflows/go-release\\.yml$/"
-      ],
+      "managerFilePatterns": ["/^\\.github/workflows/go-release\\.yml$/"],
       "matchStrings": ["go install github\\.com/anchore/quill/cmd/quill@(?<currentValue>v\\d+\\.\\d+\\.\\d+)"],
       "depNameTemplate": "anchore/quill",
       "datasourceTemplate": "github-releases"
@@ -18,12 +16,19 @@
     {
       "customType": "regex",
       "description": "Update parlay version in SBOM workflows",
-      "managerFilePatterns": [
-        "/^\\.github/workflows/sbom-(?:source|image)\\.yml$/"
-      ],
+      "managerFilePatterns": ["/^\\.github/workflows/sbom-(?:source|image)\\.yml$/"],
       "matchStrings": ["go install github\\.com/snyk/parlay@(?<currentValue>v\\d+\\.\\d+\\.\\d+)"],
       "depNameTemplate": "snyk/parlay",
       "datasourceTemplate": "github-releases"
+    },
+    {
+      "customType": "regex",
+      "description": "Update pinned mise version in the mise-task reusable workflow",
+      "managerFilePatterns": ["/^\\.github/workflows/mise-task\\.yml$/"],
+      "matchStrings": ["version:\\s*\"(?<currentValue>\\d+\\.\\d+\\.\\d+)\""],
+      "depNameTemplate": "jdx/mise",
+      "datasourceTemplate": "github-releases",
+      "extractVersionTemplate": "^v(?<version>.+)$"
     }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -25,7 +25,7 @@
       "customType": "regex",
       "description": "Update pinned mise version in the mise-task reusable workflow",
       "managerFilePatterns": ["/^\\.github/workflows/mise-task\\.yml$/"],
-      "matchStrings": ["version:\\s*\"(?<currentValue>\\d+\\.\\d+\\.\\d+)\""],
+      "matchStrings": ["jdx/mise-action@[\\s\\S]*?version:\\s*\"(?<currentValue>\\d+\\.\\d+\\.\\d+)\""],
       "depNameTemplate": "jdx/mise",
       "datasourceTemplate": "github-releases",
       "extractVersionTemplate": "^v(?<version>.+)$"


### PR DESCRIPTION
Release v0.2.4.2 (dev to main)。

## 主要變更

修復所有 nics-dp repo 的 CI 工具安裝（semgrep）失敗，根因為 mise 把 `minimum_release_age` 當 pip flag 注入 pipx，uv 不認得而 fatal：

- **fix(ci)**: job env 設 `MISE_MINIMUM_RELEASE_AGE=0` 停用注入；因 `0` 需 mise ≥ 2026.6.3，mise-action 釘 `version: 2026.6.3`；另設 `MISE_USE_VERSIONS_HOST=false` 消除 mise-versions CDN 403 雜訊
- **ci(codeql)**: code scanning 改為對所有 PR 觸發（原本只對 base=main，導致 dev PR 卡在 code scanning gate）
- **ci(renovate)**: 新增 customManager 追蹤 mise-task.yml 內 pin 的 mise 版本，並錨定到 jdx/mise-action step 避免誤判

完整 commit 見 Files changed。

Generated with [Claude Code](https://claude.com/claude-code)
