### PR TITLE
ci(workflows): add scorecard and go-dependency-submission reusables

### DIFF
--- a/.github/workflows/go-dependency-submission.yml
+++ b/.github/workflows/go-dependency-submission.yml
@@ -51,28 +51,39 @@ jobs:
           GH_PAT: ${{ secrets.gh_pat }}
         run: |
           if [ -n "$GH_PAT" ]; then
-            # Self-healing: drop any stale token-bearing url.*@github.com/nics-dp
-            # insteadOf rewrites left by a prior run before adding this run's
-            # fresh token, so an equal-length insteadOf tie can't pick up an
-            # expired token (mirrors codeql-reusable / go-release).
-            while read -r s; do
-              if [ -n "$s" ]; then git config --global --remove-section "$s" 2>/dev/null || true; fi
-            done < <(git config --global --name-only --get-regexp '^url\..*@github\.com/nics-dp' 2>/dev/null | sed -E 's/\.insteadof$//' | sort -u || true)
+            # Scope the PAT to a short-lived git config under $RUNNER_TEMP rather
+            # than the runner's default ~/.gitconfig, so the third-party
+            # go-dependency-submission action that runs later cannot read the
+            # credential and a reused (non-ephemeral) runner keeps no stale token.
+            # GIT_CONFIG_GLOBAL points git at this file for the rest of the job;
+            # because the file is fresh each run there is no stale-rewrite scrub
+            # to do (mirrors security-sarif.yml).
+            PRIV_GITCONFIG="${RUNNER_TEMP}/go-dep-submission-gitconfig"
+            : > "$PRIV_GITCONFIG"
             # Scope the rewrite to the nics-dp org prefix so only private org
             # modules carry the token; public github.com fetches stay anonymous
             # (do not rewrite all of github.com -- that over-scopes the token).
-            git config --global \
+            git config --file "$PRIV_GITCONFIG" \
               url."https://x-access-token:${GH_PAT}@github.com/nics-dp/".insteadOf "https://github.com/nics-dp/"
             {
+              echo "GIT_CONFIG_GLOBAL=${PRIV_GITCONFIG}"
               echo "GOPRIVATE=github.com/nics-dp/*"
               echo "GONOSUMDB=github.com/nics-dp/*"
             } >> "$GITHUB_ENV"
           fi
 
-      - name: Submit Go dependency graph
+      # Two variants so go-build-target is genuinely OMITTED when go_build_target
+      # is empty -- the action then applies its own default ('all', every build
+      # target including tests and tools) instead of us hardcoding it here.
+      - name: Submit Go dependency graph (all targets)
+        if: inputs.go_build_target == ''
         uses: actions/go-dependency-submission@f35d5c9af13ce9cc32f7930b171e315e878f6921 # v2.0.3
         with:
           go-mod-path: ${{ inputs.go_mod_path }}
-          # Pass go_build_target through only when set; otherwise fall back to
-          # the action's own default ('all') so every build target is scanned.
-          go-build-target: ${{ inputs.go_build_target != '' && inputs.go_build_target || 'all' }}
+
+      - name: Submit Go dependency graph (target)
+        if: inputs.go_build_target != ''
+        uses: actions/go-dependency-submission@f35d5c9af13ce9cc32f7930b171e315e878f6921 # v2.0.3
+        with:
+          go-mod-path: ${{ inputs.go_mod_path }}
+          go-build-target: ${{ inputs.go_build_target }}

--- a/.github/workflows/go-dependency-submission.yml
+++ b/.github/workflows/go-dependency-submission.yml
@@ -68,8 +68,8 @@ jobs:
               url."https://x-access-token:${GH_PAT}@github.com/nics-dp/".insteadOf "https://github.com/nics-dp/"
             {
               echo "GIT_CONFIG_GLOBAL=${PRIV_GITCONFIG}"
-              echo "GOPRIVATE=github.com/nics-dp/*"
-              echo "GONOSUMDB=github.com/nics-dp/*"
+              echo "GOPRIVATE=github.com/nics-dp"
+              echo "GONOSUMDB=github.com/nics-dp"
             } >> "$GITHUB_ENV"
           fi
 

