### PR TITLE
ci(security): stop persisting credentials on untrusted-ref checkouts

### DIFF
--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -105,6 +105,10 @@ jobs:
         with:
           ref: ${{ inputs.ref }}
           fetch-depth: 0
+          # The ref is a workflow_call input and may be attacker-influenced;
+          # do not persist the GITHUB_TOKEN into the checkout so later steps
+          # cannot be coerced into using it (CodeQL actions/untrusted-checkout).
+          persist-credentials: false
 
       - name: Compute version
         id: version
@@ -168,6 +172,10 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ inputs.ref }}
+          # The ref is a workflow_call input and may be attacker-influenced;
+          # do not persist the GITHUB_TOKEN. Private module access is granted
+          # separately via gh_pat (CodeQL actions/untrusted-checkout).
+          persist-credentials: false
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
@@ -335,6 +343,10 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ inputs.ref }}
+          # The ref is a workflow_call input and may be attacker-influenced;
+          # do not persist the GITHUB_TOKEN. Release upload authenticates via
+          # the explicit GH_TOKEN env below (CodeQL actions/untrusted-checkout).
+          persist-credentials: false
 
       - name: Download all build artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1

--- a/.github/workflows/sbom-image.yml
+++ b/.github/workflows/sbom-image.yml
@@ -52,6 +52,10 @@ jobs:
         with:
           ref: ${{ inputs.ref }}
           fetch-depth: 1
+          # The ref is a workflow_call input and may be attacker-influenced;
+          # do not persist the GITHUB_TOKEN into the checkout so later steps
+          # cannot be coerced into using it (CodeQL actions/untrusted-checkout).
+          persist-credentials: false
 
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0

--- a/.github/workflows/sbom-source.yml
+++ b/.github/workflows/sbom-source.yml
@@ -50,6 +50,10 @@ jobs:
         with:
           ref: ${{ inputs.ref }}
           fetch-depth: 1
+          # The ref is a workflow_call input and may be attacker-influenced;
+          # do not persist the GITHUB_TOKEN. Private module access is granted
+          # separately via gh_pat (CodeQL actions/untrusted-checkout).
+          persist-credentials: false
 
       - name: Configure git for private modules
         env:


### PR DESCRIPTION
## 摘要
解決 CodeQL `actions/untrusted-checkout/medium` - reusable workflow checkout `workflow_call` 的 `inputs.ref` (呼叫端可影響) 時, 不應將 `GITHUB_TOKEN` 持久化到 git config.

## 變更
為以下 checkout 加上 `persist-credentials: false`:
- `go-release.yml`: `prepare` / `build` / `release` 三個 job 的 checkout (alert lines 104, 168, 335).
- `sbom-source.yml`: checkout (line 48).
- `sbom-image.yml`: checkout (line 50).

## 為何安全 (不破壞既有功能)
- 私有 Go module 存取由 `gh_pat` 透過獨立的 `git config url.insteadOf` 設定, 與 checkout 持久化 token 無關.
- `go-release` 的 release upload 使用步驟層級顯式的 `GH_TOKEN` env, source archive 用 `git archive HEAD` (本地操作).
- sbom 流程的 SARIF 上傳走 action 的 GITHUB_TOKEN env, 非 git 持久化憑證.

## 備註
- `image-release.yml` 的兩個對應 alert 在當前 dev 已帶 `persist-credentials: false` (lines 175, 459); 那兩個 alert 係於較舊 commit 掃出, rescan 後會自動關閉.

## 驗證
- `actionlint` 通過; YAML parse OK.
