### PR TITLE
feat(mise): add go:dev air live-reload task

### DIFF
--- a/.mise/tasks/go/dev
+++ b/.mise/tasks/go/dev
@@ -64,8 +64,16 @@ if [ -d vendor ]; then go_mod="vendor"; else go_mod="mod"; fi
 # Config-free fallback: drive air via flags so the task works in any Go repo
 # without committing an .air.toml. Use -build.entrypoint (the deprecated
 # -build.bin flag is NOT honored for the run step) and watch go/mod/sum.
+#
+# air runs -build.cmd via /bin/sh -c, so the ldflags string is re-parsed by a
+# shell. Single-quote ${VERSION_LDFLAGS} (not double) so that shell does NOT
+# re-expand it: a VERSION/COMMIT override containing $(...) or backticks would
+# otherwise be command-substituted at air's shell stage. lib/go-version already
+# rejects whitespace/quotes but NOT $ or backticks, so single-quoting here is
+# the layer that neutralizes those. VERSION_LDFLAGS never contains a single
+# quote (lib/go-version rejects it), so the value passes through intact.
 air \
-  -build.cmd "go build -mod=${go_mod} -ldflags \"${VERSION_LDFLAGS}\" -o ./tmp/${usage_name} ./cmd/${usage_name}" \
+  -build.cmd "go build -mod=${go_mod} -ldflags '${VERSION_LDFLAGS}' -o ./tmp/${usage_name} ./cmd/${usage_name}" \
   -build.entrypoint "./tmp/${usage_name}" \
   -build.include_ext "go,mod,sum" \
   -build.exclude_dir "vendor,tmp,bin,test,testdata,asset,deploy,scripts"

--- a/.mise/tasks/go/dev
+++ b/.mise/tasks/go/dev
@@ -55,11 +55,17 @@ if [ ! -f "cmd/$usage_name/main.go" ]; then
   exit 1
 fi
 
+# Pick the module mode the same way lib/go-env does: -mod=vendor only when a
+# vendor/ tree exists, otherwise -mod=mod. Hard-coding -mod=vendor would make
+# `go build` fail with "inconsistent vendoring" on a non-vendored repo, which
+# contradicts the "any Go repo" claim below.
+if [ -d vendor ]; then go_mod="vendor"; else go_mod="mod"; fi
+
 # Config-free fallback: drive air via flags so the task works in any Go repo
 # without committing an .air.toml. Use -build.entrypoint (the deprecated
 # -build.bin flag is NOT honored for the run step) and watch go/mod/sum.
 air \
-  -build.cmd "go build -mod=vendor -ldflags \"${VERSION_LDFLAGS}\" -o ./tmp/${usage_name} ./cmd/${usage_name}" \
+  -build.cmd "go build -mod=${go_mod} -ldflags \"${VERSION_LDFLAGS}\" -o ./tmp/${usage_name} ./cmd/${usage_name}" \
   -build.entrypoint "./tmp/${usage_name}" \
   -build.include_ext "go,mod,sum" \
   -build.exclude_dir "vendor,tmp,bin,test,testdata,asset,deploy,scripts"

--- a/.mise/tasks/go/dev
+++ b/.mise/tasks/go/dev
@@ -13,26 +13,46 @@ source "$(dirname "$0")/../lib/go-version"
 # go:build. lib/go-version sets these but does not export them.
 export VERSION COMMIT BUILD_DATE
 
