### PR TITLE
fix(ci): back-port x-access-token git auth fix to dev

### DIFF
--- a/.github/workflows/codeql-reusable.yml
+++ b/.github/workflows/codeql-reusable.yml
@@ -90,8 +90,8 @@ jobs:
             echo "GONOPROXY=github.com/nics-dp"
             echo "GONOSUMDB=github.com/nics-dp"
           } >> "$GITHUB_ENV"
-          git config --global url."https://${GH_PAT}@github.com/nics-dp".insteadOf "https://github.com/nics-dp"
-          git config --global url."https://${GH_PAT}@github.com/nics-dp/".insteadOf "git@github.com:nics-dp/"
+          git config --global url."https://x-access-token:${GH_PAT}@github.com/nics-dp".insteadOf "https://github.com/nics-dp"
+          git config --global url."https://x-access-token:${GH_PAT}@github.com/nics-dp/".insteadOf "git@github.com:nics-dp/"
 
       - name: Manual Go build for CodeQL
         if: matrix.language == 'go'
@@ -107,8 +107,8 @@ jobs:
         env:
           GH_PAT: ${{ steps.priv-token.outputs.token }}
         run: |
-          git config --global --remove-section "url.https://${GH_PAT}@github.com/nics-dp" 2>/dev/null || true
-          git config --global --remove-section "url.https://${GH_PAT}@github.com/nics-dp/" 2>/dev/null || true
+          git config --global --remove-section "url.https://x-access-token:${GH_PAT}@github.com/nics-dp" 2>/dev/null || true
+          git config --global --remove-section "url.https://x-access-token:${GH_PAT}@github.com/nics-dp/" 2>/dev/null || true
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2

--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -210,9 +210,9 @@ jobs:
               echo "GONOPROXY=github.com/nics-dp"
               echo "GONOSUMDB=github.com/nics-dp"
             } >> "$GITHUB_ENV"
-            git config --global url."https://${GH_PAT}@github.com/nics-dp/".insteadOf "git@github.com:nics-dp/"
+            git config --global url."https://x-access-token:${GH_PAT}@github.com/nics-dp/".insteadOf "git@github.com:nics-dp/"
           fi
-          git config --global url."https://${GH_PAT}@github.com/nics-dp".insteadOf "https://github.com/nics-dp"
+          git config --global url."https://x-access-token:${GH_PAT}@github.com/nics-dp".insteadOf "https://github.com/nics-dp"
 
       - name: Cache vendor directory
         if: contains(inputs.extra_build_flags, '-mod=vendor')
@@ -345,8 +345,8 @@ jobs:
         env:
           GH_PAT: ${{ steps.priv-token.outputs.token }}
         run: |
-          git config --global --remove-section "url.https://${GH_PAT}@github.com/nics-dp/" 2>/dev/null || true
-          git config --global --remove-section "url.https://${GH_PAT}@github.com/nics-dp" 2>/dev/null || true
+          git config --global --remove-section "url.https://x-access-token:${GH_PAT}@github.com/nics-dp/" 2>/dev/null || true
+          git config --global --remove-section "url.https://x-access-token:${GH_PAT}@github.com/nics-dp" 2>/dev/null || true
 
   release:
     needs: [prepare, build]

--- a/.github/workflows/image-release.yml
+++ b/.github/workflows/image-release.yml
@@ -533,12 +533,12 @@ jobs:
           GH_PAT: ${{ steps.priv-token.outputs.token }}
         run: |
           if [[ "$HAS_PRIV" == "true" ]]; then
-            git config --global url."https://${GH_PAT}@github.com/nics-dp".insteadOf "https://github.com/nics-dp"
+            git config --global url."https://x-access-token:${GH_PAT}@github.com/nics-dp".insteadOf "https://github.com/nics-dp"
           fi
           go env -w GOPRIVATE=github.com/nics-dp GONOPROXY=github.com/nics-dp GONOSUMDB=github.com/nics-dp
           go mod vendor
           if [[ "$HAS_PRIV" == "true" ]]; then
-            git config --global --remove-section "url.https://${GH_PAT}@github.com/nics-dp" 2>/dev/null || true
+            git config --global --remove-section "url.https://x-access-token:${GH_PAT}@github.com/nics-dp" 2>/dev/null || true
           fi
 
       - name: Set up QEMU

--- a/.github/workflows/image-release.yml
+++ b/.github/workflows/image-release.yml
@@ -537,9 +537,17 @@ jobs:
           fi
           go env -w GOPRIVATE=github.com/nics-dp GONOPROXY=github.com/nics-dp GONOSUMDB=github.com/nics-dp
           go mod vendor
-          if [[ "$HAS_PRIV" == "true" ]]; then
-            git config --global --remove-section "url.https://x-access-token:${GH_PAT}@github.com/nics-dp" 2>/dev/null || true
-          fi
+
+      - name: Revoke private module access
+        # Separate always()-guarded step: go mod vendor runs under `set -e`, so an
+        # inline revoke after it would be skipped on vendor failure, leaving the
+        # token-bearing insteadOf rewrite in the runner's global git config
+        # (the releasers group runners are not ephemeral). Mirrors go-release.yml.
+        if: ${{ always() && inputs.go_vendor && env.HAS_CI_APP == 'true' }}
+        env:
+          GH_PAT: ${{ steps.priv-token.outputs.token }}
+        run: |
+          git config --global --remove-section "url.https://x-access-token:${GH_PAT}@github.com/nics-dp" 2>/dev/null || true
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0


### PR DESCRIPTION
## What

Back-port the App-token git-auth fix (already on `main` via #165, released as `v0.2.4.6`) into `dev`, so `dev` does not regress the fix on the next `dev`-based release.

Cherry-picks of:
- `8ec2e8d` fix(ci): use x-access-token for App-token git auth in release builds
- `a99d197` fix(ci): always revoke private-module git auth in image-release

## Why

`dev` diverged from `main`: `main` carries #165 (this fix) while `dev` carries #164 (drop gh_pat fallback) + renovate bumps. Downstream pins `@main`, so the fix is already live, but `dev` lacked it.

## Adaptation to dev

The cherry-pick was reconciled with #164's convention on `dev`: the new `Revoke private module access` step in `image-release.yml` uses `env.HAS_CI_APP` and `steps.priv-token.outputs.token` only (no `secrets.gh_pat` / `HAS_GH_PAT` fallback, consistent with the rest of `dev`).

`actionlint` passes on all three workflows.
