### PR TITLE
ci(release): add github-native artifact attestations

### DIFF
--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -424,7 +424,7 @@ jobs:
       # /attestations. checksums.txt itself is signed by cosign above.
       - name: Attest build provenance
         if: inputs.attest
-        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
         with:
           subject-checksums: dist/checksums.txt
 

--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -52,6 +52,11 @@ on:
         type: boolean
         default: false
         description: "Sign and notarize macOS binaries with quill"
+      attest:
+        required: false
+        type: boolean
+        default: true
+        description: "Generate GitHub-native SLSA build provenance attestation for the released binaries (verifiable with `gh attestation verify`)"
       snapshot:
         required: false
         type: boolean
@@ -360,6 +365,11 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      # attestations + id-token: write are required for
+      # actions/attest-build-provenance to mint the SLSA provenance attestation
+      # and request an OIDC token for keyless signing. id-token: write is also
+      # what cosign sign-blob already relies on for its keyless flow.
+      attestations: write
       id-token: write
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -398,6 +408,18 @@ jobs:
       - name: Sign checksums with cosign
         working-directory: dist
         run: cosign sign-blob --bundle checksums.txt.sigstore.json checksums.txt --yes
+
+      # GitHub-native SLSA build provenance, complementary to the cosign
+      # sign-blob above. subject-checksums points at the same checksums.txt
+      # that enumerates every released archive (sha256sum ./*.tar.gz ./*.zip),
+      # so one attestation covers all artifacts and each is verifiable with
+      # `gh attestation verify <archive>` and appears under the repo's
+      # /attestations. checksums.txt itself is signed by cosign above.
+      - name: Attest build provenance
+        if: inputs.attest
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4
+        with:
+          subject-checksums: dist/checksums.txt
 
       - name: Upload release assets
         env:

--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -56,7 +56,14 @@ on:
         required: false
         type: boolean
         default: true
-        description: "Generate GitHub-native SLSA build provenance attestation for the released binaries (verifiable with `gh attestation verify`)"
+        description: >
+          Generate GitHub-native SLSA build provenance attestation for the
+          released binaries (verifiable with `gh attestation verify`). A
+          reusable workflow cannot raise the caller's token scopes, so when this
+          is enabled the caller's job must grant attestations: write and
+          id-token: write (the release job already needs id-token: write for the
+          existing cosign keyless flow). Set attest: false to skip it where the
+          caller cannot grant those scopes.
       snapshot:
         required: false
         type: boolean

--- a/.github/workflows/sbom-image.yml
+++ b/.github/workflows/sbom-image.yml
@@ -27,6 +27,11 @@ on:
         type: boolean
         default: false
         description: "Snapshot mode (skip release upload)"
+      attest:
+        required: false
+        type: boolean
+        default: true
+        description: "Generate a GitHub-native SBOM attestation binding the CycloneDX SBOM to the image digest (verifiable with `gh attestation verify`). Mirrors image-release.yml's `attest` input."
       runs_on:
         required: false
         type: string
@@ -46,6 +51,10 @@ jobs:
       contents: write
       packages: read
       security-events: write
+      # attestations + id-token: write let actions/attest-sbom mint the SBOM
+      # attestation and obtain an OIDC token for keyless Sigstore signing.
+      attestations: write
+      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -85,6 +94,21 @@ jobs:
           format: cyclonedx-json
           output-file: sbom-image.cdx.json
           upload-artifact: false
+
+      # GitHub-native SBOM attestation: bind the CycloneDX SBOM to the image
+      # digest the SBOM was generated from. Both the subject (inputs.digest)
+      # and the SBOM file exist in this job, so this is the correct place to
+      # attest. Attests the as-generated sbom-image.cdx.json rather than the
+      # parlay-enriched copy, so the attested document matches the SBOM the
+      # scanners below consume. Verifiable with `gh attestation verify`.
+      - name: Attest SBOM
+        if: inputs.attest
+        uses: actions/attest-sbom@c604332985a26aa8cf1bdc465b92731239ec6b9e # v4.1.0
+        with:
+          subject-name: ${{ env.REGISTRY_GHCR }}/${{ env.GHCR_NAMESPACE }}/${{ inputs.image_name }}
+          subject-digest: ${{ inputs.digest }}
+          sbom-path: sbom-image.cdx.json
+          push-to-registry: true
 
       - name: Set up Go (for tooling)
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0

--- a/.github/workflows/sbom-image.yml
+++ b/.github/workflows/sbom-image.yml
@@ -36,7 +36,8 @@ on:
           to the image digest (verifiable with `gh attestation verify`). Mirrors
           image-release.yml's `attest` input. A reusable workflow cannot raise
           the caller's token scopes, so when this is enabled the caller's job
