### PR TITLE
ci: prefer nics-dp-ci-read app token for private modules (PAT->App stage 1)

### DIFF
--- a/.github/workflows/codeql-reusable.yml
+++ b/.github/workflows/codeql-reusable.yml
@@ -27,6 +27,12 @@ on:
     secrets:
       GH_PAT_READ_NICSDP:
         required: false
+      ci_read_app_id:
+        required: false
+        description: "App ID of the nics-dp-ci-read GitHub App. Preferred over GH_PAT_READ_NICSDP for private module access; pass via secrets: inherit. Falls back to the PAT when empty."
+      ci_read_app_private_key:
+        required: false
+        description: "Private key of the nics-dp-ci-read GitHub App (pair with ci_read_app_id)."
 
 jobs:
   analyze:
@@ -38,6 +44,8 @@ jobs:
       actions: read
       contents: read
     env:
+      # secrets cannot be used in step-level if:, so bridge them to env here.
+      HAS_CI_APP: ${{ secrets.ci_read_app_id != '' }}
       HAS_GH_PAT: ${{ secrets.GH_PAT_READ_NICSDP != '' }}
       USE_PRIVATE_GO: ${{ inputs.use-private-go-modules }}
 
@@ -47,13 +55,25 @@ jobs:
         include: ${{ fromJSON(inputs.matrix-include) }}
 
     steps:
+      # Prefer a nics-dp-ci-read App token for private module access. The App secrets
+      # arrive via `secrets: inherit`; when absent (legacy callers) the step is skipped
+      # and the later steps fall back to GH_PAT_READ_NICSDP. See nics-dp PAT->App migration.
+      - name: Setup | Mint private-module token
+        id: priv-token
+        if: env.HAS_CI_APP == 'true'
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
+        with:
+          app-id: ${{ secrets.ci_read_app_id }}
+          private-key: ${{ secrets.ci_read_app_private_key }}
+          owner: ${{ github.repository_owner }}
+
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           submodules: ${{ inputs.submodules }}
           # Use PAT only when checking out submodules (likely private nics-dp repos);
           # default github.token suffices for the main repo and reduces token surface.
-          token: ${{ inputs.submodules != 'false' && secrets.GH_PAT_READ_NICSDP || github.token }}
+          token: ${{ inputs.submodules != 'false' && (steps.priv-token.outputs.token || secrets.GH_PAT_READ_NICSDP) || github.token }}
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
@@ -62,12 +82,12 @@ jobs:
           build-mode: ${{ matrix.build-mode }}
           dependency-caching: true
           queries: security-extended,security-and-quality
-          external-repository-token: ${{ secrets.GH_PAT_READ_NICSDP }}
+          external-repository-token: ${{ steps.priv-token.outputs.token || secrets.GH_PAT_READ_NICSDP }}
 
       - name: Configure access to private Go modules
-        if: matrix.language == 'go' && env.USE_PRIVATE_GO == 'true' && env.HAS_GH_PAT == 'true'
+        if: matrix.language == 'go' && env.USE_PRIVATE_GO == 'true' && (env.HAS_CI_APP == 'true' || env.HAS_GH_PAT == 'true')
         env:
-          GH_PAT: ${{ secrets.GH_PAT_READ_NICSDP }}
+          GH_PAT: ${{ steps.priv-token.outputs.token || secrets.GH_PAT_READ_NICSDP }}
         run: |
           {
             echo "GOPRIVATE=github.com/nics-dp"
@@ -87,9 +107,9 @@ jobs:
           go build -mod=vendor ./...
 
       - name: Revoke private module access
-        if: always() && matrix.language == 'go' && env.USE_PRIVATE_GO == 'true' && env.HAS_GH_PAT == 'true'
+        if: always() && matrix.language == 'go' && env.USE_PRIVATE_GO == 'true' && (env.HAS_CI_APP == 'true' || env.HAS_GH_PAT == 'true')
         env:
-          GH_PAT: ${{ secrets.GH_PAT_READ_NICSDP }}
+          GH_PAT: ${{ steps.priv-token.outputs.token || secrets.GH_PAT_READ_NICSDP }}
         run: |
           git config --global --remove-section "url.https://${GH_PAT}@github.com/nics-dp" 2>/dev/null || true
           git config --global --remove-section "url.https://${GH_PAT}@github.com/nics-dp/" 2>/dev/null || true

--- a/.github/workflows/codeql-reusable.yml
+++ b/.github/workflows/codeql-reusable.yml
@@ -45,7 +45,7 @@ jobs:
       contents: read
     env:
       # secrets cannot be used in step-level if:, so bridge them to env here.
-      HAS_CI_APP: ${{ secrets.ci_read_app_id != '' }}
+      HAS_CI_APP: ${{ secrets.ci_read_app_id != '' && secrets.ci_read_app_private_key != '' }}
       HAS_GH_PAT: ${{ secrets.GH_PAT_READ_NICSDP != '' }}
       USE_PRIVATE_GO: ${{ inputs.use-private-go-modules }}
 

--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -80,6 +80,12 @@ on:
     secrets:
       gh_pat:
         required: false
+      ci_read_app_id:
+        required: false
+        description: "App ID of the nics-dp-ci-read GitHub App. Preferred over gh_pat for private module access; pass via secrets: inherit. Falls back to gh_pat when empty."
+      ci_read_app_private_key:
+        required: false
+        description: "Private key of the nics-dp-ci-read GitHub App (pair with ci_read_app_id)."
       quill_sign_p12:
         required: false
       quill_sign_password:
@@ -167,14 +173,28 @@ jobs:
       fail-fast: false
       matrix: ${{ fromJSON(needs.prepare.outputs.matrix) }}
     env:
+      # secrets cannot be used in step-level if:, so bridge them to env here.
+      HAS_CI_APP: ${{ secrets.ci_read_app_id != '' }}
       HAS_GH_PAT: ${{ secrets.gh_pat != '' }}
     steps:
+      # Prefer a nics-dp-ci-read App token for private module access. The App secrets
+      # arrive via `secrets: inherit`; when absent (legacy callers) the step is skipped
+      # and the later steps fall back to gh_pat. See nics-dp PAT->App migration.
+      - name: Setup | Mint private-module token
+        id: priv-token
+        if: env.HAS_CI_APP == 'true'
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
+        with:
+          app-id: ${{ secrets.ci_read_app_id }}
+          private-key: ${{ secrets.ci_read_app_private_key }}
+          owner: ${{ github.repository_owner }}
+
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ inputs.ref }}
           # The ref is a workflow_call input and may be attacker-influenced;
           # do not persist the GITHUB_TOKEN. Private module access is granted
-          # separately via gh_pat (CodeQL actions/untrusted-checkout).
+          # separately via the App token / gh_pat (CodeQL actions/untrusted-checkout).
           persist-credentials: false
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
@@ -183,9 +203,9 @@ jobs:
           cache: true
 
       - name: Configure private git repository
-        if: env.HAS_GH_PAT == 'true'
+        if: ${{ env.HAS_CI_APP == 'true' || env.HAS_GH_PAT == 'true' }}
         env:
-          GH_PAT: ${{ secrets.gh_pat }}
+          GH_PAT: ${{ steps.priv-token.outputs.token || secrets.gh_pat }}
           GO_PRIVATE_FULL: ${{ inputs.go_private_full }}
         run: |
           if [[ "$GO_PRIVATE_FULL" == "true" ]]; then
@@ -325,9 +345,9 @@ jobs:
           retention-days: ${{ inputs.snapshot && 7 || 30 }}
 
       - name: Revoke private git repository access
-        if: always() && env.HAS_GH_PAT == 'true'
+        if: ${{ always() && (env.HAS_CI_APP == 'true' || env.HAS_GH_PAT == 'true') }}
         env:
-          GH_PAT: ${{ secrets.gh_pat }}
+          GH_PAT: ${{ steps.priv-token.outputs.token || secrets.gh_pat }}
         run: |
           git config --global --remove-section "url.https://${GH_PAT}@github.com/nics-dp/" 2>/dev/null || true
           git config --global --remove-section "url.https://${GH_PAT}@github.com/nics-dp" 2>/dev/null || true

--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -174,7 +174,7 @@ jobs:
       matrix: ${{ fromJSON(needs.prepare.outputs.matrix) }}
     env:
       # secrets cannot be used in step-level if:, so bridge them to env here.
