### PR TITLE
fix(mise): align go:run with go:dev for correctness and consistency

### DIFF
--- a/.mise/tasks/go/run
+++ b/.mise/tasks/go/run
@@ -9,18 +9,34 @@
 # shellcheck disable=SC1091
 source "$(dirname "$0")/../lib/go-version"
 
+# nullglob so an unmatched cmd/*/main.go expands to nothing (count 0) instead of
+# the literal pattern — otherwise an empty repo auto-detects usage_name='*' and
+# prints a misleading "cmd/*/main.go not found".
+shopt -s nullglob
 if [ "$usage_name" = "" ]; then
   entries=(cmd/*/main.go)
   if [ "${#entries[@]}" -eq 1 ]; then
     usage_name=$(basename "$(dirname "${entries[0]}")")
+  elif [ "${#entries[@]}" -eq 0 ]; then
+    echo "Error: no cmd/*/main.go found" >&2
+    exit 1
   else
-    echo "Multiple cmd entries found. Please specify one of:"
-    for e in "${entries[@]}"; do basename "$(dirname "$e")"; done
+    echo "Multiple cmd entries found. Please specify one of:" >&2
+    for e in "${entries[@]}"; do basename "$(dirname "$e")"; done >&2
     exit 1
   fi
 fi
+# Allowlist-validate the name: it is interpolated into the "./cmd/$usage_name"
+# path, so restrict to a safe set and reject `..` to prevent escaping ./cmd.
+# (Unlike go:dev this value is not re-parsed by a second shell, so it is not a
+# shell-injection vector; the guard blocks path traversal and keeps the two
+# atoms consistent.)
+if ! [[ "$usage_name" =~ ^[A-Za-z0-9._-]+$ ]] || [[ "$usage_name" == *..* ]]; then
+  echo "Error: invalid name '$usage_name' (allowed: letters, digits, '.', '_', '-'; no '..')" >&2
+  exit 1
+fi
 if [ ! -f "cmd/$usage_name/main.go" ]; then
-  echo "Error: cmd/$usage_name/main.go not found"
+  echo "Error: cmd/$usage_name/main.go not found" >&2
   exit 1
 fi
 # usage_args is a shell-escaped string for a variadic arg; eval into an array
@@ -31,4 +47,12 @@ if ! eval "args=(${usage_args:-})"; then
   echo "Error: failed to parse arguments: ${usage_args:-}" >&2
   exit 1
 fi
-go run -mod=vendor -ldflags "${VERSION_LDFLAGS}" "./cmd/$usage_name" "${args[@]}"
+# Module mode by repo layout (mirrors lib/go-env): -mod=vendor only when a
+# vendor/ tree exists, else -mod=mod — hard-coding vendor breaks a non-vendored
+# repo with "inconsistent vendoring".
+if [ -d vendor ]; then go_mod="vendor"; else go_mod="mod"; fi
+# ${VERSION_LDFLAGS} stays double-quoted (unlike go:dev's single-quote): this
+# `go run` is exec'd directly by this shell, so the value is expanded once and
+# NOT re-parsed by a second shell — there is no command-substitution stage to
+# guard against here.
+go run -mod="${go_mod}" -ldflags "${VERSION_LDFLAGS}" "./cmd/$usage_name" "${args[@]}"


### PR DESCRIPTION
## 摘要
在確保正確性的前提下, 將既有的 `go:run` atom 與新加的 `go:dev` 對齊一致.

## 變更 (.mise/tasks/go/run)
- **module mode 依 repo 結構選擇**: 有 `vendor/` 才 `-mod=vendor`, 否則 `-mod=mod` (對齊 `lib/go-env`). 原本寫死 `-mod=vendor` 會讓未 vendor 的 repo 以 "inconsistent vendoring" 失敗 -> 正確性修正.
- **`shopt -s nullglob` + 明確的 zero-entry 錯誤**: 空 repo 給清楚錯誤, 而非自動偵測成 `usage_name='*'` -> 正確性修正.
- **錯誤訊息導向 stderr** (原本印到 stdout) -> 一致性.
- **name allowlist + 拒絕 `..`**: name 會插入 `./cmd/$name` 路徑, 加 allowlist 防止逸出 ./cmd (path traversal); 與 go:dev 一致.

## 引號的正確性說明 (刻意與 go:dev 不同)
- `go:run` 直接由本 shell `exec` `go run` -> `${VERSION_LDFLAGS}` 只展開一次, **不會被第二個 shell 重新解析** -> **維持雙引號** (正確).
- `go:dev` 的 flag fallback 是把 cmd 字串交給 air 的 `/bin/sh -c` **重新解析** -> 需 **單引號** 阻止 `$(...)`/backtick 二次命令替換.
- 兩者引號不同是**因應各自的執行模型**, 都正確; 已在程式碼註解說明, 避免後續維護者誤改.

## 驗證
- `bash -n` + `shellcheck` 皆 clean.