--- a/.github/workflows/go-dependency-submission.yml
+++ b/.github/workflows/go-dependency-submission.yml
@@ -1,0 +1,78 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+
+name: Go Dependency Submission
+
+# Resolves the Go module's dependency graph and submits it to GitHub's
+# Dependency Submission API (Dependency graph / Dependabot alerts). Running the
+# `go` resolver needs access to the org's PRIVATE Go modules, so the caller
+# passes an optional gh_pat secret that this workflow scopes to the nics-dp org
+# (mirrors mise-task.yml's private-module handling). Callers add a job that
+# `uses:` this workflow.
+on:
+  workflow_call:
+    inputs:
+      go_mod_path:
+        required: false
+        type: string
+        default: "go.mod"
+        description: "Repo path to the go.mod file used to detect dependencies."
+      go_build_target:
+        required: false
+        type: string
+        default: ""
+        description: "Build target to detect build dependencies for (e.g. './cmd/app'). Empty uses the action default of 'all' (every build target, including tests and tools)."
+    secrets:
+      gh_pat:
+        required: false
+        description: "Optional token for private Go module access (the resolver must fetch github.com/nics-dp/* modules)."
+
+permissions:
+  contents: read
+
+jobs:
+  go-dependency-submission:
+    # Pinned to ubuntu-latest: no caller passes a custom runner.
+    runs-on: ubuntu-latest
+    permissions:
+      # required to submit the resolved graph to the Dependency Submission API
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          fetch-depth: 1
+          # Do not persist the GITHUB_TOKEN into the checkout so later steps
+          # cannot be coerced into using it (CodeQL actions/untrusted-checkout).
+          # Private module access is granted separately via gh_pat below.
+          persist-credentials: false
+
+      - name: Configure git for private modules
+        env:
+          GH_PAT: ${{ secrets.gh_pat }}
+        run: |
+          if [ -n "$GH_PAT" ]; then
+            # Self-healing: drop any stale token-bearing url.*@github.com/nics-dp
+            # insteadOf rewrites left by a prior run before adding this run's
+            # fresh token, so an equal-length insteadOf tie can't pick up an
+            # expired token (mirrors codeql-reusable / go-release).
+            while read -r s; do
+              if [ -n "$s" ]; then git config --global --remove-section "$s" 2>/dev/null || true; fi
+            done < <(git config --global --name-only --get-regexp '^url\..*@github\.com/nics-dp' 2>/dev/null | sed -E 's/\.insteadof$//' | sort -u || true)
+            # Scope the rewrite to the nics-dp org prefix so only private org
+            # modules carry the token; public github.com fetches stay anonymous
+            # (do not rewrite all of github.com -- that over-scopes the token).
+            git config --global \
+              url."https://x-access-token:${GH_PAT}@github.com/nics-dp/".insteadOf "https://github.com/nics-dp/"
+            {
+              echo "GOPRIVATE=github.com/nics-dp/*"
+              echo "GONOSUMDB=github.com/nics-dp/*"
+            } >> "$GITHUB_ENV"
+          fi
+
+      - name: Submit Go dependency graph
+        uses: actions/go-dependency-submission@f35d5c9af13ce9cc32f7930b171e315e878f6921 # v2.0.3
+        with:
+          go-mod-path: ${{ inputs.go_mod_path }}
+          # Pass go_build_target through only when set; otherwise fall back to
+          # the action's own default ('all') so every build target is scanned.
+          go-build-target: ${{ inputs.go_build_target != '' && inputs.go_build_target || 'all' }}

--- a/.github/workflows/go-dependency-submission.yml
+++ b/.github/workflows/go-dependency-submission.yml
@@ -52,12 +52,13 @@ jobs:
         run: |
           if [ -n "$GH_PAT" ]; then
             # Scope the PAT to a short-lived git config under $RUNNER_TEMP rather
-            # than the runner's default ~/.gitconfig, so the third-party
-            # go-dependency-submission action that runs later cannot read the
-            # credential and a reused (non-ephemeral) runner keeps no stale token.
-            # GIT_CONFIG_GLOBAL points git at this file for the rest of the job;
-            # because the file is fresh each run there is no stale-rewrite scrub
-            # to do (mirrors security-sarif.yml).
+            # than the runner's default ~/.gitconfig. GIT_CONFIG_GLOBAL points git
+            # at this file for the rest of the job so the submission action below
+            # CAN use it to fetch private modules (that is the point); the benefit
+            # is that nothing is written to ~/.gitconfig, a reused (non-ephemeral)
+            # runner keeps no stale credential, and the cleanup step can revoke it
+            # right after submission. Because the file is fresh each run there is
+            # also no stale-rewrite scrub to do (mirrors security-sarif.yml).
             PRIV_GITCONFIG="${RUNNER_TEMP}/go-dep-submission-gitconfig"
             : > "$PRIV_GITCONFIG"
             # Scope the rewrite to the nics-dp org prefix so only private org
