### PR TITLE
ci: use client-id (org var) for create-github-app-token, retire app-id

### DIFF
--- a/.github/workflows/codeql-reusable.yml
+++ b/.github/workflows/codeql-reusable.yml
@@ -27,10 +27,10 @@ on:
     secrets:
       ci_read_app_id:
         required: false
-        description: "App ID of the nics-dp-ci-read GitHub App for private module access (pass via secrets: inherit)."
+        description: "Legacy/unused: the nics-dp-ci-read App is now identified by the CI_READ_APP_CLIENT_ID org variable (client-id); this input is kept only for backward compatibility with callers still passing it, and is ignored."
       ci_read_app_private_key:
         required: false
-        description: "Private key of the nics-dp-ci-read GitHub App (pair with ci_read_app_id)."
+        description: "Private key of the nics-dp-ci-read GitHub App (paired with the CI_READ_APP_CLIENT_ID org variable)."
 
 jobs:
   analyze:
@@ -43,7 +43,7 @@ jobs:
       contents: read
     env:
       # secrets cannot be used in step-level if:, so bridge to env here.
-      HAS_CI_APP: ${{ secrets.ci_read_app_id != '' && secrets.ci_read_app_private_key != '' }}
+      HAS_CI_APP: ${{ vars.CI_READ_APP_CLIENT_ID != '' && secrets.ci_read_app_private_key != '' }}
       USE_PRIVATE_GO: ${{ inputs.use-private-go-modules }}
 
     strategy:
@@ -52,14 +52,14 @@ jobs:
         include: ${{ fromJSON(inputs.matrix-include) }}
 
     steps:
-      # Mint a nics-dp-ci-read App token for private module access. The App secrets
-      # arrive via `secrets: inherit`; when absent the private-module steps are skipped.
+      # Mint a nics-dp-ci-read App token for private module access. The client-id comes
+      # from the CI_READ_APP_CLIENT_ID org variable; when the private key is absent the private-module steps are skipped.
       - name: Setup | Mint private-module token
         id: priv-token
         if: env.HAS_CI_APP == 'true'
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.ci_read_app_id }}
+          client-id: ${{ vars.CI_READ_APP_CLIENT_ID }}
           private-key: ${{ secrets.ci_read_app_private_key }}
           owner: ${{ github.repository_owner }}
 

--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -80,10 +80,10 @@ on:
     secrets:
       ci_read_app_id:
         required: false
-        description: "App ID of the nics-dp-ci-read GitHub App for private module access (pass via secrets: inherit)."
+        description: "Legacy/unused: the nics-dp-ci-read App is now identified by the CI_READ_APP_CLIENT_ID org variable (client-id); this input is kept only for backward compatibility with callers still passing it, and is ignored."
       ci_read_app_private_key:
         required: false
-        description: "Private key of the nics-dp-ci-read GitHub App (pair with ci_read_app_id)."
+        description: "Private key of the nics-dp-ci-read GitHub App (paired with the CI_READ_APP_CLIENT_ID org variable)."
       quill_sign_p12:
         required: false
       quill_sign_password:
@@ -172,16 +172,16 @@ jobs:
       matrix: ${{ fromJSON(needs.prepare.outputs.matrix) }}
     env:
       # secrets cannot be used in step-level if:, so bridge to env here.
-      HAS_CI_APP: ${{ secrets.ci_read_app_id != '' && secrets.ci_read_app_private_key != '' }}
+      HAS_CI_APP: ${{ vars.CI_READ_APP_CLIENT_ID != '' && secrets.ci_read_app_private_key != '' }}
     steps:
-      # Mint a nics-dp-ci-read App token for private module access. The App secrets
-      # arrive via `secrets: inherit`; when absent the private-module steps are skipped.
+      # Mint a nics-dp-ci-read App token for private module access. The client-id comes
+      # from the CI_READ_APP_CLIENT_ID org variable; when the private key is absent the private-module steps are skipped.
       - name: Setup | Mint private-module token
         id: priv-token
         if: env.HAS_CI_APP == 'true'
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.ci_read_app_id }}
+          client-id: ${{ vars.CI_READ_APP_CLIENT_ID }}
           private-key: ${{ secrets.ci_read_app_private_key }}
           owner: ${{ github.repository_owner }}
 

--- a/.github/workflows/image-release.yml
+++ b/.github/workflows/image-release.yml
@@ -128,10 +128,10 @@ on:
         required: true
       ci_read_app_id:
         required: false
-        description: "App ID of the nics-dp-ci-read GitHub App for private module/repo access during checkout and build (pass via secrets: inherit). GHCR push uses GITHUB_TOKEN, not this."
+        description: "Legacy/unused: the nics-dp-ci-read App is now identified by the CI_READ_APP_CLIENT_ID org variable (client-id); this input is kept only for backward compatibility with callers still passing it, and is ignored."
       ci_read_app_private_key:
         required: false
-        description: "Private key of the nics-dp-ci-read GitHub App (pair with ci_read_app_id)."
+        description: "Private key of the nics-dp-ci-read GitHub App (paired with the CI_READ_APP_CLIENT_ID org variable)."
 
 env:
   REGISTRY_DH: docker.io
@@ -153,17 +153,17 @@ jobs:
       id-token: write
     env:
       # secrets cannot be used in step-level if:, so bridge to env here.
-      HAS_CI_APP: ${{ secrets.ci_read_app_id != '' && secrets.ci_read_app_private_key != '' }}
+      HAS_CI_APP: ${{ vars.CI_READ_APP_CLIENT_ID != '' && secrets.ci_read_app_private_key != '' }}
 
     steps:
-      # Mint a nics-dp-ci-read App token for private module access. The App secrets
-      # arrive via `secrets: inherit`; when absent the private-module steps are skipped.
+      # Mint a nics-dp-ci-read App token for private module access. The client-id comes
+      # from the CI_READ_APP_CLIENT_ID org variable; when the private key is absent the private-module steps are skipped.
       - name: Setup | Mint private-module token
         id: priv-token
         if: env.HAS_CI_APP == 'true'
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.ci_read_app_id }}
+          client-id: ${{ vars.CI_READ_APP_CLIENT_ID }}
           private-key: ${{ secrets.ci_read_app_private_key }}
           owner: ${{ github.repository_owner }}
 

--- a/.github/workflows/mise-task.yml
+++ b/.github/workflows/mise-task.yml
@@ -19,8 +19,9 @@
 #         task: ${{ matrix.task }}
 #         private-modules: true
 #       secrets:
-#         ci_read_app_id: ${{ secrets.CI_READ_APP_ID }}
 #         ci_read_app_private_key: ${{ secrets.CI_READ_APP_PRIVATE_KEY }}
+#       # client-id is read from the CI_READ_APP_CLIENT_ID org variable (auto-available in
+#       # reusable workflows, no passing needed); ci_read_app_id input is legacy/ignored.
 
 name: mise-task
 
@@ -54,10 +55,10 @@ on:
     secrets:
       ci_read_app_id:
         required: false
-        description: "App ID of the nics-dp-ci-read GitHub App for private module access (pass via secrets: inherit). Relevant when private-modules=true."
+        description: "Legacy/unused: the nics-dp-ci-read App is now identified by the CI_READ_APP_CLIENT_ID org variable (client-id); this input is kept only for backward compatibility with callers still passing it, and is ignored."
       ci_read_app_private_key:
         required: false
-        description: "Private key of the nics-dp-ci-read GitHub App (pair with ci_read_app_id)."
+        description: "Private key of the nics-dp-ci-read GitHub App (paired with the CI_READ_APP_CLIENT_ID org variable)."
 
 permissions:
   contents: read