+# A repo-local .air.toml wins (e.g. dcf services also watch embedded .sql). It
+# inherits VERSION/COMMIT/BUILD_DATE from the environment exported above, and
+# carries its own build.cmd/bin, so short-circuit here BEFORE the cmd/ auto-
+# detection below — that detection only feeds the config-free fallback, and a
+# repo with .air.toml may legitimately have multiple cmd entries or a non-
+# standard layout that would otherwise fail before air ever runs.
+if [ -f .air.toml ]; then
+  air -c .air.toml
+  exit $?
+fi
+
+# nullglob so an unmatched cmd/*/main.go expands to nothing (count 0) instead of
+# the literal pattern — otherwise the empty-repo case auto-detects usage_name='*'
+# and prints a misleading "cmd/*/main.go not found".
+shopt -s nullglob
 if [ "$usage_name" = "" ]; then
   entries=(cmd/*/main.go)
   if [ "${#entries[@]}" -eq 1 ]; then
     usage_name=$(basename "$(dirname "${entries[0]}")")
+  elif [ "${#entries[@]}" -eq 0 ]; then
+    echo "Error: no cmd/*/main.go found" >&2
+    exit 1
   else
     echo "Multiple cmd entries found. Please specify one of:"
     for e in "${entries[@]}"; do basename "$(dirname "$e")"; done
     exit 1
   fi
 fi
+# Reject a name containing path separators or traversal: usage_name is
+# interpolated into -build.cmd / -build.entrypoint / ./tmp/<name>, so a value
+# like "../x" or "a/b" would escape ./cmd and ./tmp.
+case "$usage_name" in
+  */* | *..*)
+    echo "Error: invalid name '$usage_name' (must not contain '/' or '..')" >&2
+    exit 1
+    ;;
+esac
 if [ ! -f "cmd/$usage_name/main.go" ]; then
   echo "Error: cmd/$usage_name/main.go not found"
   exit 1
-fi
-
-# A repo-local .air.toml wins (e.g. dcf services also watch embedded .sql). It
-# inherits VERSION/COMMIT/BUILD_DATE from the environment exported above.
-if [ -f .air.toml ]; then
-  air -c .air.toml
-  exit $?
 fi
 
 # Config-free fallback: drive air via flags so the task works in any Go repo

--- a/.mise/tasks/go/dev
+++ b/.mise/tasks/go/dev
@@ -41,15 +41,15 @@ if [ "$usage_name" = "" ]; then
     exit 1
   fi
 fi
-# Reject a name containing path separators or traversal: usage_name is
-# interpolated into -build.cmd / -build.entrypoint / ./tmp/<name>, so a value
-# like "../x" or "a/b" would escape ./cmd and ./tmp.
-case "$usage_name" in
-  */* | *..*)
-    echo "Error: invalid name '$usage_name' (must not contain '/' or '..')" >&2
-    exit 1
-    ;;
-esac
+# Allowlist-validate the name: it is interpolated into -build.cmd, which air
+# runs via /bin/sh -c, so a name with whitespace/quotes/`;`/`$`/backticks would
+# be a shell-injection vector (and `/` or `..` would escape ./cmd / ./tmp).
+# Restrict to a safe character set that still covers real Go cmd dir names
+# (letters, digits, dot, underscore, dash), and reject `..` traversal.
+if ! [[ "$usage_name" =~ ^[A-Za-z0-9._-]+$ ]] || [[ "$usage_name" == *..* ]]; then
+  echo "Error: invalid name '$usage_name' (allowed: letters, digits, '.', '_', '-'; no '..')" >&2
+  exit 1
+fi
 if [ ! -f "cmd/$usage_name/main.go" ]; then
   echo "Error: cmd/$usage_name/main.go not found"
   exit 1