-          must grant attestations: write, id-token: write and (because the SBOM
+          must grant attestations: write, id-token: write, artifact-metadata:
+          write (for the attestation storage record) and (because the SBOM
           attestation is pushed to GHCR) packages: write. Set attest: false to
           skip it where the caller cannot grant those scopes.
       runs_on:

--- a/.github/workflows/sbom-image.yml
+++ b/.github/workflows/sbom-image.yml
@@ -31,7 +31,14 @@ on:
         required: false
         type: boolean
         default: true
-        description: "Generate a GitHub-native SBOM attestation binding the CycloneDX SBOM to the image digest (verifiable with `gh attestation verify`). Mirrors image-release.yml's `attest` input."
+        description: >
+          Generate a GitHub-native SBOM attestation binding the CycloneDX SBOM
+          to the image digest (verifiable with `gh attestation verify`). Mirrors
+          image-release.yml's `attest` input. A reusable workflow cannot raise
+          the caller's token scopes, so when this is enabled the caller's job
+          must grant attestations: write, id-token: write and (because the SBOM
+          attestation is pushed to GHCR) packages: write. Set attest: false to
+          skip it where the caller cannot grant those scopes.
       runs_on:
         required: false
         type: string
@@ -49,11 +56,18 @@ jobs:
     permissions:
       actions: read
       contents: write
-      packages: read
+      # packages: write (not read) because attest-sbom runs with
+      # push-to-registry: true, which pushes the SBOM attestation to the GHCR
+      # package - the same permission set image-release.yml's attestation steps
+      # use. The earlier `packages: read` was sufficient only for pulling the
+      # image to generate the SBOM.
+      packages: write
       security-events: write
       # attestations + id-token: write let actions/attest-sbom mint the SBOM
-      # attestation and obtain an OIDC token for keyless Sigstore signing.
+      # attestation and obtain an OIDC token for keyless Sigstore signing;
+      # artifact-metadata: write lets it create the artifact storage record.
       attestations: write
+      artifact-metadata: write
       id-token: write
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary

Add GitHub-native artifact attestations to the reusable release workflows so
released artifacts are verifiable with `gh attestation verify` and appear under
each consuming repo's /attestations tab. These attestations are complementary
to the existing cosign signing (cosign sign-blob over checksums.txt and cosign
sign over image digests) - neither replaces the other.

## Changes

### go-release.yml - SLSA build provenance for Go binaries
- New `attest` input (default true), mirroring image-release.yml's `attest`.
- New step `Attest build provenance` (actions/attest-build-provenance, SHA-pinned
  to the same v4.1.0 commit already used in image-release.yml) using
  `subject-checksums: dist/checksums.txt`. The release job already produces
  checksums.txt via `sha256sum ./*.tar.gz ./*.zip`, so one attestation covers
  every released archive and each is independently verifiable.
- Release job permissions extended with `attestations: write` and
  `id-token: write`; existing `contents: write` is kept for the release upload.
  (id-token: write was already present for the cosign keyless flow.)

### sbom-image.yml - SBOM attestation for the container image
- New `attest` input (default true), mirroring image-release.yml.
- New step `Attest SBOM` (actions/attest-sbom, SHA-pinned to v4.1.0) binding the
  generated CycloneDX SBOM to the image digest: `subject-digest = inputs.digest`,
  `sbom-path = sbom-image.cdx.json`, `push-to-registry: true`. This is the only
  job where BOTH the image digest and the SBOM file co-exist, so it is the
  correct placement. It attests the as-generated SBOM (not the parlay-enriched
  copy) so the attested document matches what the scanners consume.
- sbom-image job permissions extended with `attestations: write` and
  `id-token: write`.

## Why image-release.yml is unchanged

image-release.yml already emits attest-build-provenance for both DockerHub and
GHCR digests, gated behind its `attest` input. The image SBOM is generated in a
separate workflow (sbom-image.yml), so the SBOM attestation belongs there, not
in image-release.yml.

## Why sbom-source.yml is intentionally left unchanged

The attest-sbom action requires a concrete subject (a digest/path) to bind the
SBOM to. In sbom-source.yml the SBOM describes the source tree scan, but the
released source archive (`*_source.tar.gz`) is produced in a different workflow
(go-release.yml's release job), not in this job. There is no immutable subject
artifact present alongside the source SBOM here to attest against, so forcing an
attestation would mean binding to a synthetic or absent subject. Rather than
introduce a weak/misleading binding, this PR leaves sbom-source.yml as-is. The
source archive is still covered indirectly: it is one of the artifacts hashed
into checksums.txt, which the new go-release provenance attestation covers.

## Conventions

- All new action refs are full-SHA-pinned with a trailing `# vX.Y.Z` comment.
- No caller repos touched - meta-only change.
- Validated with actionlint (zero findings on both edited files).