-      HAS_CI_APP: ${{ secrets.ci_read_app_id != '' }}
+      HAS_CI_APP: ${{ secrets.ci_read_app_id != '' && secrets.ci_read_app_private_key != '' }}
       HAS_GH_PAT: ${{ secrets.gh_pat != '' }}
     steps:
       # Prefer a nics-dp-ci-read App token for private module access. The App secrets

--- a/.github/workflows/image-release.yml
+++ b/.github/workflows/image-release.yml
@@ -128,7 +128,7 @@ on:
         required: true
       gh_pat:
         required: false
-        description: "Optional PAT for GitHub registry access; falls back to GITHUB_TOKEN when not provided (with its usual permission limits)."
+        description: "Fallback PAT for private module/repo access during checkout and build, used only when the ci_read_app_* App secrets are absent. GHCR push uses GITHUB_TOKEN, not this."
       ci_read_app_id:
         required: false
         description: "App ID of the nics-dp-ci-read GitHub App. Preferred over the PAT for private module access; pass via secrets: inherit. Falls back to the PAT when empty."

--- a/.github/workflows/image-release.yml
+++ b/.github/workflows/image-release.yml
@@ -129,6 +129,12 @@ on:
       gh_pat:
         required: false
         description: "Optional PAT for GitHub registry access; falls back to GITHUB_TOKEN when not provided (with its usual permission limits)."
+      ci_read_app_id:
+        required: false
+        description: "App ID of the nics-dp-ci-read GitHub App. Preferred over the PAT for private module access; pass via secrets: inherit. Falls back to the PAT when empty."
+      ci_read_app_private_key:
+        required: false
+        description: "Private key of the nics-dp-ci-read GitHub App (pair with ci_read_app_id)."
 
 env:
   REGISTRY_DH: docker.io
@@ -148,8 +154,24 @@ jobs:
       artifact-metadata: write
       attestations: write
       id-token: write
+    env:
+      # secrets cannot be used in step-level if:, so bridge them to env here.
+      HAS_CI_APP: ${{ secrets.ci_read_app_id != '' }}
+      HAS_GH_PAT: ${{ secrets.gh_pat != '' }}
 
     steps:
+      # Prefer a nics-dp-ci-read App token for private module access. The App secrets
+      # arrive via `secrets: inherit`; when absent (legacy callers) the step is skipped
+      # and the later steps fall back to gh_pat. See nics-dp PAT->App migration.
+      - name: Setup | Mint private-module token
+        id: priv-token
+        if: env.HAS_CI_APP == 'true'
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
+        with:
+          app-id: ${{ secrets.ci_read_app_id }}
+          private-key: ${{ secrets.ci_read_app_private_key }}
+          owner: ${{ github.repository_owner }}
+
       - name: Log in to DockerHub Container Registry
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
@@ -449,7 +471,7 @@ jobs:
           repository: ${{ inputs.external_repo }}
           ref: ${{ inputs.external_ref }}
           path: ${{ inputs.external_path }}
-          token: ${{ secrets.gh_pat || github.token }}
+          token: ${{ steps.priv-token.outputs.token || secrets.gh_pat || github.token }}
           # This checkout IS the docker build context. The token is still used
           # for the initial fetch, but must not be persisted afterwards: never
           # run authenticated git here, and keep credential material out of the
@@ -511,15 +533,17 @@ jobs:
       - name: Configure private modules and vendor
         if: inputs.go_vendor
         env:
-          HAS_GH_PAT: ${{ secrets.gh_pat != '' }}
-          GH_PAT: ${{ secrets.gh_pat }}
+          # Prefer the minted App token; fall back to gh_pat. HAS_PRIV is true
+          # when either credential is available.
+          HAS_PRIV: ${{ env.HAS_CI_APP == 'true' || env.HAS_GH_PAT == 'true' }}
+          GH_PAT: ${{ steps.priv-token.outputs.token || secrets.gh_pat }}
         run: |