--- a/.mise/tasks/go/dev
+++ b/.mise/tasks/go/dev
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+#MISE description="Run a Go cmd from cmd/ with air live-reload (hot reload on save)"
+#MISE hide=true
+#MISE raw=true
+#MISE tools={"go:github.com/air-verse/air"="v1.65.3"}
+#USAGE arg "[name]" help="Script name to run (auto-detected if cmd/ has only one entry)"
+# shellcheck disable=SC2154 # usage_name is set by mise USAGE
+
+# shellcheck disable=SC1091
+source "$(dirname "$0")/../lib/go-version"
+# Export so a repo-local .air.toml's `${VERSION:-dev}` ldflags expansion (which
+# air runs via the shell) inherits the same git-derived version as go:run /
+# go:build. lib/go-version sets these but does not export them.
+export VERSION COMMIT BUILD_DATE
+
+if [ "$usage_name" = "" ]; then
+  entries=(cmd/*/main.go)
+  if [ "${#entries[@]}" -eq 1 ]; then
+    usage_name=$(basename "$(dirname "${entries[0]}")")
+  else
+    echo "Multiple cmd entries found. Please specify one of:"
+    for e in "${entries[@]}"; do basename "$(dirname "$e")"; done
+    exit 1
+  fi
+fi
+if [ ! -f "cmd/$usage_name/main.go" ]; then
+  echo "Error: cmd/$usage_name/main.go not found"
+  exit 1
+fi
+
+# A repo-local .air.toml wins (e.g. dcf services also watch embedded .sql). It
+# inherits VERSION/COMMIT/BUILD_DATE from the environment exported above.
+if [ -f .air.toml ]; then
+  air -c .air.toml
+  exit $?
+fi
+
+# Config-free fallback: drive air via flags so the task works in any Go repo
+# without committing an .air.toml. Use -build.entrypoint (the deprecated
+# -build.bin flag is NOT honored for the run step) and watch go/mod/sum.
+air \
+  -build.cmd "go build -mod=vendor -ldflags \"${VERSION_LDFLAGS}\" -o ./tmp/${usage_name} ./cmd/${usage_name}" \
+  -build.entrypoint "./tmp/${usage_name}" \
+  -build.include_ext "go,mod,sum" \
+  -build.exclude_dir "vendor,tmp,bin,test,testdata,asset,deploy,scripts"

--- a/.mise/tasks/go/dev
+++ b/.mise/tasks/go/dev
@@ -36,8 +36,8 @@ if [ "$usage_name" = "" ]; then
     echo "Error: no cmd/*/main.go found" >&2
     exit 1
   else
-    echo "Multiple cmd entries found. Please specify one of:"
-    for e in "${entries[@]}"; do basename "$(dirname "$e")"; done
+    echo "Multiple cmd entries found. Please specify one of:" >&2
+    for e in "${entries[@]}"; do basename "$(dirname "$e")"; done >&2
     exit 1
   fi
 fi
@@ -51,7 +51,7 @@ if ! [[ "$usage_name" =~ ^[A-Za-z0-9._-]+$ ]] || [[ "$usage_name" == *..* ]]; th
   exit 1
 fi
 if [ ! -f "cmd/$usage_name/main.go" ]; then
-  echo "Error: cmd/$usage_name/main.go not found"
+  echo "Error: cmd/$usage_name/main.go not found" >&2
   exit 1
 fi
 

--- a/templates/facades/mise.go-service.toml
+++ b/templates/facades/mise.go-service.toml
@@ -56,6 +56,10 @@ depends = ["go:build"]
 description = "Run Go service from cmd/"
 depends = ["go:run"]
 
+[tasks.dev]
+description = "Run Go service from cmd/ with air live-reload (hot reload on save)"
+depends = ["go:dev"]
+
 [tasks.bench]
 description = "Run Go benchmarks (single pass)"
 depends = ["go:test --bench"]


### PR DESCRIPTION
## 摘要
新增共享 mise atom `go:dev`,以 **air** (air-verse/air) 做本地開發的 live hot-reload,並在 go-service facade 暴露為 `dev` vocabulary task (`mise run dev`).

## 變更
- `.mise/tasks/go/dev` (new): 沿用 `go:run` 的 cmd 自動偵測;air 透過 mise `go:` backend 佈建 (header `#MISE tools={"go:github.com/air-verse/air"="v1.65.3"}`),consumer 免手動安裝.
  - 優先用 repo-local `.air.toml` (例如 dcf services 另監看 embedded `.sql`);否則以 flag 驅動 (config-free) 跑 air.
  - 使用 `-build.entrypoint` (deprecated 的 `-build.bin` flag 在 run 階段不生效,已實測);監看 `go,mod,sum`.
  - 版本注入比照 `go:run`:source `lib/go-version` 取得 `VERSION_LDFLAGS`,並 export `VERSION/COMMIT/BUILD_DATE` 供 `.air.toml` 路徑的 ldflags 展開.
- `templates/facades/mise.go-service.toml`: 新增 `[tasks.dev] depends=["go:dev"]`.

## 驗證 (air v1.65.3 本地實測)
- `.air.toml` 的 `bin` key 會正確執行目標 binary (HELLO smoke test 通過).
- flag fallback: `-build.bin` flag 壞 (退回預設 `./tmp/main`),改用 `-build.entrypoint` 正確執行;`-build.cmd` 內嵌 `-ldflags` 注入版本實測 `VER=9.9.9-flagtest` 正確.
- `bash -n` 通過;facade toml parse OK.

## 用法
- consumer repo 有 `.air.toml`: `mise run dev` -> air 監看重載.
- 無 `.air.toml`: 仍可 `mise run dev`,flag 驅動.

## 備註
此為 host 端 (mise) 開發用;Docker compose dev 容器內無 mise,維持自包含的 air 啟動 (見各 service repo 的 compose).
