### PR TITLE
fix(ci): scrub stale git-auth insteadOf rewrites before configuring (dev)

### DIFF
--- a/.github/workflows/codeql-reusable.yml
+++ b/.github/workflows/codeql-reusable.yml
@@ -90,6 +90,12 @@ jobs:
             echo "GONOPROXY=github.com/nics-dp"
             echo "GONOSUMDB=github.com/nics-dp"
           } >> "$GITHUB_ENV"
+          # Self-healing: drop any stale token-bearing url.*@github.com/nics-dp
+          # insteadOf rewrites left by a prior run before adding this run's fresh
+          # token, so an equal-length insteadOf tie can't pick up an expired token.
+          while read -r s; do
+            if [ -n "$s" ]; then git config --global --remove-section "$s" 2>/dev/null || true; fi
+          done < <(git config --global --name-only --get-regexp '^url\..*@github\.com/nics-dp' 2>/dev/null | sed -E 's/\.insteadof$//' | sort -u || true)
           git config --global url."https://x-access-token:${GH_PAT}@github.com/nics-dp".insteadOf "https://github.com/nics-dp"
           git config --global url."https://x-access-token:${GH_PAT}@github.com/nics-dp/".insteadOf "git@github.com:nics-dp/"
 

--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -204,6 +204,12 @@ jobs:
           GH_PAT: ${{ steps.priv-token.outputs.token }}
           GO_PRIVATE_FULL: ${{ inputs.go_private_full }}
         run: |
+          # Self-healing: drop any stale token-bearing url.*@github.com/nics-dp
+          # insteadOf rewrites left by a prior run before adding this run's fresh
+          # token, so an equal-length insteadOf tie can't pick up an expired token.
+          while read -r s; do
+            if [ -n "$s" ]; then git config --global --remove-section "$s" 2>/dev/null || true; fi
+          done < <(git config --global --name-only --get-regexp '^url\..*@github\.com/nics-dp' 2>/dev/null | sed -E 's/\.insteadof$//' | sort -u || true)
           if [[ "$GO_PRIVATE_FULL" == "true" ]]; then
             {
               echo "GOPRIVATE=github.com/nics-dp"

--- a/.github/workflows/image-release.yml
+++ b/.github/workflows/image-release.yml
@@ -533,6 +533,13 @@ jobs:
           GH_PAT: ${{ steps.priv-token.outputs.token }}
         run: |
           if [[ "$HAS_PRIV" == "true" ]]; then
+            # Self-healing: drop any stale token-bearing url.*@github.com/nics-dp
+            # insteadOf rewrites left by a prior run before adding this run's
+            # fresh token, so an equal-length insteadOf tie can't pick up an
+            # expired token.
+            while read -r s; do
+              if [ -n "$s" ]; then git config --global --remove-section "$s" 2>/dev/null || true; fi
+            done < <(git config --global --name-only --get-regexp '^url\..*@github\.com/nics-dp' 2>/dev/null | sed -E 's/\.insteadof$//' | sort -u || true)
             git config --global url."https://x-access-token:${GH_PAT}@github.com/nics-dp".insteadOf "https://github.com/nics-dp"
           fi
           go env -w GOPRIVATE=github.com/nics-dp GONOPROXY=github.com/nics-dp GONOSUMDB=github.com/nics-dp


### PR DESCRIPTION
## What

Same self-healing change as #167 (base `main`), cherry-picked to `dev` so the two branches stay in sync: before writing this run's `x-access-token:<token>` `insteadOf` rewrite, scrub any pre-existing `url.*@github.com/nics-dp*` sections from the global git config.

Applied to `go-release.yml`, `image-release.yml` and `codeql-reusable.yml`.

## Why

Multiple `insteadOf` rules rewriting the same prefix are an equal-length match with an undefined tie-break; a stale section from an earlier run on a non-ephemeral runner could feed git an expired token. Defense-in-depth — the `releasers` runners currently look ephemeral (a one-off scrub found no leftovers).

Cherry-pick of `a429ff2`; applied cleanly on `dev`. `actionlint` passes on all three files.
