### PR TITLE
fix(ci): scrub stale git-auth insteadOf rewrites before configuring (self-healing)

### DIFF
--- a/.github/workflows/codeql-reusable.yml
+++ b/.github/workflows/codeql-reusable.yml
@@ -94,6 +94,12 @@ jobs:
             echo "GONOPROXY=github.com/nics-dp"
             echo "GONOSUMDB=github.com/nics-dp"
           } >> "$GITHUB_ENV"
+          # Self-healing: drop any stale token-bearing url.*@github.com/nics-dp
+          # insteadOf rewrites left by a prior run before adding this run's fresh
+          # token, so an equal-length insteadOf tie can't pick up an expired token.
+          while read -r s; do
+            if [ -n "$s" ]; then git config --global --remove-section "$s" 2>/dev/null || true; fi
+          done < <(git config --global --name-only --get-regexp '^url\..*@github\.com/nics-dp' 2>/dev/null | sed -E 's/\.insteadof$//' | sort -u || true)
           git config --global url."https://x-access-token:${GH_PAT}@github.com/nics-dp".insteadOf "https://github.com/nics-dp"
           git config --global url."https://x-access-token:${GH_PAT}@github.com/nics-dp/".insteadOf "git@github.com:nics-dp/"
 

--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -208,6 +208,12 @@ jobs:
           GH_PAT: ${{ steps.priv-token.outputs.token || secrets.gh_pat }}
           GO_PRIVATE_FULL: ${{ inputs.go_private_full }}
         run: |
+          # Self-healing: drop any stale token-bearing url.*@github.com/nics-dp
+          # insteadOf rewrites left by a prior run before adding this run's fresh
+          # token, so an equal-length insteadOf tie can't pick up an expired token.
+          while read -r s; do
+            if [ -n "$s" ]; then git config --global --remove-section "$s" 2>/dev/null || true; fi
+          done < <(git config --global --name-only --get-regexp '^url\..*@github\.com/nics-dp' 2>/dev/null | sed -E 's/\.insteadof$//' | sort -u || true)
           if [[ "$GO_PRIVATE_FULL" == "true" ]]; then
             {
               echo "GOPRIVATE=github.com/nics-dp"

--- a/.github/workflows/image-release.yml
+++ b/.github/workflows/image-release.yml
@@ -539,6 +539,13 @@ jobs:
           GH_PAT: ${{ steps.priv-token.outputs.token || secrets.gh_pat }}
         run: |
           if [[ "$HAS_PRIV" == "true" ]]; then
+            # Self-healing: drop any stale token-bearing url.*@github.com/nics-dp
+            # insteadOf rewrites left by a prior run before adding this run's
+            # fresh token, so an equal-length insteadOf tie can't pick up an
+            # expired token.
+            while read -r s; do
+              if [ -n "$s" ]; then git config --global --remove-section "$s" 2>/dev/null || true; fi
+            done < <(git config --global --name-only --get-regexp '^url\..*@github\.com/nics-dp' 2>/dev/null | sed -E 's/\.insteadof$//' | sort -u || true)
             git config --global url."https://x-access-token:${GH_PAT}@github.com/nics-dp".insteadOf "https://github.com/nics-dp"
           fi
           go env -w GOPRIVATE=github.com/nics-dp GONOPROXY=github.com/nics-dp GONOSUMDB=github.com/nics-dp


### PR DESCRIPTION
## What

Make the private-module git-auth setup self-healing: before writing this
run's `x-access-token:<token>` `insteadOf` rewrite, scrub any pre-existing
`url.*@github.com/nics-dp*` sections from the global git config.

Applied to `go-release.yml`, `image-release.yml` and `codeql-reusable.yml`.

## Why

Multiple `insteadOf` rules that rewrite the same prefix
(`https://github.com/nics-dp`) are an equal-length match; git's longest-match
tie-break between them is undefined. On a non-ephemeral runner, a stale
section left by an earlier run (e.g. a pre-fix crash before revoke) could win
the tie and feed git an expired token, breaking the fetch even after the
`x-access-token` fix.

The `releasers` runners currently look ephemeral (a one-off scrub job found no
leftovers), so this is defense-in-depth: it keeps the workflows correct if the
runner pool ever becomes persistent, and makes each run start from a known
state regardless of what a prior run left behind.

The scrub is idempotent and tolerates "no match" (process substitution + `|| true`
so it never trips `set -e`/`pipefail`). `actionlint` passes on all three files.