-          if [[ "$HAS_GH_PAT" == "true" ]]; then
+          if [[ "$HAS_PRIV" == "true" ]]; then
             git config --global url."https://${GH_PAT}@github.com/nics-dp".insteadOf "https://github.com/nics-dp"
           fi
           go env -w GOPRIVATE=github.com/nics-dp GONOPROXY=github.com/nics-dp GONOSUMDB=github.com/nics-dp
           go mod vendor
-          if [[ "$HAS_GH_PAT" == "true" ]]; then
+          if [[ "$HAS_PRIV" == "true" ]]; then
             git config --global --remove-section "url.https://${GH_PAT}@github.com/nics-dp" 2>/dev/null || true
           fi
 
@@ -578,7 +602,7 @@ jobs:
             ${{ inputs.build_args }}
             ${{ steps.env-args.outputs.build_args }}
           secrets: |
-            github_token=${{ secrets.gh_pat || secrets.GITHUB_TOKEN }}
+            github_token=${{ steps.priv-token.outputs.token || secrets.gh_pat || secrets.GITHUB_TOKEN }}
           cache-from: type=registry,ref=${{ env.REGISTRY_GHCR }}/${{ env.GHCR_NAMESPACE }}/${{ env.IMAGE_NAME }}:buildcache
           cache-to: type=registry,ref=${{ env.REGISTRY_GHCR }}/${{ env.GHCR_NAMESPACE }}/${{ env.IMAGE_NAME }}:buildcache,mode=max
           sbom: ${{ inputs.sbom }}

--- a/.github/workflows/image-release.yml
+++ b/.github/workflows/image-release.yml
@@ -156,7 +156,7 @@ jobs:
       id-token: write
     env:
       # secrets cannot be used in step-level if:, so bridge them to env here.
-      HAS_CI_APP: ${{ secrets.ci_read_app_id != '' }}
+      HAS_CI_APP: ${{ secrets.ci_read_app_id != '' && secrets.ci_read_app_private_key != '' }}
       HAS_GH_PAT: ${{ secrets.gh_pat != '' }}
 
     steps:

--- a/.github/workflows/mise-task.yml
+++ b/.github/workflows/mise-task.yml
@@ -54,6 +54,12 @@ on:
       gh_pat:
         description: "GitHub PAT with read access to private modules (required when private-modules=true)"
         required: false
+      ci_read_app_id:
+        required: false
+        description: "App ID of the nics-dp-ci-read GitHub App. Preferred over gh_pat for private module access; pass via secrets: inherit. Falls back to gh_pat when empty."
+      ci_read_app_private_key:
+        required: false
+        description: "Private key of the nics-dp-ci-read GitHub App (pair with ci_read_app_id)."
 
 permissions:
   contents: read
@@ -79,7 +85,22 @@ jobs:
     env:
       MISE_MINIMUM_RELEASE_AGE: "0"
       MISE_USE_VERSIONS_HOST: "false"
+      # secrets cannot be used in step-level if:, so bridge them to env here.
+      HAS_CI_APP: ${{ secrets.ci_read_app_id != '' }}
+      HAS_GH_PAT: ${{ secrets.gh_pat != '' }}
     steps:
+      # Prefer a nics-dp-ci-read App token for private module access. The App secrets
+      # arrive via `secrets: inherit`; when absent (legacy callers) the step is skipped
+      # and the git-config below falls back to gh_pat. See nics-dp PAT->App migration.
+      - name: Setup | Mint private-module token
+        id: priv-token
+        if: env.HAS_CI_APP == 'true'
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
+        with:
+          app-id: ${{ secrets.ci_read_app_id }}
+          private-key: ${{ secrets.ci_read_app_private_key }}
+          owner: ${{ github.repository_owner }}
+
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: ${{ inputs.fetch-depth }}
@@ -92,10 +113,10 @@ jobs:
       - name: Configure git for private modules
         if: ${{ inputs.private-modules }}
         env:
-          GH_PAT: ${{ secrets.gh_pat }}
+          GH_PAT: ${{ steps.priv-token.outputs.token || secrets.gh_pat }}
         run: |
           if [ -z "$GH_PAT" ]; then
-            echo "::warning::private-modules=true but gh_pat secret is empty"
+            echo "::warning::private-modules=true but neither the ci-read App token nor gh_pat is available"
             exit 0
           fi
           git config --global url."https://x-access-token:${GH_PAT}@github.com/nics-dp/".insteadOf "https://github.com/nics-dp/"