@@ -87,3 +88,15 @@ jobs:
         with:
           go-mod-path: ${{ inputs.go_mod_path }}
           go-build-target: ${{ inputs.go_build_target }}
+
+      # Revoke the private-module credential after submission: delete the
+      # short-lived git config and clear GIT_CONFIG_GLOBAL so the PAT is no
+      # longer reachable by any step a future edit might append (mirrors
+      # security-sarif.yml's "Revoke private-module credential").
+      - name: Revoke private-module credential
+        if: always()
+        run: |
+          if [ -n "${GIT_CONFIG_GLOBAL:-}" ]; then
+            rm -f "$GIT_CONFIG_GLOBAL"
+          fi
+          echo "GIT_CONFIG_GLOBAL=" >> "$GITHUB_ENV"

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,61 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+
+name: Scorecard
+
+# Runs OpenSSF Scorecard against the caller's repository and uploads the
+# findings to GitHub code scanning (Security > Code scanning) under the
+# `scorecard` category. NON-BLOCKING upload by design: a SARIF upload failure
+# never fails the caller's CI (mirrors security-sarif.yml). Callers add a job
+# that `uses:` this workflow.
+on:
+  workflow_call:
+    inputs:
+      publish:
+        required: false
+        type: boolean
+        default: false
+        description: "Publish results to the public OpenSSF Scorecard API. Only works for PUBLIC repos; defaults false so it stays safe for the org's mostly-private repos."
+
+permissions:
+  contents: read
+
+jobs:
+  scorecard:
+    # Pinned to ubuntu-latest: scorecard-action is a Linux/Docker-based action
+    # and no caller passes a custom runner.
+    runs-on: ubuntu-latest
+    permissions:
+      # required by github/codeql-action/upload-sarif to write code-scanning results
+      security-events: write
+      # required for the publish path to authenticate to the Scorecard API via OIDC
+      id-token: write
+      contents: read
+      # scorecard reads branch-protection / workflow settings via the API
+      actions: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          fetch-depth: 1
+          # Do not persist the GITHUB_TOKEN into the checkout so later steps
+          # cannot be coerced into using it (CodeQL actions/untrusted-checkout).
+          persist-credentials: false
+
+      - name: Run OpenSSF Scorecard
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
+        with:
+          results_format: sarif
+          results_file: results.sarif
+          # Publishing to the public Scorecard API only works for public repos;
+          # default false keeps it safe for the org's mostly-private repos.
+          publish_results: ${{ inputs.publish }}
+
+      - name: Upload Scorecard SARIF
+        if: always() && hashFiles('results.sarif') != ''
+        # non-blocking: a failed upload (API / permissions / SARIF format) must
+        # not fail the job and break the caller's CI (mirrors security-sarif.yml).
+        continue-on-error: true
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        with:
+          sarif_file: results.sarif
+          category: scorecard

--- a/.ruler/AGENTS.md
+++ b/.ruler/AGENTS.md
@@ -77,6 +77,10 @@ includes = ["git::https://github.com/nics-dp/meta.git//.mise/tasks?ref=main"]
 - **`codeql-reusable.yml`** — CodeQL Advanced analysis (configurable language matrix + Go build).
 - **`codeql.yml`** — meta repo's own CodeQL (workflow YAML scan only).
 
