### PR TITLE
feat(ci): add reusable dependency-review workflow

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,82 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+
+name: Dependency Review
+
+# PR-time dependency review. Runs actions/dependency-review-action, which diffs
+# the base..head of a pull request against the GitHub dependency graph and FAILS
+# the job when the PR introduces a dependency with a known vulnerability at or
+# above `fail_on_severity`, or one carrying a disallowed license. Go go.mod is
+# natively understood by the dependency graph, so no extra setup is required.
+#
+# IMPORTANT: dependency-review-action only operates on `pull_request` /
+# `pull_request_target` events -- it needs the PR base/head refs to diff. Callers
+# MUST invoke this reusable workflow from a workflow that is triggered by
+# `pull_request` (or `pull_request_target`); on any other event the action errors.
+#
+# Caller example (.github/workflows/dependency-review.yml in a consumer repo):
+#   on:
+#     pull_request:
+#   jobs:
+#     dependency-review:
+#       uses: nics-dp/meta/.github/workflows/dependency-review.yml@main
+on:
+  workflow_call:
+    inputs:
+      fail_on_severity:
+        description: "Minimum vulnerability severity that fails the job (low | moderate | high | critical)"
+        required: false
+        type: string
+        default: "high"
+      comment_summary_in_pr:
+        description: "When to post the review summary as a PR comment (always | on-failure | never)"
+        required: false
+        type: string
+        default: "on-failure"
+      allow_licenses:
+        description: "Comma-separated SPDX allowlist; only these licenses are permitted. Empty = unset (no allowlist). Mutually exclusive with deny_licenses."
+        required: false
+        type: string
+        default: ""
+      deny_licenses:
+        description: "Comma-separated SPDX denylist; these licenses are rejected. Empty = unset (no denylist). Mutually exclusive with allow_licenses."
+        required: false
+        type: string
+        default: ""
+
+permissions:
+  contents: read
+  # required so dependency-review-action can post / update its summary comment
+  pull-requests: write
+
+jobs:
+  dependency-review:
+    # Pinned to ubuntu-latest: dependency-review-action is a Linux/Node action
+    # and this workflow has no OS-specific needs, so there is no configurable
+    # runner input (a configurable runner was a footgun in security-sarif).
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          fetch-depth: 1
+          # No GITHUB_TOKEN is persisted into the checkout: the action reads the
+          # dependency diff from the GitHub API using the job token directly, so
+          # the on-disk checkout never needs credentials (CodeQL
+          # actions/untrusted-checkout hardening).
+          persist-credentials: false
+
+      - name: Dependency Review
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
+        with:
+          fail-on-severity: ${{ inputs.fail_on_severity }}
+          comment-summary-in-pr: ${{ inputs.comment_summary_in_pr }}
+          # The action reads these via getOptionalInput + parseList: an empty
+          # string is coerced to "unset" (not "allow/deny nothing"), so passing
+          # the empty default through is equivalent to omitting the key. When
+          # both are left empty the action's "cannot set both" guard stays off;
+          # callers set at most one.
+          allow-licenses: ${{ inputs.allow_licenses }}
+          deny-licenses: ${{ inputs.deny_licenses }}

--- a/.ruler/AGENTS.md
+++ b/.ruler/AGENTS.md
@@ -77,6 +77,10 @@ includes = ["git::https://github.com/nics-dp/meta.git//.mise/tasks?ref=main"]
 - **`codeql-reusable.yml`** — CodeQL Advanced analysis (configurable language matrix + Go build).
 - **`codeql.yml`** — meta repo's own CodeQL (workflow YAML scan only).
 
+### Security
+- **`security-sarif.yml`** — Reusable. Runs the gate-only scanners (gosec, govulncheck, semgrep, trivy config, hadolint) and uploads each as a distinct GitHub code-scanning SARIF category. Non-blocking: findings only populate the Security tab, never fail the caller's CI.
+- **`dependency-review.yml`** — Reusable. PR-time `actions/dependency-review-action` over the GitHub dependency graph (Go go.mod natively supported). BLOCKS PRs introducing dependencies with known vulnerabilities (>= `fail_on_severity`, default `high`) or disallowed licenses, and posts a summary comment (`comment_summary_in_pr`, default `on-failure`). Optional `allow_licenses` / `deny_licenses` SPDX lists. `runs-on: ubuntu-latest` (no runner input). Callers MUST invoke it from a `pull_request`-triggered workflow.
+
 ### Utility
 - **`artifacts-comment.yml`** — Sticky PR comment listing artifacts (nightly.link URLs).
 


### PR DESCRIPTION
## What

Adds `.github/workflows/dependency-review.yml`, a reusable (`on: workflow_call`) workflow that runs `actions/dependency-review-action` at PR time.

## Why

Gives consumer repos a one-line, SHA-pinned way to gate PRs on dependency risk. The action diffs the PR `base..head` against the GitHub dependency graph (Go `go.mod` is natively supported) and fails the job when a PR introduces a dependency with a known vulnerability at or above `fail_on_severity`, or one carrying a disallowed license. It also posts a summary comment on the PR.

## Inputs

- `fail_on_severity` (default `high`) - minimum severity that fails the job.
- `comment_summary_in_pr` (default `on-failure`) - when to post the summary comment.
- `allow_licenses` / `deny_licenses` (default empty) - optional comma-separated SPDX lists; an empty value is coerced to "unset" by the action, so the empty default is equivalent to omitting the key. Callers set at most one.

## Notes

- `runs-on` is hardcoded to `ubuntu-latest` (no configurable runner input - a configurable runner was a footgun in security-sarif; this workflow is Linux-only).
- `permissions`: `contents: read` + `pull-requests: write` (for the summary comment).
- Checkout uses `persist-credentials: false`; the action reads the diff via the job token directly.
- The third-party action is SHA-pinned to `a1d282b` (v5.0.0).
- The action only works on `pull_request` / `pull_request_target` events; the header comment documents that callers must invoke it from a `pull_request`-triggered workflow.
- meta-only: no downstream caller jobs are added (the workflow is only on `dev`; `@main` callers would fail with "workflow not found" until a dev->main promotion).
- Documented under a new Security section in `.ruler/AGENTS.md`.

Validated with `actionlint` (clean).