@@ -84,16 +85,16 @@ jobs:
       MISE_MINIMUM_RELEASE_AGE: "0"
       MISE_USE_VERSIONS_HOST: "false"
       # secrets cannot be used in step-level if:, so bridge to env here.
-      HAS_CI_APP: ${{ secrets.ci_read_app_id != '' && secrets.ci_read_app_private_key != '' }}
+      HAS_CI_APP: ${{ vars.CI_READ_APP_CLIENT_ID != '' && secrets.ci_read_app_private_key != '' }}
     steps:
       # Mint a nics-dp-ci-read App token for private module access, but only when this
-      # run actually needs private modules. The App secrets arrive via `secrets: inherit`.
+      # run actually needs private modules. The client-id comes from the CI_READ_APP_CLIENT_ID org variable.
       - name: Setup | Mint private-module token
         id: priv-token
         if: ${{ env.HAS_CI_APP == 'true' && inputs.private-modules }}
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.ci_read_app_id }}
+          client-id: ${{ vars.CI_READ_APP_CLIENT_ID }}
           private-key: ${{ secrets.ci_read_app_private_key }}
           owner: ${{ github.repository_owner }}
 

--- a/.github/workflows/sbom-source.yml
+++ b/.github/workflows/sbom-source.yml
@@ -32,10 +32,10 @@ on:
     secrets:
       ci_read_app_id:
         required: false
-        description: "App ID of the nics-dp-ci-read GitHub App for private module access. Mints an installation token to fetch private nics-dp Go modules; pass via secrets: inherit. When absent the private-module steps are skipped."
+        description: "Legacy/unused: the nics-dp-ci-read App is now identified by the CI_READ_APP_CLIENT_ID org variable (client-id); this input is kept only for backward compatibility with callers still passing it, and is ignored."
       ci_read_app_private_key:
         required: false
-        description: "Private key of the nics-dp-ci-read GitHub App (pair with ci_read_app_id)."
+        description: "Private key of the nics-dp-ci-read GitHub App (paired with the CI_READ_APP_CLIENT_ID org variable)."
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
@@ -49,16 +49,16 @@ jobs:
       security-events: write
     env:
       # secrets cannot be used in step-level if:, so bridge to env here.
-      HAS_CI_APP: ${{ secrets.ci_read_app_id != '' && secrets.ci_read_app_private_key != '' }}
+      HAS_CI_APP: ${{ vars.CI_READ_APP_CLIENT_ID != '' && secrets.ci_read_app_private_key != '' }}
     steps:
-      # Mint a nics-dp-ci-read App token for private module access. The App secrets
-      # arrive via `secrets: inherit`; when absent the git-config below is a no-op.
+      # Mint a nics-dp-ci-read App token for private module access. The client-id comes
+      # from the CI_READ_APP_CLIENT_ID org variable; when the private key is absent the git-config below is a no-op.
       - name: Setup | Mint private-module token
         id: priv-token
         if: env.HAS_CI_APP == 'true'
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.ci_read_app_id }}
+          client-id: ${{ vars.CI_READ_APP_CLIENT_ID }}
           private-key: ${{ secrets.ci_read_app_private_key }}
           owner: ${{ github.repository_owner }}
 

--- a/.ruler/AGENTS.md
+++ b/.ruler/AGENTS.md
@@ -48,7 +48,7 @@ includes = ["git::https://github.com/nics-dp/meta.git//.mise/tasks?ref=main"]
 **Shared configs (`configs/`)**: Atoms fetch raw URLs at runtime (no commit to consumer repos). Trap cleanup removes the downloaded config when atom exits. Note: `.golangci.yml` is **per-repo committed** (not shared via curl) — `go:lint-check` / `go:lint-fix` read consumer's own file because gofumpt requires per-module `module-path` setting.
 
 **Auth (GitHub App + DockerHub)**:
