### PR TITLE
release: v0.2.4.7

### DIFF
--- a/.github/workflows/codeql-reusable.yml
+++ b/.github/workflows/codeql-reusable.yml
@@ -90,6 +90,12 @@ jobs:
             echo "GONOPROXY=github.com/nics-dp"
             echo "GONOSUMDB=github.com/nics-dp"
           } >> "$GITHUB_ENV"
+          # Self-healing: drop any stale token-bearing url.*@github.com/nics-dp
+          # insteadOf rewrites left by a prior run before adding this run's fresh
+          # token, so an equal-length insteadOf tie can't pick up an expired token.
+          while read -r s; do
+            if [ -n "$s" ]; then git config --global --remove-section "$s" 2>/dev/null || true; fi
+          done < <(git config --global --name-only --get-regexp '^url\..*@github\.com/nics-dp' 2>/dev/null | sed -E 's/\.insteadof$//' | sort -u || true)
           git config --global url."https://x-access-token:${GH_PAT}@github.com/nics-dp".insteadOf "https://github.com/nics-dp"
           git config --global url."https://x-access-token:${GH_PAT}@github.com/nics-dp/".insteadOf "git@github.com:nics-dp/"
 

--- a/.github/workflows/codeql-reusable.yml
+++ b/.github/workflows/codeql-reusable.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Setup | Mint private-module token
         id: priv-token
         if: env.HAS_CI_APP == 'true'
-        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           app-id: ${{ secrets.ci_read_app_id }}
           private-key: ${{ secrets.ci_read_app_private_key }}

--- a/.github/workflows/codeql-reusable.yml
+++ b/.github/workflows/codeql-reusable.yml
@@ -90,8 +90,8 @@ jobs:
             echo "GONOPROXY=github.com/nics-dp"
             echo "GONOSUMDB=github.com/nics-dp"
           } >> "$GITHUB_ENV"
-          git config --global url."https://${GH_PAT}@github.com/nics-dp".insteadOf "https://github.com/nics-dp"
-          git config --global url."https://${GH_PAT}@github.com/nics-dp/".insteadOf "git@github.com:nics-dp/"
+          git config --global url."https://x-access-token:${GH_PAT}@github.com/nics-dp".insteadOf "https://github.com/nics-dp"
+          git config --global url."https://x-access-token:${GH_PAT}@github.com/nics-dp/".insteadOf "git@github.com:nics-dp/"
 
       - name: Manual Go build for CodeQL
         if: matrix.language == 'go'
@@ -107,8 +107,8 @@ jobs:
         env:
           GH_PAT: ${{ steps.priv-token.outputs.token }}
         run: |
-          git config --global --remove-section "url.https://${GH_PAT}@github.com/nics-dp" 2>/dev/null || true
-          git config --global --remove-section "url.https://${GH_PAT}@github.com/nics-dp/" 2>/dev/null || true
+          git config --global --remove-section "url.https://x-access-token:${GH_PAT}@github.com/nics-dp" 2>/dev/null || true
+          git config --global --remove-section "url.https://x-access-token:${GH_PAT}@github.com/nics-dp/" 2>/dev/null || true
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2

--- a/.github/workflows/codeql-reusable.yml
+++ b/.github/workflows/codeql-reusable.yml
@@ -25,11 +25,9 @@ on:
         type: string
         default: "false"
     secrets:
-      GH_PAT_READ_NICSDP:
-        required: false
       ci_read_app_id:
         required: false
-        description: "App ID of the nics-dp-ci-read GitHub App. Preferred over GH_PAT_READ_NICSDP for private module access; pass via secrets: inherit. Falls back to the PAT when empty."
+        description: "App ID of the nics-dp-ci-read GitHub App for private module access (pass via secrets: inherit)."
       ci_read_app_private_key:
         required: false
         description: "Private key of the nics-dp-ci-read GitHub App (pair with ci_read_app_id)."
@@ -44,9 +42,8 @@ jobs:
       actions: read
       contents: read
     env:
-      # secrets cannot be used in step-level if:, so bridge them to env here.
+      # secrets cannot be used in step-level if:, so bridge to env here.
       HAS_CI_APP: ${{ secrets.ci_read_app_id != '' && secrets.ci_read_app_private_key != '' }}
-      HAS_GH_PAT: ${{ secrets.GH_PAT_READ_NICSDP != '' }}
       USE_PRIVATE_GO: ${{ inputs.use-private-go-modules }}
 
     strategy:
@@ -55,9 +52,8 @@ jobs:
         include: ${{ fromJSON(inputs.matrix-include) }}
 
     steps:
-      # Prefer a nics-dp-ci-read App token for private module access. The App secrets
-      # arrive via `secrets: inherit`; when absent (legacy callers) the step is skipped
-      # and the later steps fall back to GH_PAT_READ_NICSDP. See nics-dp PAT->App migration.
+      # Mint a nics-dp-ci-read App token for private module access. The App secrets
+      # arrive via `secrets: inherit`; when absent the private-module steps are skipped.
       - name: Setup | Mint private-module token
         id: priv-token
         if: env.HAS_CI_APP == 'true'
@@ -71,9 +67,9 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           submodules: ${{ inputs.submodules }}
-          # Use PAT only when checking out submodules (likely private nics-dp repos);
-          # default github.token suffices for the main repo and reduces token surface.
-          token: ${{ inputs.submodules != 'false' && (steps.priv-token.outputs.token || secrets.GH_PAT_READ_NICSDP) || github.token }}
+          # Use the App token only when checking out submodules (likely private nics-dp
+          # repos); default github.token suffices for the main repo and reduces token surface.
+          token: ${{ inputs.submodules != 'false' && steps.priv-token.outputs.token || github.token }}
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
@@ -82,12 +78,12 @@ jobs:
           build-mode: ${{ matrix.build-mode }}
           dependency-caching: true
           queries: security-extended,security-and-quality
-          external-repository-token: ${{ steps.priv-token.outputs.token || secrets.GH_PAT_READ_NICSDP }}
+          external-repository-token: ${{ steps.priv-token.outputs.token }}
 
       - name: Configure access to private Go modules
-        if: matrix.language == 'go' && env.USE_PRIVATE_GO == 'true' && (env.HAS_CI_APP == 'true' || env.HAS_GH_PAT == 'true')
+        if: matrix.language == 'go' && env.USE_PRIVATE_GO == 'true' && env.HAS_CI_APP == 'true'
         env:
-          GH_PAT: ${{ steps.priv-token.outputs.token || secrets.GH_PAT_READ_NICSDP }}
+          GH_PAT: ${{ steps.priv-token.outputs.token }}
         run: |
           {
             echo "GOPRIVATE=github.com/nics-dp"
@@ -107,9 +103,9 @@ jobs:
           go build -mod=vendor ./...
 
       - name: Revoke private module access
-        if: always() && matrix.language == 'go' && env.USE_PRIVATE_GO == 'true' && (env.HAS_CI_APP == 'true' || env.HAS_GH_PAT == 'true')
+        if: always() && matrix.language == 'go' && env.USE_PRIVATE_GO == 'true' && env.HAS_CI_APP == 'true'
         env:
-          GH_PAT: ${{ steps.priv-token.outputs.token || secrets.GH_PAT_READ_NICSDP }}
+          GH_PAT: ${{ steps.priv-token.outputs.token }}
         run: |
           git config --global --remove-section "url.https://${GH_PAT}@github.com/nics-dp" 2>/dev/null || true
           git config --global --remove-section "url.https://${GH_PAT}@github.com/nics-dp/" 2>/dev/null || true

--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -78,11 +78,9 @@ on:
         default: '"windows-latest"'
         description: "Runner for Windows build jobs as JSON"
     secrets:
-      gh_pat:
-        required: false
       ci_read_app_id:
         required: false
-        description: "App ID of the nics-dp-ci-read GitHub App. Preferred over gh_pat for private module access; pass via secrets: inherit. Falls back to gh_pat when empty."
+        description: "App ID of the nics-dp-ci-read GitHub App for private module access (pass via secrets: inherit)."
       ci_read_app_private_key:
         required: false
         description: "Private key of the nics-dp-ci-read GitHub App (pair with ci_read_app_id)."
@@ -173,13 +171,11 @@ jobs:
       fail-fast: false
       matrix: ${{ fromJSON(needs.prepare.outputs.matrix) }}
     env:
-      # secrets cannot be used in step-level if:, so bridge them to env here.
+      # secrets cannot be used in step-level if:, so bridge to env here.
       HAS_CI_APP: ${{ secrets.ci_read_app_id != '' && secrets.ci_read_app_private_key != '' }}
-      HAS_GH_PAT: ${{ secrets.gh_pat != '' }}
     steps:
-      # Prefer a nics-dp-ci-read App token for private module access. The App secrets
-      # arrive via `secrets: inherit`; when absent (legacy callers) the step is skipped
-      # and the later steps fall back to gh_pat. See nics-dp PAT->App migration.
+      # Mint a nics-dp-ci-read App token for private module access. The App secrets
+      # arrive via `secrets: inherit`; when absent the private-module steps are skipped.
       - name: Setup | Mint private-module token
         id: priv-token
         if: env.HAS_CI_APP == 'true'
@@ -194,7 +190,7 @@ jobs:
           ref: ${{ inputs.ref }}
           # The ref is a workflow_call input and may be attacker-influenced;
           # do not persist the GITHUB_TOKEN. Private module access is granted
-          # separately via the App token / gh_pat (CodeQL actions/untrusted-checkout).
+          # separately via the App token (CodeQL actions/untrusted-checkout).
           persist-credentials: false
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
@@ -203,9 +199,9 @@ jobs:
           cache: true
 
       - name: Configure private git repository
-        if: ${{ env.HAS_CI_APP == 'true' || env.HAS_GH_PAT == 'true' }}
+        if: env.HAS_CI_APP == 'true'
         env:
-          GH_PAT: ${{ steps.priv-token.outputs.token || secrets.gh_pat }}
+          GH_PAT: ${{ steps.priv-token.outputs.token }}
           GO_PRIVATE_FULL: ${{ inputs.go_private_full }}
         run: |
           if [[ "$GO_PRIVATE_FULL" == "true" ]]; then
@@ -345,9 +341,9 @@ jobs:
           retention-days: ${{ inputs.snapshot && 7 || 30 }}
 
       - name: Revoke private git repository access
-        if: ${{ always() && (env.HAS_CI_APP == 'true' || env.HAS_GH_PAT == 'true') }}
+        if: ${{ always() && env.HAS_CI_APP == 'true' }}
         env:
-          GH_PAT: ${{ steps.priv-token.outputs.token || secrets.gh_pat }}
+          GH_PAT: ${{ steps.priv-token.outputs.token }}
         run: |
           git config --global --remove-section "url.https://${GH_PAT}@github.com/nics-dp/" 2>/dev/null || true
           git config --global --remove-section "url.https://${GH_PAT}@github.com/nics-dp" 2>/dev/null || true

--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -204,6 +204,12 @@ jobs:
           GH_PAT: ${{ steps.priv-token.outputs.token }}
           GO_PRIVATE_FULL: ${{ inputs.go_private_full }}
         run: |
+          # Self-healing: drop any stale token-bearing url.*@github.com/nics-dp
+          # insteadOf rewrites left by a prior run before adding this run's fresh
+          # token, so an equal-length insteadOf tie can't pick up an expired token.
+          while read -r s; do
+            if [ -n "$s" ]; then git config --global --remove-section "$s" 2>/dev/null || true; fi
+          done < <(git config --global --name-only --get-regexp '^url\..*@github\.com/nics-dp' 2>/dev/null | sed -E 's/\.insteadof$//' | sort -u || true)
           if [[ "$GO_PRIVATE_FULL" == "true" ]]; then
             {
               echo "GOPRIVATE=github.com/nics-dp"

--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -183,7 +183,7 @@ jobs:
       - name: Setup | Mint private-module token
         id: priv-token
         if: env.HAS_CI_APP == 'true'
-        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           app-id: ${{ secrets.ci_read_app_id }}
           private-key: ${{ secrets.ci_read_app_private_key }}

--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -210,9 +210,9 @@ jobs:
               echo "GONOPROXY=github.com/nics-dp"
               echo "GONOSUMDB=github.com/nics-dp"
             } >> "$GITHUB_ENV"
-            git config --global url."https://${GH_PAT}@github.com/nics-dp/".insteadOf "git@github.com:nics-dp/"
+            git config --global url."https://x-access-token:${GH_PAT}@github.com/nics-dp/".insteadOf "git@github.com:nics-dp/"
           fi
-          git config --global url."https://${GH_PAT}@github.com/nics-dp".insteadOf "https://github.com/nics-dp"
+          git config --global url."https://x-access-token:${GH_PAT}@github.com/nics-dp".insteadOf "https://github.com/nics-dp"
 
       - name: Cache vendor directory
         if: contains(inputs.extra_build_flags, '-mod=vendor')
@@ -345,8 +345,8 @@ jobs:
         env:
           GH_PAT: ${{ steps.priv-token.outputs.token }}
         run: |
-          git config --global --remove-section "url.https://${GH_PAT}@github.com/nics-dp/" 2>/dev/null || true
-          git config --global --remove-section "url.https://${GH_PAT}@github.com/nics-dp" 2>/dev/null || true
+          git config --global --remove-section "url.https://x-access-token:${GH_PAT}@github.com/nics-dp/" 2>/dev/null || true
+          git config --global --remove-section "url.https://x-access-token:${GH_PAT}@github.com/nics-dp" 2>/dev/null || true
 
   release:
     needs: [prepare, build]

--- a/.github/workflows/image-release.yml
+++ b/.github/workflows/image-release.yml
@@ -126,12 +126,9 @@ on:
         required: true
       dockerhub_token:
         required: true
-      gh_pat:
-        required: false
-        description: "Fallback PAT for private module/repo access during checkout and build, used only when the ci_read_app_* App secrets are absent. GHCR push uses GITHUB_TOKEN, not this."
       ci_read_app_id:
         required: false
-        description: "App ID of the nics-dp-ci-read GitHub App. Preferred over the PAT for private module access; pass via secrets: inherit. Falls back to the PAT when empty."
+        description: "App ID of the nics-dp-ci-read GitHub App for private module/repo access during checkout and build (pass via secrets: inherit). GHCR push uses GITHUB_TOKEN, not this."
       ci_read_app_private_key:
         required: false
         description: "Private key of the nics-dp-ci-read GitHub App (pair with ci_read_app_id)."
@@ -155,14 +152,12 @@ jobs:
       attestations: write
       id-token: write
     env:
-      # secrets cannot be used in step-level if:, so bridge them to env here.
+      # secrets cannot be used in step-level if:, so bridge to env here.
       HAS_CI_APP: ${{ secrets.ci_read_app_id != '' && secrets.ci_read_app_private_key != '' }}
-      HAS_GH_PAT: ${{ secrets.gh_pat != '' }}
 
     steps:
-      # Prefer a nics-dp-ci-read App token for private module access. The App secrets
-      # arrive via `secrets: inherit`; when absent (legacy callers) the step is skipped
-      # and the later steps fall back to gh_pat. See nics-dp PAT->App migration.
+      # Mint a nics-dp-ci-read App token for private module access. The App secrets
+      # arrive via `secrets: inherit`; when absent the private-module steps are skipped.
       - name: Setup | Mint private-module token
         id: priv-token
         if: env.HAS_CI_APP == 'true'
@@ -471,7 +466,7 @@ jobs:
           repository: ${{ inputs.external_repo }}
           ref: ${{ inputs.external_ref }}
           path: ${{ inputs.external_path }}
-          token: ${{ steps.priv-token.outputs.token || secrets.gh_pat || github.token }}
+          token: ${{ steps.priv-token.outputs.token || github.token }}
           # This checkout IS the docker build context. The token is still used
           # for the initial fetch, but must not be persisted afterwards: never
           # run authenticated git here, and keep credential material out of the
@@ -533,10 +528,9 @@ jobs:
       - name: Configure private modules and vendor
         if: inputs.go_vendor
         env:
-          # Prefer the minted App token; fall back to gh_pat. HAS_PRIV is true
-          # when either credential is available.
-          HAS_PRIV: ${{ env.HAS_CI_APP == 'true' || env.HAS_GH_PAT == 'true' }}
-          GH_PAT: ${{ steps.priv-token.outputs.token || secrets.gh_pat }}
+          # the minted App token (empty when ci_read_app_* not inherited).
+          HAS_PRIV: ${{ env.HAS_CI_APP == 'true' }}
+          GH_PAT: ${{ steps.priv-token.outputs.token }}
         run: |
           if [[ "$HAS_PRIV" == "true" ]]; then
             git config --global url."https://${GH_PAT}@github.com/nics-dp".insteadOf "https://github.com/nics-dp"
@@ -602,7 +596,7 @@ jobs:
             ${{ inputs.build_args }}
             ${{ steps.env-args.outputs.build_args }}
           secrets: |
-            github_token=${{ steps.priv-token.outputs.token || secrets.gh_pat || secrets.GITHUB_TOKEN }}
+            github_token=${{ steps.priv-token.outputs.token || secrets.GITHUB_TOKEN }}
           cache-from: type=registry,ref=${{ env.REGISTRY_GHCR }}/${{ env.GHCR_NAMESPACE }}/${{ env.IMAGE_NAME }}:buildcache
           cache-to: type=registry,ref=${{ env.REGISTRY_GHCR }}/${{ env.GHCR_NAMESPACE }}/${{ env.IMAGE_NAME }}:buildcache,mode=max
           sbom: ${{ inputs.sbom }}

--- a/.github/workflows/image-release.yml
+++ b/.github/workflows/image-release.yml
@@ -533,12 +533,12 @@ jobs:
           GH_PAT: ${{ steps.priv-token.outputs.token }}
         run: |
           if [[ "$HAS_PRIV" == "true" ]]; then
-            git config --global url."https://${GH_PAT}@github.com/nics-dp".insteadOf "https://github.com/nics-dp"
+            git config --global url."https://x-access-token:${GH_PAT}@github.com/nics-dp".insteadOf "https://github.com/nics-dp"
           fi
           go env -w GOPRIVATE=github.com/nics-dp GONOPROXY=github.com/nics-dp GONOSUMDB=github.com/nics-dp
           go mod vendor
           if [[ "$HAS_PRIV" == "true" ]]; then
-            git config --global --remove-section "url.https://${GH_PAT}@github.com/nics-dp" 2>/dev/null || true
+            git config --global --remove-section "url.https://x-access-token:${GH_PAT}@github.com/nics-dp" 2>/dev/null || true
           fi
 
       - name: Set up QEMU

--- a/.github/workflows/image-release.yml
+++ b/.github/workflows/image-release.yml
@@ -537,9 +537,17 @@ jobs:
           fi
           go env -w GOPRIVATE=github.com/nics-dp GONOPROXY=github.com/nics-dp GONOSUMDB=github.com/nics-dp
           go mod vendor
-          if [[ "$HAS_PRIV" == "true" ]]; then
-            git config --global --remove-section "url.https://x-access-token:${GH_PAT}@github.com/nics-dp" 2>/dev/null || true
-          fi
+
+      - name: Revoke private module access
+        # Separate always()-guarded step: go mod vendor runs under `set -e`, so an
+        # inline revoke after it would be skipped on vendor failure, leaving the
+        # token-bearing insteadOf rewrite in the runner's global git config
+        # (the releasers group runners are not ephemeral). Mirrors go-release.yml.
+        if: ${{ always() && inputs.go_vendor && env.HAS_CI_APP == 'true' }}
+        env:
+          GH_PAT: ${{ steps.priv-token.outputs.token }}
+        run: |
+          git config --global --remove-section "url.https://x-access-token:${GH_PAT}@github.com/nics-dp" 2>/dev/null || true
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0

--- a/.github/workflows/image-release.yml
+++ b/.github/workflows/image-release.yml
@@ -533,6 +533,13 @@ jobs:
           GH_PAT: ${{ steps.priv-token.outputs.token }}
         run: |
           if [[ "$HAS_PRIV" == "true" ]]; then
+            # Self-healing: drop any stale token-bearing url.*@github.com/nics-dp
+            # insteadOf rewrites left by a prior run before adding this run's
+            # fresh token, so an equal-length insteadOf tie can't pick up an
+            # expired token.
+            while read -r s; do
+              if [ -n "$s" ]; then git config --global --remove-section "$s" 2>/dev/null || true; fi
+            done < <(git config --global --name-only --get-regexp '^url\..*@github\.com/nics-dp' 2>/dev/null | sed -E 's/\.insteadof$//' | sort -u || true)
             git config --global url."https://x-access-token:${GH_PAT}@github.com/nics-dp".insteadOf "https://github.com/nics-dp"
           fi
           go env -w GOPRIVATE=github.com/nics-dp GONOPROXY=github.com/nics-dp GONOSUMDB=github.com/nics-dp

--- a/.github/workflows/image-release.yml
+++ b/.github/workflows/image-release.yml
@@ -166,7 +166,7 @@ jobs:
       - name: Setup | Mint private-module token
         id: priv-token
         if: env.HAS_CI_APP == 'true'
-        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           app-id: ${{ secrets.ci_read_app_id }}
           private-key: ${{ secrets.ci_read_app_private_key }}

--- a/.github/workflows/mise-task.yml
+++ b/.github/workflows/mise-task.yml
@@ -19,7 +19,8 @@
 #         task: ${{ matrix.task }}
 #         private-modules: true
 #       secrets:
-#         gh_pat: ${{ secrets.GH_PAT_READ_NICSDP }}
+#         ci_read_app_id: ${{ secrets.CI_READ_APP_ID }}
+#         ci_read_app_private_key: ${{ secrets.CI_READ_APP_PRIVATE_KEY }}
 
 name: mise-task
 
@@ -46,17 +47,14 @@ on:
         type: number
         default: 1
       private-modules:
-        description: "Configure git to authenticate to private GitHub repos via gh_pat secret"
+        description: "Configure git to authenticate to private GitHub repos via the ci-read App token"
         required: false
         type: boolean
         default: false
     secrets:
-      gh_pat:
-        description: "Fallback PAT (read access to private modules) used only when the ci_read_app_* App secrets are not provided. Relevant when private-modules=true."
-        required: false
       ci_read_app_id:
         required: false
-        description: "App ID of the nics-dp-ci-read GitHub App. Preferred over gh_pat for private module access; pass via secrets: inherit. Falls back to gh_pat when empty."
+        description: "App ID of the nics-dp-ci-read GitHub App for private module access (pass via secrets: inherit). Relevant when private-modules=true."
       ci_read_app_private_key:
         required: false
         description: "Private key of the nics-dp-ci-read GitHub App (pair with ci_read_app_id)."
@@ -88,10 +86,8 @@ jobs:
       # secrets cannot be used in step-level if:, so bridge to env here.
       HAS_CI_APP: ${{ secrets.ci_read_app_id != '' && secrets.ci_read_app_private_key != '' }}
     steps:
-      # Prefer a nics-dp-ci-read App token for private module access, but only when this
-      # run actually needs private modules. The App secrets arrive via `secrets: inherit`;
-      # when absent (legacy callers) the step is skipped and the git-config below falls
-      # back to gh_pat. See nics-dp PAT->App migration.
+      # Mint a nics-dp-ci-read App token for private module access, but only when this
+      # run actually needs private modules. The App secrets arrive via `secrets: inherit`.
       - name: Setup | Mint private-module token
         id: priv-token
         if: ${{ env.HAS_CI_APP == 'true' && inputs.private-modules }}
@@ -113,10 +109,10 @@ jobs:
       - name: Configure git for private modules
         if: ${{ inputs.private-modules }}
         env:
-          GH_PAT: ${{ steps.priv-token.outputs.token || secrets.gh_pat }}
+          GH_PAT: ${{ steps.priv-token.outputs.token }}
         run: |
           if [ -z "$GH_PAT" ]; then
-            echo "::warning::private-modules=true but neither the ci-read App token nor gh_pat is available"
+            echo "::warning::private-modules=true but the ci-read App token is unavailable (ci_read_app_* secrets not inherited?)"
             exit 0
           fi
           git config --global url."https://x-access-token:${GH_PAT}@github.com/nics-dp/".insteadOf "https://github.com/nics-dp/"

--- a/.github/workflows/mise-task.yml
+++ b/.github/workflows/mise-task.yml
@@ -107,7 +107,7 @@ jobs:
 
       - uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
         with:
-          version: "2026.6.3"
+          version: "2026.6.6"
           cache: true
 
       - name: Configure git for private modules

--- a/.github/workflows/mise-task.yml
+++ b/.github/workflows/mise-task.yml
@@ -95,7 +95,7 @@ jobs:
       - name: Setup | Mint private-module token
         id: priv-token
         if: ${{ env.HAS_CI_APP == 'true' && inputs.private-modules }}
-        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           app-id: ${{ secrets.ci_read_app_id }}
           private-key: ${{ secrets.ci_read_app_private_key }}

--- a/.github/workflows/sbom-source.yml
+++ b/.github/workflows/sbom-source.yml
@@ -32,7 +32,7 @@ on:
     secrets:
       ci_read_app_id:
         required: false
-        description: "App ID of the nics-dp-ci-read GitHub App. Preferred over the PAT for private module access; pass via secrets: inherit. Falls back to the PAT when empty."
+        description: "App ID of the nics-dp-ci-read GitHub App for private module access. Mints an installation token to fetch private nics-dp Go modules; pass via secrets: inherit. When absent the private-module steps are skipped."
       ci_read_app_private_key:
         required: false
         description: "Private key of the nics-dp-ci-read GitHub App (pair with ci_read_app_id)."

--- a/.github/workflows/sbom-source.yml
+++ b/.github/workflows/sbom-source.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Setup | Mint private-module token
         id: priv-token
         if: env.HAS_CI_APP == 'true'
-        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           app-id: ${{ secrets.ci_read_app_id }}
           private-key: ${{ secrets.ci_read_app_private_key }}

--- a/.github/workflows/sbom-source.yml
+++ b/.github/workflows/sbom-source.yml
@@ -30,9 +30,6 @@ on:
         default: '"ubuntu-latest"'
         description: 'Runner as JSON (e.g., ''"ubuntu-latest"'' or ''{"group":"releasers"}'')'
     secrets:
-      gh_pat:
-        required: false
-        description: "Optional PAT for private Go module access"
       ci_read_app_id:
         required: false
         description: "App ID of the nics-dp-ci-read GitHub App. Preferred over the PAT for private module access; pass via secrets: inherit. Falls back to the PAT when empty."
@@ -54,9 +51,8 @@ jobs:
       # secrets cannot be used in step-level if:, so bridge to env here.
       HAS_CI_APP: ${{ secrets.ci_read_app_id != '' && secrets.ci_read_app_private_key != '' }}
     steps:
-      # Prefer a nics-dp-ci-read App token for private module access. The App secrets
-      # arrive via `secrets: inherit`; when absent (legacy callers) the step is skipped
-      # and the git-config below falls back to gh_pat. See nics-dp PAT->App migration.
+      # Mint a nics-dp-ci-read App token for private module access. The App secrets
+      # arrive via `secrets: inherit`; when absent the git-config below is a no-op.
       - name: Setup | Mint private-module token
         id: priv-token
         if: env.HAS_CI_APP == 'true'
@@ -73,12 +69,12 @@ jobs:
           fetch-depth: 1
           # The ref is a workflow_call input and may be attacker-influenced;
           # do not persist the GITHUB_TOKEN. Private module access is granted
-          # separately via gh_pat (CodeQL actions/untrusted-checkout).
+          # separately via the App token (CodeQL actions/untrusted-checkout).
           persist-credentials: false
 
       - name: Configure git for private modules
         env:
-          GH_PAT: ${{ steps.priv-token.outputs.token || secrets.gh_pat }}
+          GH_PAT: ${{ steps.priv-token.outputs.token }}
         run: |
           if [ -n "$GH_PAT" ]; then
             git config --global url."https://x-access-token:${GH_PAT}@github.com/".insteadOf "https://github.com/"

--- a/.github/workflows/security-sarif.yml
+++ b/.github/workflows/security-sarif.yml
@@ -129,6 +129,9 @@ jobs:
 
       - name: Upload gosec SARIF
         if: always() && inputs.run_go && hashFiles('gosec.sarif') != ''
+        # non-blocking: a failed upload (API / permissions / SARIF format) must
+        # not fail the job and break the caller's CI.
+        continue-on-error: true
         uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
         with:
           sarif_file: gosec.sarif
@@ -145,6 +148,8 @@ jobs:
 
       - name: Upload govulncheck SARIF
         if: always() && inputs.run_go && hashFiles('govulncheck.sarif') != ''
+        # non-blocking: a failed upload must not fail the job (see gosec upload).
+        continue-on-error: true
         uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
         with:
           sarif_file: govulncheck.sarif
@@ -176,7 +181,9 @@ jobs:
           # pipx is preinstalled on GitHub-hosted runners and gives an isolated
           # install (avoids PEP 668 externally-managed-environment failures),
           # matching the pipx:semgrep tool used by the ci:semgrep mise task.
-          pipx install semgrep
+          # --force reinstalls cleanly when a reused runner already has semgrep,
+          # instead of erroring out and silently skipping the scan.
+          pipx install --force semgrep
           # --enable-nosem honours in-repo `nosem` suppression comments, mirroring
           # .mise/tasks/ci/semgrep (this differs only by dropping --error so
           # findings populate the Security tab without failing the job).
@@ -192,6 +199,8 @@ jobs:
 
       - name: Upload semgrep SARIF
         if: always() && inputs.run_semgrep && hashFiles('semgrep.sarif') != ''
+        # non-blocking: a failed upload must not fail the job (see gosec upload).
+        continue-on-error: true
         uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
         with:
           sarif_file: semgrep.sarif
@@ -213,6 +222,8 @@ jobs:
 
       - name: Upload trivy config SARIF
         if: always() && inputs.run_dockerfile && hashFiles('trivy-config.sarif') != ''
+        # non-blocking: a failed upload must not fail the job (see gosec upload).
+        continue-on-error: true
         uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
         with:
           sarif_file: trivy-config.sarif
@@ -231,6 +242,8 @@ jobs:
 
       - name: Upload hadolint SARIF
         if: always() && inputs.run_dockerfile && hashFiles('hadolint.sarif') != ''
+        # non-blocking: a failed upload must not fail the job (see gosec upload).
+        continue-on-error: true
         uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
         with:
           sarif_file: hadolint.sarif

--- a/.github/workflows/security-sarif.yml
+++ b/.github/workflows/security-sarif.yml
@@ -91,8 +91,17 @@ jobs:
           GH_PAT: ${{ secrets.gh_pat }}
         run: |
           if [ -n "$GH_PAT" ]; then
-            git config --global url."https://x-access-token:${GH_PAT}@github.com/".insteadOf "https://github.com/"
+            # Scope the PAT to a short-lived git config under $RUNNER_TEMP rather
+            # than the runner's default ~/.gitconfig, so the third-party
+            # trivy-action / hadolint-action that run later in this job cannot
+            # read the credential. GIT_CONFIG_GLOBAL is exported only for the
+            # Go-scan steps and the file is deleted by the cleanup step below.
+            PRIV_GITCONFIG="${RUNNER_TEMP}/security-sarif-gitconfig"
+            : > "$PRIV_GITCONFIG"
+            git config --file "$PRIV_GITCONFIG" \
+              url."https://x-access-token:${GH_PAT}@github.com/".insteadOf "https://github.com/"
             {
+              echo "GIT_CONFIG_GLOBAL=${PRIV_GITCONFIG}"
               echo "GOPRIVATE=github.com/nics-dp"
               echo "GONOSUMDB=github.com/nics-dp"
             } >> "$GITHUB_ENV"
@@ -100,9 +109,11 @@ jobs:
 
       # Consumer repos may vendor (-mod=vendor). Refresh the vendor tree so
       # gosec/govulncheck can type-check and build the module consistently;
-      # only acts when a vendor/ directory is present.
+      # only acts when a vendor/ directory is present. continue-on-error keeps
+      # the non-blocking contract if private-module access / vendoring fails.
       - name: Vendor Go modules
         if: inputs.run_go
+        continue-on-error: true
         run: |
           if [ -d vendor ]; then
             go mod vendor
@@ -139,6 +150,17 @@ jobs:
           sarif_file: govulncheck.sarif
           category: govulncheck
 
+      # Revoke the private-module credential before any third-party action runs:
+      # delete the short-lived git config and clear GIT_CONFIG_GLOBAL so the
+      # PAT is no longer reachable by trivy-action / hadolint-action below.
+      - name: Revoke private-module credential
+        if: always() && inputs.run_go
+        run: |
+          if [ -n "${GIT_CONFIG_GLOBAL:-}" ]; then
+            rm -f "$GIT_CONFIG_GLOBAL"
+          fi
+          echo "GIT_CONFIG_GLOBAL=" >> "$GITHUB_ENV"
+
       # ----------------------------------------------------------------------
       # semgrep (SAST). Mirrors .mise/tasks/ci/semgrep config selection
       # (p/ci baseline + go/python/typescript/javascript lang packs), minus
@@ -155,7 +177,11 @@ jobs:
           # install (avoids PEP 668 externally-managed-environment failures),
           # matching the pipx:semgrep tool used by the ci:semgrep mise task.
           pipx install semgrep
+          # --enable-nosem honours in-repo `nosem` suppression comments, mirroring
+          # .mise/tasks/ci/semgrep (this differs only by dropping --error so
+          # findings populate the Security tab without failing the job).
           semgrep scan \
+            --enable-nosem \
             --config p/ci \
             --config p/golang \
             --config p/python \

--- a/.github/workflows/security-sarif.yml
+++ b/.github/workflows/security-sarif.yml
@@ -195,7 +195,7 @@ jobs:
             --config p/typescript \
             --config p/javascript \
             --sarif --output semgrep.sarif \
-            "$SCAN_PATH"
+            -- "$SCAN_PATH"
 
       - name: Upload semgrep SARIF
         if: always() && inputs.run_semgrep && hashFiles('semgrep.sarif') != ''

--- a/.github/workflows/security-sarif.yml
+++ b/.github/workflows/security-sarif.yml
@@ -73,17 +73,23 @@ jobs:
           # Private module access is granted separately via gh_pat below.
           persist-credentials: false
 
-      # Constrain the caller-supplied scan_path to a workspace-relative path:
-      # reject absolute paths and any '..' segment so a misconfigured caller
-      # cannot point a scanner outside the checkout (which would otherwise leak
-      # out-of-tree file paths into the uploaded SARIF). The validated value is
-      # exported once as SCAN_PATH and reused by the semgrep and trivy steps.
+      # Pure fail-fast gate for the caller-supplied scan_path: reject an empty
+      # value, absolute paths, any '..' segment, and any newline/CR. This runs
+      # before every scanner (steps execute in order), so a path that escapes
+      # the workspace fails the job here instead of letting a scanner read
+      # out-of-tree files and leak their paths into the uploaded SARIF.
       #
-      # This step fails fast on an invalid path. That does NOT break the
-      # non-blocking contract: an out-of-workspace scan_path is a CALLER
-      # CONFIGURATION error and should be surfaced loudly, which is distinct
-      # from a scanner FINDING (those never fail the job). Mirrors the
-      # allowlist-then-fail input validation used by the go:dev / go:run atoms.
+      # The step ONLY validates -- it does not write the value to $GITHUB_ENV
+      # or $GITHUB_OUTPUT, so there is no user-controlled environment-file write
+      # (avoids CodeQL "env var from user-controlled source" / CRLF env-file
+      # injection). Each shell scanner re-bridges inputs.scan_path through its
+      # own per-step env var instead.
+      #
+      # Failing on a bad path does NOT break the non-blocking contract: an
+      # out-of-workspace scan_path is a CALLER CONFIGURATION error and should be
+      # surfaced loudly, which is distinct from a scanner FINDING (those never
+      # fail the job). Mirrors the allowlist-then-fail input validation used by
+      # the go:dev / go:run atoms.
       - name: Validate scan path
         env:
           RAW_SCAN_PATH: ${{ inputs.scan_path }}
@@ -94,15 +100,20 @@ jobs:
           fi
           case "$RAW_SCAN_PATH" in
             /*)
-              echo "::error::scan_path '${RAW_SCAN_PATH}' must be workspace-relative, not absolute"
+              echo "::error::scan_path must be workspace-relative, not absolute"
               exit 1
               ;;
             *..*)
-              echo "::error::scan_path '${RAW_SCAN_PATH}' must not contain '..'"
+              echo "::error::scan_path must not contain '..'"
               exit 1
               ;;
           esac
-          echo "SCAN_PATH=${RAW_SCAN_PATH}" >> "$GITHUB_ENV"
+          # Reject newline / carriage-return (CRLF env-file / log-injection guard)
+          # by comparing the value against itself with those bytes stripped.
+          if [ "$(printf '%s' "$RAW_SCAN_PATH" | tr -d '\n\r')" != "$RAW_SCAN_PATH" ]; then
+            echo "::error::scan_path must not contain newline or carriage-return characters"
+            exit 1
+          fi
 
       # ----------------------------------------------------------------------
       # Go scanners: gosec (SAST) + govulncheck (known vulns). Both must BUILD
@@ -207,6 +218,12 @@ jobs:
       - name: Run semgrep (SARIF)
         if: inputs.run_semgrep
         continue-on-error: true
+        env:
+          # Per-step env bridge: keep inputs.scan_path out of the shell command
+          # text (no ${{ }} interpolation -> no shell injection); the value was
+          # already gated by "Validate scan path" above. Quoted + passed after
+          # `--` so a leading dash is never parsed as a semgrep option.
+          SCAN_PATH: ${{ inputs.scan_path }}
         run: |
           # pipx is preinstalled on GitHub-hosted runners and gives an isolated
           # install (avoids PEP 668 externally-managed-environment failures),
@@ -245,8 +262,11 @@ jobs:
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           scan-type: config
-          # use the validated workspace-relative path (set by "Validate scan path")
-          scan-ref: ${{ env.SCAN_PATH }}
+          # trivy-action is a third-party action with no shell we control, so the
+          # value goes straight into its `scan-ref` input. Path safety is enforced
+          # by the earlier "Validate scan path" gate, which fails the job before
+          # this step for any absolute / '..' / newline path.
+          scan-ref: ${{ inputs.scan_path }}
           format: sarif
           output: trivy-config.sarif
           exit-code: "0"

--- a/.github/workflows/security-sarif.yml
+++ b/.github/workflows/security-sarif.yml
@@ -73,6 +73,37 @@ jobs:
           # Private module access is granted separately via gh_pat below.
           persist-credentials: false
 
+      # Constrain the caller-supplied scan_path to a workspace-relative path:
+      # reject absolute paths and any '..' segment so a misconfigured caller
+      # cannot point a scanner outside the checkout (which would otherwise leak
+      # out-of-tree file paths into the uploaded SARIF). The validated value is
+      # exported once as SCAN_PATH and reused by the semgrep and trivy steps.
+      #
+      # This step fails fast on an invalid path. That does NOT break the
+      # non-blocking contract: an out-of-workspace scan_path is a CALLER
+      # CONFIGURATION error and should be surfaced loudly, which is distinct
+      # from a scanner FINDING (those never fail the job). Mirrors the
+      # allowlist-then-fail input validation used by the go:dev / go:run atoms.
+      - name: Validate scan path
+        env:
+          RAW_SCAN_PATH: ${{ inputs.scan_path }}
+        run: |
+          if [ -z "$RAW_SCAN_PATH" ]; then
+            echo "::error::scan_path must not be empty (use '.' for the repo root)"
+            exit 1
+          fi
+          case "$RAW_SCAN_PATH" in
+            /*)
+              echo "::error::scan_path '${RAW_SCAN_PATH}' must be workspace-relative, not absolute"
+              exit 1
+              ;;
+            *..*)
+              echo "::error::scan_path '${RAW_SCAN_PATH}' must not contain '..'"
+              exit 1
+              ;;
+          esac
+          echo "SCAN_PATH=${RAW_SCAN_PATH}" >> "$GITHUB_ENV"
+
       # ----------------------------------------------------------------------
       # Go scanners: gosec (SAST) + govulncheck (known vulns). Both must BUILD
       # the module, which imports the private github.com/nics-dp/libdcf, so we
@@ -176,9 +207,6 @@ jobs:
       - name: Run semgrep (SARIF)
         if: inputs.run_semgrep
         continue-on-error: true
-        env:
-          # bridge the input to env to avoid shell injection via ${{ }} interpolation
-          SCAN_PATH: ${{ inputs.scan_path }}
         run: |
           # pipx is preinstalled on GitHub-hosted runners and gives an isolated
           # install (avoids PEP 668 externally-managed-environment failures),
@@ -217,7 +245,8 @@ jobs:
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           scan-type: config
-          scan-ref: ${{ inputs.scan_path }}
+          # use the validated workspace-relative path (set by "Validate scan path")
+          scan-ref: ${{ env.SCAN_PATH }}
           format: sarif
           output: trivy-config.sarif
           exit-code: "0"

--- a/.github/workflows/security-sarif.yml
+++ b/.github/workflows/security-sarif.yml
@@ -151,7 +151,10 @@ jobs:
           # bridge the input to env to avoid shell injection via ${{ }} interpolation
           SCAN_PATH: ${{ inputs.scan_path }}
         run: |
-          python3 -m pip install --quiet --upgrade semgrep
+          # pipx is preinstalled on GitHub-hosted runners and gives an isolated
+          # install (avoids PEP 668 externally-managed-environment failures),
+          # matching the pipx:semgrep tool used by the ci:semgrep mise task.
+          pipx install semgrep
           semgrep scan \
             --config p/ci \
             --config p/golang \

--- a/.github/workflows/security-sarif.yml
+++ b/.github/workflows/security-sarif.yml
@@ -1,0 +1,208 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+
+name: Security SARIF
+
+# Runs the security / IaC scanners that historically only GATED CI (no SARIF
+# export) and uploads their findings to GitHub code scanning (Security > Code
+# scanning), each under a distinct category. NON-BLOCKING by design: a scan
+# step erroring or finding issues never fails the caller's CI — findings only
+# populate the Security tab. Callers add a job that `uses:` this workflow.
+on:
+  workflow_call:
+    inputs:
+      ref:
+        required: false
+        type: string
+        default: ""
+        description: "Git ref to checkout (defaults to event ref)"
+      runs_on:
+        required: false
+        type: string
+        default: '"ubuntu-latest"'
+        description: 'Runner as JSON (e.g., ''"ubuntu-latest"'' or ''{"group":"releasers"}'')'
+      go_version:
+        required: false
+        type: string
+        default: "stable"
+        description: "Go toolchain version for gosec/govulncheck"
+      scan_path:
+        required: false
+        type: string
+        default: "."
+        description: "Directory to scan (trivy config / semgrep root)"
+      run_go:
+        required: false
+        type: boolean
+        default: true
+        description: "Run the Go scanners (gosec + govulncheck)"
+      run_dockerfile:
+        required: false
+        type: boolean
+        default: true
+        description: "Run the Dockerfile scanners (hadolint + trivy config)"
+      run_semgrep:
+        required: false
+        type: boolean
+        default: true
+        description: "Run the semgrep SAST scan"
+    secrets:
+      gh_pat:
+        required: false
+        description: "Optional PAT for private Go module access (gosec/govulncheck must build github.com/nics-dp/libdcf)"
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  security-sarif:
+    runs-on: ${{ fromJSON(inputs.runs_on) }}
+    permissions:
+      contents: read
+      # required by github/codeql-action/upload-sarif to write code-scanning results
+      security-events: write
+      actions: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          ref: ${{ inputs.ref }}
+          fetch-depth: 1
+          # The ref is a workflow_call input and may be attacker-influenced;
+          # do not persist the GITHUB_TOKEN into the checkout so later steps
+          # cannot be coerced into using it (CodeQL actions/untrusted-checkout).
+          # Private module access is granted separately via gh_pat below.
+          persist-credentials: false
+
+      # ----------------------------------------------------------------------
+      # Go scanners: gosec (SAST) + govulncheck (known vulns). Both must BUILD
+      # the module, which imports the private github.com/nics-dp/libdcf, so we
+      # set up Go and configure git to fetch private modules via gh_pat.
+      # ----------------------------------------------------------------------
+      - name: Set up Go
+        if: inputs.run_go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version: ${{ inputs.go_version }}
+          cache: false
+
+      - name: Configure git for private modules
+        if: inputs.run_go
+        env:
+          GH_PAT: ${{ secrets.gh_pat }}
+        run: |
+          if [ -n "$GH_PAT" ]; then
+            git config --global url."https://x-access-token:${GH_PAT}@github.com/".insteadOf "https://github.com/"
+            {
+              echo "GOPRIVATE=github.com/nics-dp"
+              echo "GONOSUMDB=github.com/nics-dp"
+            } >> "$GITHUB_ENV"
+          fi
+
+      # Consumer repos may vendor (-mod=vendor). Refresh the vendor tree so
+      # gosec/govulncheck can type-check and build the module consistently;
+      # only acts when a vendor/ directory is present.
+      - name: Vendor Go modules
+        if: inputs.run_go
+        run: |
+          if [ -d vendor ]; then
+            go mod vendor
+          fi
+
+      - name: Run gosec (SARIF)
+        if: inputs.run_go
+        continue-on-error: true
+        run: |
+          go install github.com/securego/gosec/v2/cmd/gosec@v2.27.1
+          # -no-fail keeps exit 0 regardless of findings; SARIF lands in gosec.sarif
+          gosec -fmt sarif -out gosec.sarif -no-fail ./...
+
+      - name: Upload gosec SARIF
+        if: always() && inputs.run_go && hashFiles('gosec.sarif') != ''
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        with:
+          sarif_file: gosec.sarif
+          category: gosec
+
+      - name: Run govulncheck (SARIF)
+        if: inputs.run_go
+        continue-on-error: true
+        run: |
+          go install golang.org/x/vuln/cmd/govulncheck@v1.3.0
+          # -format sarif makes govulncheck exit 0 regardless of findings; the
+          # || true is a guard in case the build itself errors out.
+          govulncheck -format sarif ./... > govulncheck.sarif || true
+
+      - name: Upload govulncheck SARIF
+        if: always() && inputs.run_go && hashFiles('govulncheck.sarif') != ''
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        with:
+          sarif_file: govulncheck.sarif
+          category: govulncheck
+
+      # ----------------------------------------------------------------------
+      # semgrep (SAST). Mirrors .mise/tasks/ci/semgrep config selection
+      # (p/ci baseline + go/python/typescript/javascript lang packs), minus
+      # --error so findings never fail the job.
+      # ----------------------------------------------------------------------
+      - name: Run semgrep (SARIF)
+        if: inputs.run_semgrep
+        continue-on-error: true
+        env:
+          # bridge the input to env to avoid shell injection via ${{ }} interpolation
+          SCAN_PATH: ${{ inputs.scan_path }}
+        run: |
+          python3 -m pip install --quiet --upgrade semgrep
+          semgrep scan \
+            --config p/ci \
+            --config p/golang \
+            --config p/python \
+            --config p/typescript \
+            --config p/javascript \
+            --sarif --output semgrep.sarif \
+            "$SCAN_PATH"
+
+      - name: Upload semgrep SARIF
+        if: always() && inputs.run_semgrep && hashFiles('semgrep.sarif') != ''
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        with:
+          sarif_file: semgrep.sarif
+          category: semgrep
+
+      # ----------------------------------------------------------------------
+      # IaC / Dockerfile scanners: trivy config (misconfig) + hadolint (lint).
+      # ----------------------------------------------------------------------
+      - name: Run trivy config (SARIF)
+        if: inputs.run_dockerfile
+        continue-on-error: true
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          scan-type: config
+          scan-ref: ${{ inputs.scan_path }}
+          format: sarif
+          output: trivy-config.sarif
+          exit-code: "0"
+
+      - name: Upload trivy config SARIF
+        if: always() && inputs.run_dockerfile && hashFiles('trivy-config.sarif') != ''
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        with:
+          sarif_file: trivy-config.sarif
+          category: trivy-config
+
+      - name: Run hadolint (SARIF)
+        if: inputs.run_dockerfile
+        continue-on-error: true
+        uses: hadolint/hadolint-action@2332a7b74a6de0dda2e2221d575162eba76ba5e5 # v3.3.0
+        with:
+          dockerfile: Dockerfile*
+          recursive: true
+          format: sarif
+          output-file: hadolint.sarif
+          no-fail: true
+
+      - name: Upload hadolint SARIF
+        if: always() && inputs.run_dockerfile && hashFiles('hadolint.sarif') != ''
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        with:
+          sarif_file: hadolint.sarif
+          category: hadolint

--- a/.github/workflows/security-sarif.yml
+++ b/.github/workflows/security-sarif.yml
@@ -15,11 +15,6 @@ on:
         type: string
         default: ""
         description: "Git ref to checkout (defaults to event ref)"
-      runs_on:
-        required: false
-        type: string
-        default: '"ubuntu-latest"'
-        description: 'Runner as JSON (e.g., ''"ubuntu-latest"'' or ''{"group":"releasers"}'')'
       go_version:
         required: false
         type: string
@@ -55,7 +50,10 @@ env:
 
 jobs:
   security-sarif:
-    runs-on: ${{ fromJSON(inputs.runs_on) }}
+    # Pinned to ubuntu-latest: this workflow depends on Linux/Docker-based
+    # actions (hadolint-action, trivy-action) and bash scan steps, so it is not
+    # portable to Windows/macOS runners. No caller passes a custom runner.
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       # required by github/codeql-action/upload-sarif to write code-scanning results
@@ -103,8 +101,14 @@ jobs:
               echo "::error::scan_path must be workspace-relative, not absolute"
               exit 1
               ;;
-            *..*)
-              echo "::error::scan_path must not contain '..'"
+          esac
+          # Reject '..' only as a complete path segment (parent-dir traversal),
+          # not a literal substring -- pad with leading/trailing '/' so '*/../*'
+          # matches a real ".." segment while legitimate names like 'my..dir'
+          # are allowed.
+          case "/$RAW_SCAN_PATH/" in
+            */../*)
+              echo "::error::scan_path must not contain a '..' path segment"
               exit 1
               ;;
           esac

--- a/.github/workflows/security-sarif.yml
+++ b/.github/workflows/security-sarif.yml
@@ -98,8 +98,10 @@ jobs:
             # Go-scan steps and the file is deleted by the cleanup step below.
             PRIV_GITCONFIG="${RUNNER_TEMP}/security-sarif-gitconfig"
             : > "$PRIV_GITCONFIG"
+            # Scope the rewrite to the nics-dp org prefix so only private org
+            # modules carry the token; public github.com fetches stay anonymous.
             git config --file "$PRIV_GITCONFIG" \
-              url."https://x-access-token:${GH_PAT}@github.com/".insteadOf "https://github.com/"
+              url."https://x-access-token:${GH_PAT}@github.com/nics-dp/".insteadOf "https://github.com/nics-dp/"
             {
               echo "GIT_CONFIG_GLOBAL=${PRIV_GITCONFIG}"
               echo "GOPRIVATE=github.com/nics-dp"

--- a/.ruler/AGENTS.md
+++ b/.ruler/AGENTS.md
@@ -47,8 +47,8 @@ includes = ["git::https://github.com/nics-dp/meta.git//.mise/tasks?ref=main"]
 
 **Shared configs (`configs/`)**: Atoms fetch raw URLs at runtime (no commit to consumer repos). Trap cleanup removes the downloaded config when atom exits. Note: `.golangci.yml` is **per-repo committed** (not shared via curl) — `go:lint-check` / `go:lint-fix` read consumer's own file because gofumpt requires per-module `module-path` setting.
 
-**PAT split**:
-- `GH_PAT_READ_NICSDP` — private module access, CodeQL private-repo access, release/snapshot builds, `mise-task.yml` private-modules flag
+**Auth (GitHub App + DockerHub)**:
+- `CI_READ_APP_ID` / `CI_READ_APP_PRIVATE_KEY` — nics-dp-ci-read App token (org secrets): private module access, CodeQL private-repo access, release/snapshot builds, `mise-task.yml` private-modules flag. Callers pass via `secrets: inherit` (no PAT).
 - `DOCKERHUB_USERNAME` / `DOCKERHUB_TOKEN` — image-release.yml (Docker image push)
 
 ## Key Files
@@ -66,7 +66,7 @@ includes = ["git::https://github.com/nics-dp/meta.git//.mise/tasks?ref=main"]
 ## Workflow Architecture
 
 ### Core
-- **`mise-task.yml`** — Reusable. Inputs: `task`, `name`, `runs_on` (JSON via `fromJSON()`), `fetch-depth`, `private-modules`. Secret: `gh_pat`. Encapsulates checkout (SHA-pinned) + `jdx/mise-action@<sha>` + optional git private-modules config + run mise atom + step summary + enforce.
+- **`mise-task.yml`** — Reusable. Inputs: `task`, `name`, `runs_on` (JSON via `fromJSON()`), `fetch-depth`, `private-modules`. Secrets: `ci_read_app_id` / `ci_read_app_private_key`. Encapsulates checkout (SHA-pinned) + `jdx/mise-action@<sha>` + optional git private-modules config + run mise atom + step summary + enforce.
 
 ### Release & Build
 - **`go-release.yml`** — Multi-arch Go binary release (cosign, macOS notarize via quill, GitHub Release).

--- a/README.md
+++ b/README.md
@@ -173,7 +173,8 @@ jobs:
       runs_on: '{"group":"releasers"}'
       private-modules: true
     secrets:
-      gh_pat: ${{ secrets.GH_PAT_READ_NICSDP }}
+      ci_read_app_id: ${{ secrets.CI_READ_APP_ID }}
+      ci_read_app_private_key: ${{ secrets.CI_READ_APP_PRIVATE_KEY }}
 ```
 
 | Input             | Type    | Default          | 用途                                                          |
@@ -182,9 +183,9 @@ jobs:
 | `name`            | string  | task             | display name for GH job summary                               |
 | `runs_on`         | string  | `'"ubuntu-latest"'` | runner（JSON 經 `fromJSON()` 解析；可傳 `'{"group":"X"}'`） |
 | `fetch-depth`     | number  | `1`              | git fetch depth                                               |
-| `private-modules` | boolean | `false`          | 啟用 GH PAT git config for private modules                    |
+| `private-modules` | boolean | `false`          | 啟用 ci-read App token git config for private modules         |
 
-Secret `gh_pat`：required when `private-modules=true`。
+Secrets `ci_read_app_id` / `ci_read_app_private_key`（nics-dp-ci-read App）：用於 `private-modules=true`；caller 建議以 `secrets: inherit` 傳遞 org secrets `CI_READ_APP_ID` / `CI_READ_APP_PRIVATE_KEY`。
 
 每 job 結尾自動 emit `## <name>` block 至 GitHub Actions step summary，含 ✅/❌ 狀態 + `<details>` 包 tail 300 行 stdout/stderr。
 
@@ -269,8 +270,8 @@ Meta repo 自家 `renovate.json` 額外 customManagers 處理：
 2. 確認 `[task_config].includes = ["git::https://github.com/nics-dp/meta.git//.mise/tasks?ref=main"]`
 3. 加 repo-specific tasks/tools/env at end
 4. 寫 `.github/workflows/ci.yml`，用 matrix 呼叫 `nics-dp/meta/.github/workflows/mise-task.yml@main`
-5. 設 secrets:
-   - `GH_PAT_READ_NICSDP` (Go 私模 + CodeQL private repo + release/snapshot)
+5. 設 secrets（caller 用 `secrets: inherit` 傳 org secrets）:
+   - `CI_READ_APP_ID` + `CI_READ_APP_PRIVATE_KEY` (nics-dp-ci-read App：Go 私模 + CodeQL private repo + release/snapshot)
    - `DOCKERHUB_USERNAME` + `DOCKERHUB_TOKEN` (Docker image repos)
 
 驗證：`mise tasks ls` 應顯示 ~10 facade 名 + repo-specific extras（atoms hidden）；`mise run --dry-run ci test sbom` resolve 無誤。

--- a/renovate.json
+++ b/renovate.json
@@ -48,6 +48,30 @@
     },
     {
       "customType": "regex",
+      "description": "Update gosec version in the security-sarif workflow",
+      "managerFilePatterns": [
+        "/^\\.github/workflows/security-sarif\\.yml$/"
+      ],
+      "matchStrings": [
+        "go install github\\.com/securego/gosec/v2/cmd/gosec@(?<currentValue>v\\d+\\.\\d+\\.\\d+)"
+      ],
+      "depNameTemplate": "securego/gosec",
+      "datasourceTemplate": "github-releases"
+    },
+    {
+      "customType": "regex",
+      "description": "Update govulncheck version in the security-sarif workflow",
+      "managerFilePatterns": [
+        "/^\\.github/workflows/security-sarif\\.yml$/"
+      ],
+      "matchStrings": [
+        "go install golang\\.org/x/vuln/cmd/govulncheck@(?<currentValue>v\\d+\\.\\d+\\.\\d+)"
+      ],
+      "depNameTemplate": "golang.org/x/vuln",
+      "datasourceTemplate": "go"
+    },
+    {
+      "customType": "regex",
       "description": "Update air (air-verse/air) version in the go:dev mise task (tools header + config-free fallback)",
       "managerFilePatterns": [
         "/^\\.mise/tasks/go/dev$/"

--- a/templates/facades/mise.python.toml
+++ b/templates/facades/mise.python.toml
@@ -9,7 +9,7 @@ unix_default_inline_shell_args = "bash -c"
 # ------------------------------------------------------------------------------
 [tools]
 # Python toolchain
-python = "3.14.5"
+python = "3.14.6"
 uv = "latest"
 
 [env]


### PR DESCRIPTION
## Release v0.2.4.7

Gitflow patch release: merges accumulated `dev` work into `main`. Brings `main`
up to `dev` and reconciles the divergence created when the v0.2.4.6 auth hotfix
went straight to `main`.

### Included

- **fix(ci): private-module git auth self-healing** — scrub stale
  `url.*@github.com/nics-dp*` `insteadOf` rewrites before configuring the fresh
  `x-access-token` token, in `go-release` / `image-release` / `codeql-reusable`
  (#168). Defense-in-depth against equal-length `insteadOf` ties on a persistent
  runner.
- **ci: security-sarif reusable workflow** — gosec / govulncheck / semgrep /
  trivy-config / hadolint with SARIF upload to the Security tab, non-blocking
  (#158).
- **ci: drop gh_pat fallback** now all callers use the ci-read App (#164).
- **chore(deps): renovate bumps** — github-actions v3, jdx/mise, mise dev tools
  (#161, #162, #163).
- Docs: README / AGENTS updated for the ci-read App (drop GH_PAT_READ_NICSDP).

Note: the v0.2.4.6 `x-access-token` auth fix is already on `main`; it appears on
`dev` as equivalent commits, so it is not part of this diff.

Merge as a merge commit (admin bypass per the meta release convention), then tag
`v0.2.4.7` on `main`.
