### PR TITLE
feat(image-release): add optional target input for build stage

### DIFF
--- a/.github/workflows/image-release.yml
+++ b/.github/workflows/image-release.yml
@@ -24,6 +24,17 @@ on:
         type: string
         default: "."
         description: "Docker build context path"
+      target:
+        required: false
+        type: string
+        default: ""
+        description: >
+          Docker build target stage (e.g. 'runtime'). Empty (default) builds
+          the last stage in the Dockerfile, preserving existing behaviour for
+          callers whose final stage is already the intended image (e.g.
+          otel-bundle, patroni, synth, which have no 'runtime' stage). Service
+          repos with a trailing 'debug' stage should opt in with target: runtime
+          to avoid shipping the debug image.
       build_args:
         required: false
         type: string
@@ -505,6 +516,10 @@ jobs:
           # changes and keeps existing callers identical regardless of how the
           # action handles an empty `file:` input.
           file: ${{ inputs.external_repo != '' && format('{0}/Dockerfile', inputs.external_path) || format('{0}/Dockerfile', inputs.context) }}
+          # Empty target lets build-push-action build the Dockerfile's last
+          # stage (current behaviour). Service callers pass target: runtime to
+          # ship the hardened runtime stage instead of the trailing debug stage.
+          target: ${{ inputs.target }}
           platforms: ${{ inputs.platforms }}
           push: true
           tags: ${{ steps.meta.outputs.tags }}


### PR DESCRIPTION
## What

Add an optional `target` input to the `image-release.yml` reusable workflow, wired into the `docker/build-push-action` step.

```yaml
target:
  required: false
  type: string
  default: ""
```

```yaml
# Build and push step
target: ${{ inputs.target }}
```

## Why

The `Build and push` step had no `target:`, so Docker built the **last** stage of each Dockerfile. For service images (`dcf-platform`, `dcf-access`, `dcf-service`, `dcf-proxy`) the last stage is `debug` (shell + `curl`/`vim`/`wget` on a `-dev` base), meaning release was shipping the debug image — e.g. `ghcr.io/nics-dp/dcf-access:v0.2.4` contained `vim`, which only the debug stage installs. That is the root cause of the bulk of the HIGH/CRITICAL findings on release images.

## Design choice: default empty, not `runtime`

The default is intentionally `""` (build last stage) rather than `runtime`:

- `otel-bundle` last stage is `alpine-base`, `patroni` is `postgres`, `synth` is `final` — none have a `runtime` stage.
- A default of `runtime` would turn those currently-green repos red.

Service callers opt in explicitly with `target: runtime` in follow-up per-repo PRs.

## Verification

- `actionlint` clean.
- Callers that don't pass `target` are byte-for-byte unaffected (empty input → build-push-action omits `--target`).