### PR TITLE
ci(codeql): also run CodeQL on push to dev

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -4,7 +4,7 @@ name: "CodeQL Advanced"
 
 on:
   push:
-    branches: ["main"]
+    branches: ["main", "dev"]
     paths-ignore:
       - "**/*.md"
       - "**/*.txt"


### PR DESCRIPTION
## 摘要
讓 CodeQL 的 push 分析也涵蓋 `dev`（目前只有 `main`）。

## 背景
`dev` 是 gitflow 的整合分支，但 `codeql.yml` 的 `push.branches` 只設了 `main`。因此修復合併進 `dev` 後，CodeQL 不會自動重掃 dev，alert 會卡在修復前狀態，直到每週一的排程或手動 dispatch 才更新（這次 untrusted-checkout 修復後就遇到此情況）。

## 變更
```yaml
 push:
-  branches: ["main"]
+  branches: ["main", "dev"]
```
PR / schedule / workflow_dispatch 觸發不變。

## 驗證
- `actionlint` clean、YAML parse OK