--- a/.github/workflows/mise-task.yml
+++ b/.github/workflows/mise-task.yml
@@ -86,7 +86,7 @@ jobs:
       MISE_MINIMUM_RELEASE_AGE: "0"
       MISE_USE_VERSIONS_HOST: "false"
       # secrets cannot be used in step-level if:, so bridge them to env here.
-      HAS_CI_APP: ${{ secrets.ci_read_app_id != '' }}
+      HAS_CI_APP: ${{ secrets.ci_read_app_id != '' && secrets.ci_read_app_private_key != '' }}
       HAS_GH_PAT: ${{ secrets.gh_pat != '' }}
     steps:
       # Prefer a nics-dp-ci-read App token for private module access. The App secrets

--- a/.github/workflows/mise-task.yml
+++ b/.github/workflows/mise-task.yml
@@ -85,16 +85,16 @@ jobs:
     env:
       MISE_MINIMUM_RELEASE_AGE: "0"
       MISE_USE_VERSIONS_HOST: "false"
-      # secrets cannot be used in step-level if:, so bridge them to env here.
+      # secrets cannot be used in step-level if:, so bridge to env here.
       HAS_CI_APP: ${{ secrets.ci_read_app_id != '' && secrets.ci_read_app_private_key != '' }}
-      HAS_GH_PAT: ${{ secrets.gh_pat != '' }}
     steps:
-      # Prefer a nics-dp-ci-read App token for private module access. The App secrets
-      # arrive via `secrets: inherit`; when absent (legacy callers) the step is skipped
-      # and the git-config below falls back to gh_pat. See nics-dp PAT->App migration.
+      # Prefer a nics-dp-ci-read App token for private module access, but only when this
+      # run actually needs private modules. The App secrets arrive via `secrets: inherit`;
+      # when absent (legacy callers) the step is skipped and the git-config below falls
+      # back to gh_pat. See nics-dp PAT->App migration.
       - name: Setup | Mint private-module token
         id: priv-token
-        if: env.HAS_CI_APP == 'true'
+        if: ${{ env.HAS_CI_APP == 'true' && inputs.private-modules }}
         uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
         with:
           app-id: ${{ secrets.ci_read_app_id }}

--- a/.github/workflows/mise-task.yml
+++ b/.github/workflows/mise-task.yml
@@ -52,7 +52,7 @@ on:
         default: false
     secrets:
       gh_pat:
-        description: "GitHub PAT with read access to private modules (required when private-modules=true)"
+        description: "Fallback PAT (read access to private modules) used only when the ci_read_app_* App secrets are not provided. Relevant when private-modules=true."
         required: false
       ci_read_app_id:
         required: false

--- a/.github/workflows/sbom-source.yml
+++ b/.github/workflows/sbom-source.yml
@@ -51,9 +51,8 @@ jobs:
       contents: write
       security-events: write
     env:
-      # secrets cannot be used in step-level if:, so bridge them to env here.
+      # secrets cannot be used in step-level if:, so bridge to env here.
       HAS_CI_APP: ${{ secrets.ci_read_app_id != '' && secrets.ci_read_app_private_key != '' }}
-      HAS_GH_PAT: ${{ secrets.gh_pat != '' }}
     steps:
       # Prefer a nics-dp-ci-read App token for private module access. The App secrets
       # arrive via `secrets: inherit`; when absent (legacy callers) the step is skipped

--- a/.github/workflows/sbom-source.yml
+++ b/.github/workflows/sbom-source.yml
@@ -33,6 +33,12 @@ on:
       gh_pat:
         required: false
         description: "Optional PAT for private Go module access"
+      ci_read_app_id:
+        required: false
+        description: "App ID of the nics-dp-ci-read GitHub App. Preferred over the PAT for private module access; pass via secrets: inherit. Falls back to the PAT when empty."
+      ci_read_app_private_key:
+        required: false
+        description: "Private key of the nics-dp-ci-read GitHub App (pair with ci_read_app_id)."
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
@@ -44,7 +50,23 @@ jobs:
       actions: read
       contents: write
       security-events: write