-- `CI_READ_APP_ID` / `CI_READ_APP_PRIVATE_KEY` — nics-dp-ci-read App token (org secrets): private module access, CodeQL private-repo access, release/snapshot builds, `mise-task.yml` private-modules flag. Callers pass via `secrets: inherit` (no PAT).
+- nics-dp-ci-read App token (private module access, CodeQL private-repo access, release/snapshot builds, `mise-task.yml` private-modules flag): client-id from org **variable** `CI_READ_APP_CLIENT_ID` (auto-available in reusable workflows via `vars`); private key from org **secret** `CI_READ_APP_PRIVATE_KEY`, passed by callers as `ci_read_app_private_key`. Legacy `ci_read_app_id` input retired (kept for compat, ignored). No PAT.
 - `DOCKERHUB_USERNAME` / `DOCKERHUB_TOKEN` — image-release.yml (Docker image push)
 
 ## Key Files
@@ -66,7 +66,7 @@ includes = ["git::https://github.com/nics-dp/meta.git//.mise/tasks?ref=main"]
 ## Workflow Architecture
 
 ### Core
-- **`mise-task.yml`** — Reusable. Inputs: `task`, `name`, `runs_on` (JSON via `fromJSON()`), `fetch-depth`, `private-modules`. Secrets: `ci_read_app_id` / `ci_read_app_private_key`. Encapsulates checkout (SHA-pinned) + `jdx/mise-action@<sha>` + optional git private-modules config + run mise atom + step summary + enforce.
+- **`mise-task.yml`** — Reusable. Inputs: `task`, `name`, `runs_on` (JSON via `fromJSON()`), `fetch-depth`, `private-modules`. Secret: `ci_read_app_private_key` (client-id via `CI_READ_APP_CLIENT_ID` org var; legacy `ci_read_app_id` input ignored). Encapsulates checkout (SHA-pinned) + `jdx/mise-action@<sha>` + optional git private-modules config + run mise atom + step summary + enforce.
 
 ### Release & Build
 - **`go-release.yml`** — Multi-arch Go binary release (cosign, macOS notarize via quill, GitHub Release).

--- a/README.md
+++ b/README.md
@@ -173,8 +173,9 @@ jobs:
       runs_on: '{"group":"releasers"}'
       private-modules: true
     secrets:
-      ci_read_app_id: ${{ secrets.CI_READ_APP_ID }}
       ci_read_app_private_key: ${{ secrets.CI_READ_APP_PRIVATE_KEY }}
+    # client-id is read from the CI_READ_APP_CLIENT_ID org variable (auto-available
+    # in reusable workflows); no need to pass it as a secret.
 ```
 
 | Input             | Type    | Default          | 用途                                                          |
@@ -185,7 +186,7 @@ jobs:
 | `fetch-depth`     | number  | `1`              | git fetch depth                                               |
 | `private-modules` | boolean | `false`          | 啟用 ci-read App token git config for private modules         |
 
-Secrets `ci_read_app_id` / `ci_read_app_private_key`（nics-dp-ci-read App）：用於 `private-modules=true`；caller 建議以 `secrets: inherit` 傳遞 org secrets `CI_READ_APP_ID` / `CI_READ_APP_PRIVATE_KEY`。
+App 認證（nics-dp-ci-read，用於 `private-modules=true`）：client-id 由 org **變數** `CI_READ_APP_CLIENT_ID` 提供（reusable workflow 經 `vars` context 自動取得，毋須傳遞）；caller 僅需以 secret 傳 `ci_read_app_private_key`（org secret `CI_READ_APP_PRIVATE_KEY`）。legacy `ci_read_app_id` 輸入已停用、保留相容但忽略。
 
 每 job 結尾自動 emit `## <name>` block 至 GitHub Actions step summary，含 ✅/❌ 狀態 + `<details>` 包 tail 300 行 stdout/stderr。
 