+### Security & Supply Chain
+- **`scorecard.yml`** — Reusable. Runs OpenSSF Scorecard (`ossf/scorecard-action@<sha>`) and uploads `results.sarif` to code scanning (`category: scorecard`, non-blocking upload). Input `publish` (default false) wires `publish_results`; only publish from public repos. Perms: `security-events: write`, `id-token: write`, `contents: read`, `actions: read`.
+- **`go-dependency-submission.yml`** — Reusable. Submits the resolved Go dependency graph (`actions/go-dependency-submission@<sha>`) to the Dependency Submission API. Inputs: `go_mod_path` (default `go.mod`), `go_build_target` (empty → action default `all`). Secret `gh_pat` configures an org-scoped private-module git rewrite (`github.com/nics-dp/` only) + `GOPRIVATE`. Perms: `contents: write`.
+
 ### Utility
 - **`artifacts-comment.yml`** — Sticky PR comment listing artifacts (nightly.link URLs).
 

--- a/.ruler/AGENTS.md
+++ b/.ruler/AGENTS.md
@@ -79,7 +79,7 @@ includes = ["git::https://github.com/nics-dp/meta.git//.mise/tasks?ref=main"]
 
 ### Security & Supply Chain
 - **`scorecard.yml`** — Reusable. Runs OpenSSF Scorecard (`ossf/scorecard-action@<sha>`) and uploads `results.sarif` to code scanning (`category: scorecard`, non-blocking upload). Input `publish` (default false) wires `publish_results`; only publish from public repos. Perms: `security-events: write`, `id-token: write`, `contents: read`, `actions: read`.
-- **`go-dependency-submission.yml`** — Reusable. Submits the resolved Go dependency graph (`actions/go-dependency-submission@<sha>`) to the Dependency Submission API. Inputs: `go_mod_path` (default `go.mod`), `go_build_target` (empty → action default `all`). Secret `gh_pat` configures an org-scoped private-module git rewrite (`github.com/nics-dp/` only) + `GOPRIVATE`. Perms: `contents: write`.
+- **`go-dependency-submission.yml`** — Reusable. Submits the resolved Go dependency graph (`actions/go-dependency-submission@<sha>`) to the Dependency Submission API. Inputs: `go_mod_path` (default `go.mod`), `go_build_target` (empty omits the input so the action's own `all` default applies — split across two `if:`-gated steps). Secret `gh_pat` configures an org-scoped (`github.com/nics-dp/` only) private-module git rewrite in a short-lived `$RUNNER_TEMP` gitconfig via `GIT_CONFIG_GLOBAL` + `GOPRIVATE`. Perms: `contents: write`.
 
 ### Utility
 - **`artifacts-comment.yml`** — Sticky PR comment listing artifacts (nightly.link URLs).


### PR DESCRIPTION
## Summary

Adds two supply-chain reusable workflows (`on: workflow_call`) to meta.

### `scorecard.yml` - OpenSSF Scorecard
- Runs `ossf/scorecard-action` (SHA-pinned) with `results_format: sarif`,
  `results_file: results.sarif`.
- `publish` input (default false) wires `publish_results`; publishing to the
  public Scorecard API only works for public repos, so it stays opt-in.
- Uploads to code scanning via `github/codeql-action/upload-sarif`
  (`category: scorecard`) with `continue-on-error: true` so a failed upload
  never fails the caller's CI (mirrors security-sarif.yml).
- Perms: `security-events: write`, `id-token: write`, `contents: read`,
  `actions: read`. Checkout `persist-credentials: false`.

### `go-dependency-submission.yml` - Go dependency graph
- Runs `actions/go-dependency-submission` (SHA-pinned). Inputs:
  `go_mod_path` (default `go.mod`), `go_build_target` (empty omits the input
  so the action applies its own `all` default; split across two if-gated steps).
- Optional `gh_pat` secret configures an org-scoped private-module git rewrite
  (`github.com/nics-dp/` only, never all of github.com) plus
  `GOPRIVATE=github.com/nics-dp`, confined to a short-lived `$RUNNER_TEMP`
  gitconfig via `GIT_CONFIG_GLOBAL` (mirrors security-sarif.yml) and revoked by
  a final cleanup step after submission.
- Perms: `contents: write` (required to submit to the dependency graph).
  Checkout `persist-credentials: false`.

## Notes
- All third-party actions are SHA-pinned with a trailing version comment.
- Runners hardcoded to `ubuntu-latest` (no configurable runs_on input).
- Both pass `actionlint` clean.
- meta-only PR: no downstream caller jobs added (these live on dev; `@main`
  callers would 404 until a dev->main promotion).
- Documented under a new Security & Supply Chain section in `.ruler/AGENTS.md`.
