### PR TITLE
ci: drop gh_pat fallback from reusable workflows (PAT->App stage 3)

### DIFF
--- a/.github/workflows/codeql-reusable.yml
+++ b/.github/workflows/codeql-reusable.yml
@@ -25,11 +25,9 @@ on:
         type: string
         default: "false"
     secrets:
-      GH_PAT_READ_NICSDP:
-        required: false
       ci_read_app_id:
         required: false
-        description: "App ID of the nics-dp-ci-read GitHub App. Preferred over GH_PAT_READ_NICSDP for private module access; pass via secrets: inherit. Falls back to the PAT when empty."
+        description: "App ID of the nics-dp-ci-read GitHub App for private module access (pass via secrets: inherit)."
       ci_read_app_private_key:
         required: false
         description: "Private key of the nics-dp-ci-read GitHub App (pair with ci_read_app_id)."
@@ -44,9 +42,8 @@ jobs:
       actions: read
       contents: read
     env:
-      # secrets cannot be used in step-level if:, so bridge them to env here.
+      # secrets cannot be used in step-level if:, so bridge to env here.
       HAS_CI_APP: ${{ secrets.ci_read_app_id != '' && secrets.ci_read_app_private_key != '' }}
-      HAS_GH_PAT: ${{ secrets.GH_PAT_READ_NICSDP != '' }}
       USE_PRIVATE_GO: ${{ inputs.use-private-go-modules }}
 
     strategy:
@@ -55,9 +52,8 @@ jobs:
         include: ${{ fromJSON(inputs.matrix-include) }}
 
     steps:
-      # Prefer a nics-dp-ci-read App token for private module access. The App secrets
-      # arrive via `secrets: inherit`; when absent (legacy callers) the step is skipped
-      # and the later steps fall back to GH_PAT_READ_NICSDP. See nics-dp PAT->App migration.
+      # Mint a nics-dp-ci-read App token for private module access. The App secrets
+      # arrive via `secrets: inherit`; when absent the private-module steps are skipped.
       - name: Setup | Mint private-module token
         id: priv-token
         if: env.HAS_CI_APP == 'true'
@@ -71,9 +67,9 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           submodules: ${{ inputs.submodules }}
-          # Use PAT only when checking out submodules (likely private nics-dp repos);
-          # default github.token suffices for the main repo and reduces token surface.
-          token: ${{ inputs.submodules != 'false' && (steps.priv-token.outputs.token || secrets.GH_PAT_READ_NICSDP) || github.token }}
+          # Use the App token only when checking out submodules (likely private nics-dp
+          # repos); default github.token suffices for the main repo and reduces token surface.
+          token: ${{ inputs.submodules != 'false' && steps.priv-token.outputs.token || github.token }}
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
@@ -82,12 +78,12 @@ jobs:
           build-mode: ${{ matrix.build-mode }}
           dependency-caching: true
           queries: security-extended,security-and-quality
-          external-repository-token: ${{ steps.priv-token.outputs.token || secrets.GH_PAT_READ_NICSDP }}
+          external-repository-token: ${{ steps.priv-token.outputs.token }}
 
       - name: Configure access to private Go modules
-        if: matrix.language == 'go' && env.USE_PRIVATE_GO == 'true' && (env.HAS_CI_APP == 'true' || env.HAS_GH_PAT == 'true')
+        if: matrix.language == 'go' && env.USE_PRIVATE_GO == 'true' && env.HAS_CI_APP == 'true'
         env:
-          GH_PAT: ${{ steps.priv-token.outputs.token || secrets.GH_PAT_READ_NICSDP }}
+          GH_PAT: ${{ steps.priv-token.outputs.token }}
         run: |
           {
             echo "GOPRIVATE=github.com/nics-dp"
@@ -107,9 +103,9 @@ jobs:
           go build -mod=vendor ./...
 
       - name: Revoke private module access
-        if: always() && matrix.language == 'go' && env.USE_PRIVATE_GO == 'true' && (env.HAS_CI_APP == 'true' || env.HAS_GH_PAT == 'true')
+        if: always() && matrix.language == 'go' && env.USE_PRIVATE_GO == 'true' && env.HAS_CI_APP == 'true'
         env:
-          GH_PAT: ${{ steps.priv-token.outputs.token || secrets.GH_PAT_READ_NICSDP }}
+          GH_PAT: ${{ steps.priv-token.outputs.token }}
         run: |
           git config --global --remove-section "url.https://${GH_PAT}@github.com/nics-dp" 2>/dev/null || true
           git config --global --remove-section "url.https://${GH_PAT}@github.com/nics-dp/" 2>/dev/null || true

--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -78,11 +78,9 @@ on:
         default: '"windows-latest"'
         description: "Runner for Windows build jobs as JSON"
     secrets:
-      gh_pat:
-        required: false
       ci_read_app_id:
         required: false
-        description: "App ID of the nics-dp-ci-read GitHub App. Preferred over gh_pat for private module access; pass via secrets: inherit. Falls back to gh_pat when empty."
+        description: "App ID of the nics-dp-ci-read GitHub App for private module access (pass via secrets: inherit)."
       ci_read_app_private_key:
         required: false
         description: "Private key of the nics-dp-ci-read GitHub App (pair with ci_read_app_id)."
@@ -173,13 +171,11 @@ jobs:
       fail-fast: false
       matrix: ${{ fromJSON(needs.prepare.outputs.matrix) }}
     env:
-      # secrets cannot be used in step-level if:, so bridge them to env here.
+      # secrets cannot be used in step-level if:, so bridge to env here.
       HAS_CI_APP: ${{ secrets.ci_read_app_id != '' && secrets.ci_read_app_private_key != '' }}
-      HAS_GH_PAT: ${{ secrets.gh_pat != '' }}
     steps:
-      # Prefer a nics-dp-ci-read App token for private module access. The App secrets
-      # arrive via `secrets: inherit`; when absent (legacy callers) the step is skipped
-      # and the later steps fall back to gh_pat. See nics-dp PAT->App migration.
+      # Mint a nics-dp-ci-read App token for private module access. The App secrets
+      # arrive via `secrets: inherit`; when absent the private-module steps are skipped.
       - name: Setup | Mint private-module token
         id: priv-token
         if: env.HAS_CI_APP == 'true'
@@ -194,7 +190,7 @@ jobs:
           ref: ${{ inputs.ref }}
           # The ref is a workflow_call input and may be attacker-influenced;
           # do not persist the GITHUB_TOKEN. Private module access is granted
-          # separately via the App token / gh_pat (CodeQL actions/untrusted-checkout).
+          # separately via the App token (CodeQL actions/untrusted-checkout).
           persist-credentials: false
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
@@ -203,9 +199,9 @@ jobs:
           cache: true
 
       - name: Configure private git repository
-        if: ${{ env.HAS_CI_APP == 'true' || env.HAS_GH_PAT == 'true' }}
+        if: env.HAS_CI_APP == 'true'
         env:
-          GH_PAT: ${{ steps.priv-token.outputs.token || secrets.gh_pat }}
+          GH_PAT: ${{ steps.priv-token.outputs.token }}
           GO_PRIVATE_FULL: ${{ inputs.go_private_full }}
         run: |
           if [[ "$GO_PRIVATE_FULL" == "true" ]]; then
@@ -345,9 +341,9 @@ jobs:
           retention-days: ${{ inputs.snapshot && 7 || 30 }}
 
       - name: Revoke private git repository access
-        if: ${{ always() && (env.HAS_CI_APP == 'true' || env.HAS_GH_PAT == 'true') }}
+        if: ${{ always() && env.HAS_CI_APP == 'true' }}
         env:
-          GH_PAT: ${{ steps.priv-token.outputs.token || secrets.gh_pat }}
+          GH_PAT: ${{ steps.priv-token.outputs.token }}
         run: |
           git config --global --remove-section "url.https://${GH_PAT}@github.com/nics-dp/" 2>/dev/null || true
           git config --global --remove-section "url.https://${GH_PAT}@github.com/nics-dp" 2>/dev/null || true

--- a/.github/workflows/image-release.yml
+++ b/.github/workflows/image-release.yml
@@ -126,12 +126,9 @@ on:
         required: true
       dockerhub_token:
         required: true
-      gh_pat:
-        required: false
-        description: "Fallback PAT for private module/repo access during checkout and build, used only when the ci_read_app_* App secrets are absent. GHCR push uses GITHUB_TOKEN, not this."
       ci_read_app_id:
         required: false
-        description: "App ID of the nics-dp-ci-read GitHub App. Preferred over the PAT for private module access; pass via secrets: inherit. Falls back to the PAT when empty."
+        description: "App ID of the nics-dp-ci-read GitHub App for private module/repo access during checkout and build (pass via secrets: inherit). GHCR push uses GITHUB_TOKEN, not this."
       ci_read_app_private_key:
         required: false
         description: "Private key of the nics-dp-ci-read GitHub App (pair with ci_read_app_id)."
@@ -155,14 +152,12 @@ jobs:
       attestations: write
       id-token: write
     env:
-      # secrets cannot be used in step-level if:, so bridge them to env here.
+      # secrets cannot be used in step-level if:, so bridge to env here.
       HAS_CI_APP: ${{ secrets.ci_read_app_id != '' && secrets.ci_read_app_private_key != '' }}
-      HAS_GH_PAT: ${{ secrets.gh_pat != '' }}
 
     steps:
-      # Prefer a nics-dp-ci-read App token for private module access. The App secrets
-      # arrive via `secrets: inherit`; when absent (legacy callers) the step is skipped
-      # and the later steps fall back to gh_pat. See nics-dp PAT->App migration.
+      # Mint a nics-dp-ci-read App token for private module access. The App secrets
+      # arrive via `secrets: inherit`; when absent the private-module steps are skipped.
       - name: Setup | Mint private-module token
         id: priv-token
         if: env.HAS_CI_APP == 'true'
@@ -471,7 +466,7 @@ jobs:
           repository: ${{ inputs.external_repo }}
           ref: ${{ inputs.external_ref }}
           path: ${{ inputs.external_path }}
-          token: ${{ steps.priv-token.outputs.token || secrets.gh_pat || github.token }}
+          token: ${{ steps.priv-token.outputs.token || github.token }}
           # This checkout IS the docker build context. The token is still used
           # for the initial fetch, but must not be persisted afterwards: never
           # run authenticated git here, and keep credential material out of the
@@ -533,10 +528,9 @@ jobs:
       - name: Configure private modules and vendor
         if: inputs.go_vendor
         env:
-          # Prefer the minted App token; fall back to gh_pat. HAS_PRIV is true
-          # when either credential is available.
-          HAS_PRIV: ${{ env.HAS_CI_APP == 'true' || env.HAS_GH_PAT == 'true' }}
-          GH_PAT: ${{ steps.priv-token.outputs.token || secrets.gh_pat }}
+          # the minted App token (empty when ci_read_app_* not inherited).
+          HAS_PRIV: ${{ env.HAS_CI_APP == 'true' }}
+          GH_PAT: ${{ steps.priv-token.outputs.token }}
         run: |
           if [[ "$HAS_PRIV" == "true" ]]; then
             git config --global url."https://${GH_PAT}@github.com/nics-dp".insteadOf "https://github.com/nics-dp"
@@ -602,7 +596,7 @@ jobs:
             ${{ inputs.build_args }}
             ${{ steps.env-args.outputs.build_args }}
           secrets: |
-            github_token=${{ steps.priv-token.outputs.token || secrets.gh_pat || secrets.GITHUB_TOKEN }}
+            github_token=${{ steps.priv-token.outputs.token || secrets.GITHUB_TOKEN }}
           cache-from: type=registry,ref=${{ env.REGISTRY_GHCR }}/${{ env.GHCR_NAMESPACE }}/${{ env.IMAGE_NAME }}:buildcache
           cache-to: type=registry,ref=${{ env.REGISTRY_GHCR }}/${{ env.GHCR_NAMESPACE }}/${{ env.IMAGE_NAME }}:buildcache,mode=max
           sbom: ${{ inputs.sbom }}

--- a/.github/workflows/mise-task.yml
+++ b/.github/workflows/mise-task.yml
@@ -19,7 +19,8 @@
 #         task: ${{ matrix.task }}
 #         private-modules: true
 #       secrets:
-#         gh_pat: ${{ secrets.GH_PAT_READ_NICSDP }}
+#         ci_read_app_id: ${{ secrets.CI_READ_APP_ID }}
+#         ci_read_app_private_key: ${{ secrets.CI_READ_APP_PRIVATE_KEY }}
 
 name: mise-task
 
@@ -46,17 +47,14 @@ on:
         type: number
         default: 1
       private-modules:
-        description: "Configure git to authenticate to private GitHub repos via gh_pat secret"
+        description: "Configure git to authenticate to private GitHub repos via the ci-read App token"
         required: false
         type: boolean
         default: false
     secrets:
-      gh_pat:
-        description: "Fallback PAT (read access to private modules) used only when the ci_read_app_* App secrets are not provided. Relevant when private-modules=true."
-        required: false
       ci_read_app_id:
         required: false
-        description: "App ID of the nics-dp-ci-read GitHub App. Preferred over gh_pat for private module access; pass via secrets: inherit. Falls back to gh_pat when empty."
+        description: "App ID of the nics-dp-ci-read GitHub App for private module access (pass via secrets: inherit). Relevant when private-modules=true."
       ci_read_app_private_key:
         required: false
         description: "Private key of the nics-dp-ci-read GitHub App (pair with ci_read_app_id)."
@@ -88,10 +86,8 @@ jobs:
       # secrets cannot be used in step-level if:, so bridge to env here.
       HAS_CI_APP: ${{ secrets.ci_read_app_id != '' && secrets.ci_read_app_private_key != '' }}
     steps:
-      # Prefer a nics-dp-ci-read App token for private module access, but only when this
-      # run actually needs private modules. The App secrets arrive via `secrets: inherit`;
-      # when absent (legacy callers) the step is skipped and the git-config below falls
-      # back to gh_pat. See nics-dp PAT->App migration.
+      # Mint a nics-dp-ci-read App token for private module access, but only when this
+      # run actually needs private modules. The App secrets arrive via `secrets: inherit`.
       - name: Setup | Mint private-module token
         id: priv-token
         if: ${{ env.HAS_CI_APP == 'true' && inputs.private-modules }}
@@ -113,10 +109,10 @@ jobs:
       - name: Configure git for private modules
         if: ${{ inputs.private-modules }}
         env:
-          GH_PAT: ${{ steps.priv-token.outputs.token || secrets.gh_pat }}
+          GH_PAT: ${{ steps.priv-token.outputs.token }}
         run: |
           if [ -z "$GH_PAT" ]; then
-            echo "::warning::private-modules=true but neither the ci-read App token nor gh_pat is available"
+            echo "::warning::private-modules=true but the ci-read App token is unavailable (ci_read_app_* secrets not inherited?)"
             exit 0
           fi
           git config --global url."https://x-access-token:${GH_PAT}@github.com/nics-dp/".insteadOf "https://github.com/nics-dp/"

--- a/.github/workflows/sbom-source.yml
+++ b/.github/workflows/sbom-source.yml
@@ -32,7 +32,7 @@ on:
     secrets:
       ci_read_app_id:
         required: false
-        description: "App ID of the nics-dp-ci-read GitHub App. Preferred over the PAT for private module access; pass via secrets: inherit. Falls back to the PAT when empty."
+        description: "App ID of the nics-dp-ci-read GitHub App for private module access. Mints an installation token to fetch private nics-dp Go modules; pass via secrets: inherit. When absent the private-module steps are skipped."
       ci_read_app_private_key:
         required: false
         description: "Private key of the nics-dp-ci-read GitHub App (pair with ci_read_app_id)."

--- a/.github/workflows/sbom-source.yml
+++ b/.github/workflows/sbom-source.yml
@@ -30,9 +30,6 @@ on:
         default: '"ubuntu-latest"'
         description: 'Runner as JSON (e.g., ''"ubuntu-latest"'' or ''{"group":"releasers"}'')'
     secrets:
-      gh_pat:
-        required: false
-        description: "Optional PAT for private Go module access"
       ci_read_app_id:
         required: false
         description: "App ID of the nics-dp-ci-read GitHub App. Preferred over the PAT for private module access; pass via secrets: inherit. Falls back to the PAT when empty."
@@ -54,9 +51,8 @@ jobs:
       # secrets cannot be used in step-level if:, so bridge to env here.
       HAS_CI_APP: ${{ secrets.ci_read_app_id != '' && secrets.ci_read_app_private_key != '' }}
     steps:
-      # Prefer a nics-dp-ci-read App token for private module access. The App secrets
-      # arrive via `secrets: inherit`; when absent (legacy callers) the step is skipped
-      # and the git-config below falls back to gh_pat. See nics-dp PAT->App migration.
+      # Mint a nics-dp-ci-read App token for private module access. The App secrets
+      # arrive via `secrets: inherit`; when absent the git-config below is a no-op.
       - name: Setup | Mint private-module token
         id: priv-token
         if: env.HAS_CI_APP == 'true'
@@ -73,12 +69,12 @@ jobs:
           fetch-depth: 1
           # The ref is a workflow_call input and may be attacker-influenced;
           # do not persist the GITHUB_TOKEN. Private module access is granted
-          # separately via gh_pat (CodeQL actions/untrusted-checkout).
+          # separately via the App token (CodeQL actions/untrusted-checkout).
           persist-credentials: false
 
       - name: Configure git for private modules
         env:
-          GH_PAT: ${{ steps.priv-token.outputs.token || secrets.gh_pat }}
+          GH_PAT: ${{ steps.priv-token.outputs.token }}
         run: |
           if [ -n "$GH_PAT" ]; then
             git config --global url."https://x-access-token:${GH_PAT}@github.com/".insteadOf "https://github.com/"

--- a/.ruler/AGENTS.md
+++ b/.ruler/AGENTS.md
@@ -47,8 +47,8 @@ includes = ["git::https://github.com/nics-dp/meta.git//.mise/tasks?ref=main"]
 
 **Shared configs (`configs/`)**: Atoms fetch raw URLs at runtime (no commit to consumer repos). Trap cleanup removes the downloaded config when atom exits. Note: `.golangci.yml` is **per-repo committed** (not shared via curl) — `go:lint-check` / `go:lint-fix` read consumer's own file because gofumpt requires per-module `module-path` setting.
 
-**PAT split**:
-- `GH_PAT_READ_NICSDP` — private module access, CodeQL private-repo access, release/snapshot builds, `mise-task.yml` private-modules flag
+**Auth (GitHub App + DockerHub)**:
+- `CI_READ_APP_ID` / `CI_READ_APP_PRIVATE_KEY` — nics-dp-ci-read App token (org secrets): private module access, CodeQL private-repo access, release/snapshot builds, `mise-task.yml` private-modules flag. Callers pass via `secrets: inherit` (no PAT).
 - `DOCKERHUB_USERNAME` / `DOCKERHUB_TOKEN` — image-release.yml (Docker image push)
 
 ## Key Files
@@ -66,7 +66,7 @@ includes = ["git::https://github.com/nics-dp/meta.git//.mise/tasks?ref=main"]
 ## Workflow Architecture
 
 ### Core
-- **`mise-task.yml`** — Reusable. Inputs: `task`, `name`, `runs_on` (JSON via `fromJSON()`), `fetch-depth`, `private-modules`. Secret: `gh_pat`. Encapsulates checkout (SHA-pinned) + `jdx/mise-action@<sha>` + optional git private-modules config + run mise atom + step summary + enforce.
+- **`mise-task.yml`** — Reusable. Inputs: `task`, `name`, `runs_on` (JSON via `fromJSON()`), `fetch-depth`, `private-modules`. Secrets: `ci_read_app_id` / `ci_read_app_private_key`. Encapsulates checkout (SHA-pinned) + `jdx/mise-action@<sha>` + optional git private-modules config + run mise atom + step summary + enforce.
 
 ### Release & Build
 - **`go-release.yml`** — Multi-arch Go binary release (cosign, macOS notarize via quill, GitHub Release).

--- a/README.md
+++ b/README.md
@@ -173,7 +173,8 @@ jobs:
       runs_on: '{"group":"releasers"}'
       private-modules: true
     secrets:
-      gh_pat: ${{ secrets.GH_PAT_READ_NICSDP }}
+      ci_read_app_id: ${{ secrets.CI_READ_APP_ID }}
+      ci_read_app_private_key: ${{ secrets.CI_READ_APP_PRIVATE_KEY }}
 ```
 
 | Input             | Type    | Default          | 用途                                                          |
@@ -182,9 +183,9 @@ jobs:
 | `name`            | string  | task             | display name for GH job summary                               |
 | `runs_on`         | string  | `'"ubuntu-latest"'` | runner（JSON 經 `fromJSON()` 解析；可傳 `'{"group":"X"}'`） |
 | `fetch-depth`     | number  | `1`              | git fetch depth                                               |
-| `private-modules` | boolean | `false`          | 啟用 GH PAT git config for private modules                    |
+| `private-modules` | boolean | `false`          | 啟用 ci-read App token git config for private modules         |
 
-Secret `gh_pat`：required when `private-modules=true`。
+Secrets `ci_read_app_id` / `ci_read_app_private_key`（nics-dp-ci-read App）：用於 `private-modules=true`；caller 建議以 `secrets: inherit` 傳遞 org secrets `CI_READ_APP_ID` / `CI_READ_APP_PRIVATE_KEY`。
 
 每 job 結尾自動 emit `## <name>` block 至 GitHub Actions step summary，含 ✅/❌ 狀態 + `<details>` 包 tail 300 行 stdout/stderr。
 
@@ -269,8 +270,8 @@ Meta repo 自家 `renovate.json` 額外 customManagers 處理：
 2. 確認 `[task_config].includes = ["git::https://github.com/nics-dp/meta.git//.mise/tasks?ref=main"]`
 3. 加 repo-specific tasks/tools/env at end
 4. 寫 `.github/workflows/ci.yml`，用 matrix 呼叫 `nics-dp/meta/.github/workflows/mise-task.yml@main`
-5. 設 secrets:
-   - `GH_PAT_READ_NICSDP` (Go 私模 + CodeQL private repo + release/snapshot)
+5. 設 secrets（caller 用 `secrets: inherit` 傳 org secrets）:
+   - `CI_READ_APP_ID` + `CI_READ_APP_PRIVATE_KEY` (nics-dp-ci-read App：Go 私模 + CodeQL private repo + release/snapshot)
    - `DOCKERHUB_USERNAME` + `DOCKERHUB_TOKEN` (Docker image repos)
 
 驗證：`mise tasks ls` 應顯示 ~10 facade 名 + repo-specific extras（atoms hidden）；`mise run --dry-run ci test sbom` resolve 無誤。


### PR DESCRIPTION
## 摘要
PAT -> App 遷移**階段 3**：所有 caller 都已改用 `ci_read_app_*`（無 PAT），因此把 reusable workflows 裡已成 dead code 的 `gh_pat` / `GH_PAT_READ_NICSDP` fallback 移除。

## 變更（5 個 reusable workflows）
- 移除 `workflow_call.secrets` 的 `gh_pat`（codeql 為 `GH_PAT_READ_NICSDP`）宣告
- 移除 `HAS_GH_PAT` job env 橋接
- token 表達式去掉 `|| secrets.gh_pat`（image-release/codeql 保留 `|| github.token` / `|| secrets.GITHUB_TOKEN` 的合法 fallback）
- 受影響的 step `if` 從 `HAS_CI_APP || HAS_GH_PAT` 簡化為 `HAS_CI_APP`
- 更新相關描述/註解（不再提 fallback）

私有 module 存取現在**僅**透過 mint 的 `nics-dp-ci-read` App token。

## 影響
- 純清理；fallback 早已是 empty no-op（所有 caller 不再傳 PAT）。
- 合併到 dev 後，隨下次 release 進 main。

## 驗證
- actionlint 全 5 clean；無 `gh_pat`/`GH_PAT_READ_NICSDP`/`HAS_GH_PAT` 殘留（codeql 標題註解的 usage example 已更新為 ci_read_app_*）。