@@ -270,8 +271,9 @@ Meta repo 自家 `renovate.json` 額外 customManagers 處理：
 2. 確認 `[task_config].includes = ["git::https://github.com/nics-dp/meta.git//.mise/tasks?ref=main"]`
 3. 加 repo-specific tasks/tools/env at end
 4. 寫 `.github/workflows/ci.yml`，用 matrix 呼叫 `nics-dp/meta/.github/workflows/mise-task.yml@main`
-5. 設 secrets（caller 用 `secrets: inherit` 傳 org secrets）:
-   - `CI_READ_APP_ID` + `CI_READ_APP_PRIVATE_KEY` (nics-dp-ci-read App：Go 私模 + CodeQL private repo + release/snapshot)
+5. 設 org 變數 + secrets:
+   - org **變數** `CI_READ_APP_CLIENT_ID`（nics-dp-ci-read App 的 client-id；reusable 經 `vars` 自動取得）
+   - org **secret** `CI_READ_APP_PRIVATE_KEY`（caller 以 `secrets:` 顯式傳 `ci_read_app_private_key`：Go 私模 + CodeQL private repo + release/snapshot）
    - `DOCKERHUB_USERNAME` + `DOCKERHUB_TOKEN` (Docker image repos)
 
 驗證：`mise tasks ls` 應顯示 ~10 facade 名 + repo-specific extras（atoms hidden）；`mise run --dry-run ci test sbom` resolve 無誤。


### PR DESCRIPTION
## 摘要

`actions/create-github-app-token` v3.x 把 `app-id` 標為 deprecated(action.yml:「Use 'client-id' instead.」),目前 5 個 reusable workflow 用 `app-id` 會在 log 產生 deprecation notice。改用 `client-id`。

## 關鍵設計:用 org **變數**,15 個 caller 不用改

`client-id` 非敏感(同 app_id 性質),且 **org 變數會自動在 reusable workflow 的 `vars` context 解析**(官方文件:reusable workflow 使用 **caller repo** 的變數)。因此:

- 5 個 reusable 改讀 `client-id: ${{ vars.CI_READ_APP_CLIENT_ID }}`(取代 `app-id: ${{ secrets.ci_read_app_id }}`)
- `HAS_CI_APP` gate 改檢查 `vars.CI_READ_APP_CLIENT_ID != '' && secrets.ci_read_app_private_key != ''`
- **caller 完全不用改**:`ci_read_app_private_key`(private key 必須是 secret)仍由 caller 顯式傳;`ci_read_app_id` 輸入保留(標 legacy、忽略),所以仍在傳它的 caller 不會壞
- **無 staging、無破窗**:只要 org 變數在本 PR 發版前存在,meta@main 一翻轉,所有 caller 自動改用 client-id

## 變更

- `go-release` / `image-release` / `sbom-source` / `mise-task` / `codeql-reusable`:`app-id`(secret)→ `client-id`(org var)+ HAS gate + mint 註解
- `ci_read_app_id` workflow_call secret 宣告保留但描述改為 legacy/ignored;`ci_read_app_private_key` 描述改為「配 CI_READ_APP_CLIENT_ID org 變數」
- `README.md` + `.ruler/AGENTS.md`:auth 說明更新(client-id 來自 org 變數、不再 `secrets: inherit`)
- 全 5 個已是 v3.2.0,無需升版

## 前置(部署相依)

org **變數**(非 secret,All repositories)`CI_READ_APP_CLIENT_ID = Iv23liFs42BCn482uzim`(nics-dp-ci-read App client-id)須在本 PR **發版到 main 前**建立,否則 caller 端 `vars` 解析為空 → mint 跳過。

## 後續(另案)

- TMDs add-to-project / pr-approvals / release-archive 同樣 app-id→client-id(獨立 minters,另一 PR)
- callers 仍傳的 legacy `ci_read_app_id` 可日後 cosmetic 清除(非必要)

## 驗證

- actionlint 全 5 clean。
- 殘留檢查:無 `app-id:` / `secrets: inherit` / 「App ID」/「pair with ci_read_app_id」。