+    env:
+      # secrets cannot be used in step-level if:, so bridge them to env here.
+      HAS_CI_APP: ${{ secrets.ci_read_app_id != '' }}
+      HAS_GH_PAT: ${{ secrets.gh_pat != '' }}
     steps:
+      # Prefer a nics-dp-ci-read App token for private module access. The App secrets
+      # arrive via `secrets: inherit`; when absent (legacy callers) the step is skipped
+      # and the git-config below falls back to gh_pat. See nics-dp PAT->App migration.
+      - name: Setup | Mint private-module token
+        id: priv-token
+        if: env.HAS_CI_APP == 'true'
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
+        with:
+          app-id: ${{ secrets.ci_read_app_id }}
+          private-key: ${{ secrets.ci_read_app_private_key }}
+          owner: ${{ github.repository_owner }}
+
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -57,7 +79,7 @@ jobs:
 
       - name: Configure git for private modules
         env:
-          GH_PAT: ${{ secrets.gh_pat }}
+          GH_PAT: ${{ steps.priv-token.outputs.token || secrets.gh_pat }}
         run: |
           if [ -n "$GH_PAT" ]; then
             git config --global url."https://x-access-token:${GH_PAT}@github.com/".insteadOf "https://github.com/"

--- a/.github/workflows/sbom-source.yml
+++ b/.github/workflows/sbom-source.yml
@@ -52,7 +52,7 @@ jobs:
       security-events: write
     env:
       # secrets cannot be used in step-level if:, so bridge them to env here.
-      HAS_CI_APP: ${{ secrets.ci_read_app_id != '' }}
+      HAS_CI_APP: ${{ secrets.ci_read_app_id != '' && secrets.ci_read_app_private_key != '' }}
       HAS_GH_PAT: ${{ secrets.gh_pat != '' }}
     steps:
       # Prefer a nics-dp-ci-read App token for private module access. The App secrets


### PR DESCRIPTION
## 摘要
PAT -> GitHub App 遷移**階段 1（meta，零破壞）**：讓 5 個 reusable workflows 優先使用 `nics-dp-ci-read` App token 取得私有 Go module 存取權，App secrets 不存在時**自動 fallback 回原本的 PAT**（`gh_pat` / `GH_PAT_READ_NICSDP`）。

**完全向後相容**：現有 caller（具名傳 `gh_pat`、未用 `secrets: inherit`）行為不變——App secrets 取不到時 mint step 直接 skip，所有 token 消費點 fall through 到原值。

## 變更（5 個 reusable workflows）
每個檔都加：
1. `workflow_call.secrets` 新增 optional `ci_read_app_id` / `ci_read_app_private_key`（保留既有 PAT secret 當 fallback）
2. job-level `env:` 橋接 `HAS_CI_APP` / `HAS_GH_PAT`（因為 `secrets` context 不能用在 step-level `if:`）
3. 第一個 step：`Setup | Mint private-module token`（`if: env.HAS_CI_APP == 'true'`，`create-github-app-token@v2.2.2`，`owner: github.repository_owner`）
4. token 消費點改為 `${{ steps.priv-token.outputs.token || <原 PAT> }}`（在 step `env:` / action `with:` 內，允許 secrets+steps context）

| 檔案 | job | 備註 |
|---|---|---|
| go-release.yml | build | 樣板 |
| image-release.yml | build-and-push | GHCR 登入仍用 GITHUB_TOKEN（未動）；vendor 步驟用內部 `HAS_PRIV` shell flag |
| sbom-source.yml | sbom-source | 腳本內 `[ -n "$GH_PAT" ]` guard 不變 |
| mise-task.yml | run | 受 `private-modules` input 控制 |
| codeql-reusable.yml | analyze | 用 `GH_PAT_READ_NICSDP` 當 fallback；submodule token 三元加括號保 precedence |

## 不在本 PR 範圍
- **caller 端不動**（階段 2 才逐 repo 改成 `secrets: inherit`）
- 待全部 caller 遷移後，階段 3 再移除 PAT fallback 並刪 `GH_PAT_READ_NICSDP`

## 驗證
- 5 個檔 `actionlint` 全 clean、YAML parse OK
- 無任何 `secrets.*` 出現在 step-level `if:`（GitHub 限制）
