### PR TITLE
fix(ci): use x-access-token for App-token git auth in release builds

### DIFF
--- a/.github/workflows/codeql-reusable.yml
+++ b/.github/workflows/codeql-reusable.yml
@@ -94,8 +94,8 @@ jobs:
             echo "GONOPROXY=github.com/nics-dp"
             echo "GONOSUMDB=github.com/nics-dp"
           } >> "$GITHUB_ENV"
-          git config --global url."https://${GH_PAT}@github.com/nics-dp".insteadOf "https://github.com/nics-dp"
-          git config --global url."https://${GH_PAT}@github.com/nics-dp/".insteadOf "git@github.com:nics-dp/"
+          git config --global url."https://x-access-token:${GH_PAT}@github.com/nics-dp".insteadOf "https://github.com/nics-dp"
+          git config --global url."https://x-access-token:${GH_PAT}@github.com/nics-dp/".insteadOf "git@github.com:nics-dp/"
 
       - name: Manual Go build for CodeQL
         if: matrix.language == 'go'
@@ -111,8 +111,8 @@ jobs:
         env:
           GH_PAT: ${{ steps.priv-token.outputs.token || secrets.GH_PAT_READ_NICSDP }}
         run: |
-          git config --global --remove-section "url.https://${GH_PAT}@github.com/nics-dp" 2>/dev/null || true
-          git config --global --remove-section "url.https://${GH_PAT}@github.com/nics-dp/" 2>/dev/null || true
+          git config --global --remove-section "url.https://x-access-token:${GH_PAT}@github.com/nics-dp" 2>/dev/null || true
+          git config --global --remove-section "url.https://x-access-token:${GH_PAT}@github.com/nics-dp/" 2>/dev/null || true
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2

--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -214,9 +214,9 @@ jobs:
               echo "GONOPROXY=github.com/nics-dp"
               echo "GONOSUMDB=github.com/nics-dp"
             } >> "$GITHUB_ENV"
-            git config --global url."https://${GH_PAT}@github.com/nics-dp/".insteadOf "git@github.com:nics-dp/"
+            git config --global url."https://x-access-token:${GH_PAT}@github.com/nics-dp/".insteadOf "git@github.com:nics-dp/"
           fi
-          git config --global url."https://${GH_PAT}@github.com/nics-dp".insteadOf "https://github.com/nics-dp"
+          git config --global url."https://x-access-token:${GH_PAT}@github.com/nics-dp".insteadOf "https://github.com/nics-dp"
 
       - name: Cache vendor directory
         if: contains(inputs.extra_build_flags, '-mod=vendor')
@@ -349,8 +349,8 @@ jobs:
         env:
           GH_PAT: ${{ steps.priv-token.outputs.token || secrets.gh_pat }}
         run: |
-          git config --global --remove-section "url.https://${GH_PAT}@github.com/nics-dp/" 2>/dev/null || true
-          git config --global --remove-section "url.https://${GH_PAT}@github.com/nics-dp" 2>/dev/null || true
+          git config --global --remove-section "url.https://x-access-token:${GH_PAT}@github.com/nics-dp/" 2>/dev/null || true
+          git config --global --remove-section "url.https://x-access-token:${GH_PAT}@github.com/nics-dp" 2>/dev/null || true
 
   release:
     needs: [prepare, build]

--- a/.github/workflows/image-release.yml
+++ b/.github/workflows/image-release.yml
@@ -539,12 +539,12 @@ jobs:
           GH_PAT: ${{ steps.priv-token.outputs.token || secrets.gh_pat }}
         run: |
           if [[ "$HAS_PRIV" == "true" ]]; then
-            git config --global url."https://${GH_PAT}@github.com/nics-dp".insteadOf "https://github.com/nics-dp"
+            git config --global url."https://x-access-token:${GH_PAT}@github.com/nics-dp".insteadOf "https://github.com/nics-dp"
           fi
           go env -w GOPRIVATE=github.com/nics-dp GONOPROXY=github.com/nics-dp GONOSUMDB=github.com/nics-dp
           go mod vendor
           if [[ "$HAS_PRIV" == "true" ]]; then
-            git config --global --remove-section "url.https://${GH_PAT}@github.com/nics-dp" 2>/dev/null || true
+            git config --global --remove-section "url.https://x-access-token:${GH_PAT}@github.com/nics-dp" 2>/dev/null || true
           fi
 
       - name: Set up QEMU

--- a/.github/workflows/image-release.yml
+++ b/.github/workflows/image-release.yml
@@ -543,9 +543,17 @@ jobs:
           fi
           go env -w GOPRIVATE=github.com/nics-dp GONOPROXY=github.com/nics-dp GONOSUMDB=github.com/nics-dp
           go mod vendor
-          if [[ "$HAS_PRIV" == "true" ]]; then
-            git config --global --remove-section "url.https://x-access-token:${GH_PAT}@github.com/nics-dp" 2>/dev/null || true
-          fi
+
+      - name: Revoke private module access
+        # Separate always()-guarded step: go mod vendor runs under `set -e`, so an
+        # inline revoke after it would be skipped on vendor failure, leaving the
+        # token-bearing insteadOf rewrite in the runner's global git config
+        # (the releasers group runners are not ephemeral). Mirrors go-release.yml.
+        if: ${{ always() && inputs.go_vendor && (env.HAS_CI_APP == 'true' || env.HAS_GH_PAT == 'true') }}
+        env:
+          GH_PAT: ${{ steps.priv-token.outputs.token || secrets.gh_pat }}
+        run: |
+          git config --global --remove-section "url.https://x-access-token:${GH_PAT}@github.com/nics-dp" 2>/dev/null || true
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0


### PR DESCRIPTION
## Problem

After the org PAT to App migration, the **snapshot** builds in `dcf-access`, `dcf-platform` and `dcf-service` fail in the `go-release` / `image-build` jobs when fetching the private `libdcf` module:

```
github.com/nics-dp/libdcf@v0.2.5-...: invalid version:
git ls-remote -q ... exit status 128:
fatal: could not read Password for 'https://***@github.com': terminal prompts disabled
```

## Root cause

`go-release.yml`, `image-release.yml` and `codeql-reusable.yml` configured git auth as:

```
url."https://${GH_PAT}@github.com/nics-dp"
```

This embeds the token as the URL **username** with no password. That works for a classic PAT, but a GitHub App installation token must be supplied as the **password** with the username `x-access-token`. So git could not authenticate and prompted for a password (disabled in CI).

The working `mise-task.yml` (used by `ci`) already uses the correct form, which is why `ci` is green but the release jobs are red.

This was latent until the PAT to App migration completed. Repos that did not need to fetch `libdcf` over the network (warm module cache / no `go mod vendor`, e.g. `dcf-platform-cli`) masked the bug.

## Fix

Add the `x-access-token:` username to the `insteadOf` set and the matching `remove-section` revoke keys in all three reusable workflows, aligning them with `mise-task.yml`.

| File | Lines |
|------|-------|
| `go-release.yml` | set 217/219, revoke 352/353 |
| `image-release.yml` | set 542, revoke 547 |
| `codeql-reusable.yml` | set 97/98, revoke 114/115 |

`actionlint` passes on all three.

## Verification

1. Merge to `main` (downstream pins `@main`).
2. Re-run a failed snapshot in `dcf-access` / `dcf-platform` / `dcf-service`; `go-release / build` and `image-build` should go green.
