### PR TITLE
ci: remove unused legacy ci_read_app_id workflow_call input

### DIFF
--- a/.github/workflows/codeql-reusable.yml
+++ b/.github/workflows/codeql-reusable.yml
@@ -25,9 +25,6 @@ on:
         type: string
         default: "false"
     secrets:
-      ci_read_app_id:
-        required: false
-        description: "Legacy/unused: the nics-dp-ci-read App is now identified by the CI_READ_APP_CLIENT_ID org variable (client-id); this input is kept only for backward compatibility with callers still passing it, and is ignored."
       ci_read_app_private_key:
         required: false
         description: "Private key of the nics-dp-ci-read GitHub App (paired with the CI_READ_APP_CLIENT_ID org variable)."

--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -90,9 +90,6 @@ on:
         default: '"windows-latest"'
         description: "Runner for Windows build jobs as JSON"
     secrets:
-      ci_read_app_id:
-        required: false
-        description: "Legacy/unused: the nics-dp-ci-read App is now identified by the CI_READ_APP_CLIENT_ID org variable (client-id); this input is kept only for backward compatibility with callers still passing it, and is ignored."
       ci_read_app_private_key:
         required: false
         description: "Private key of the nics-dp-ci-read GitHub App (paired with the CI_READ_APP_CLIENT_ID org variable)."

--- a/.github/workflows/image-release.yml
+++ b/.github/workflows/image-release.yml
@@ -126,9 +126,6 @@ on:
         required: true
       dockerhub_token:
         required: true
-      ci_read_app_id:
-        required: false
-        description: "Legacy/unused: the nics-dp-ci-read App is now identified by the CI_READ_APP_CLIENT_ID org variable (client-id); this input is kept only for backward compatibility with callers still passing it, and is ignored."
       ci_read_app_private_key:
         required: false
         description: "Private key of the nics-dp-ci-read GitHub App (paired with the CI_READ_APP_CLIENT_ID org variable)."

--- a/.github/workflows/mise-task.yml
+++ b/.github/workflows/mise-task.yml
@@ -21,7 +21,7 @@
 #       secrets:
 #         ci_read_app_private_key: ${{ secrets.CI_READ_APP_PRIVATE_KEY }}
 #       # client-id is read from the CI_READ_APP_CLIENT_ID org variable (auto-available in
-#       # reusable workflows, no passing needed); ci_read_app_id input is legacy/ignored.
+#       # reusable workflows, no passing needed).
 
 name: mise-task
 
@@ -53,9 +53,6 @@ on:
         type: boolean
         default: false
     secrets:
-      ci_read_app_id:
-        required: false
-        description: "Legacy/unused: the nics-dp-ci-read App is now identified by the CI_READ_APP_CLIENT_ID org variable (client-id); this input is kept only for backward compatibility with callers still passing it, and is ignored."
       ci_read_app_private_key:
         required: false
         description: "Private key of the nics-dp-ci-read GitHub App (paired with the CI_READ_APP_CLIENT_ID org variable)."

--- a/.github/workflows/sbom-source.yml
+++ b/.github/workflows/sbom-source.yml
@@ -30,9 +30,6 @@ on:
         default: '"ubuntu-latest"'
         description: 'Runner as JSON (e.g., ''"ubuntu-latest"'' or ''{"group":"releasers"}'')'
     secrets:
-      ci_read_app_id:
-        required: false
-        description: "Legacy/unused: the nics-dp-ci-read App is now identified by the CI_READ_APP_CLIENT_ID org variable (client-id); this input is kept only for backward compatibility with callers still passing it, and is ignored."
       ci_read_app_private_key:
         required: false
         description: "Private key of the nics-dp-ci-read GitHub App (paired with the CI_READ_APP_CLIENT_ID org variable)."

--- a/.ruler/AGENTS.md
+++ b/.ruler/AGENTS.md
@@ -48,7 +48,7 @@ includes = ["git::https://github.com/nics-dp/meta.git//.mise/tasks?ref=main"]
 **Shared configs (`configs/`)**: Atoms fetch raw URLs at runtime (no commit to consumer repos). Trap cleanup removes the downloaded config when atom exits. Note: `.golangci.yml` is **per-repo committed** (not shared via curl) — `go:lint-check` / `go:lint-fix` read consumer's own file because gofumpt requires per-module `module-path` setting.
 
 **Auth (GitHub App + DockerHub)**:
-- nics-dp-ci-read App token (private module access, CodeQL private-repo access, release/snapshot builds, `mise-task.yml` private-modules flag): client-id from org **variable** `CI_READ_APP_CLIENT_ID` (auto-available in reusable workflows via `vars`); private key from org **secret** `CI_READ_APP_PRIVATE_KEY`, passed by callers as `ci_read_app_private_key`. Legacy `ci_read_app_id` input retired (kept for compat, ignored). No PAT.
+- nics-dp-ci-read App token (private module access, CodeQL private-repo access, release/snapshot builds, `mise-task.yml` private-modules flag): client-id from org **variable** `CI_READ_APP_CLIENT_ID` (auto-available in reusable workflows via `vars`); private key from org **secret** `CI_READ_APP_PRIVATE_KEY`, passed by callers as `ci_read_app_private_key`. The legacy `ci_read_app_id` input has been removed (no longer declared; do not pass it). No PAT.
 - `DOCKERHUB_USERNAME` / `DOCKERHUB_TOKEN` — image-release.yml (Docker image push)
 
 ## Key Files
@@ -66,7 +66,7 @@ includes = ["git::https://github.com/nics-dp/meta.git//.mise/tasks?ref=main"]
 ## Workflow Architecture
 
 ### Core
-- **`mise-task.yml`** — Reusable. Inputs: `task`, `name`, `runs_on` (JSON via `fromJSON()`), `fetch-depth`, `private-modules`. Secret: `ci_read_app_private_key` (client-id via `CI_READ_APP_CLIENT_ID` org var; legacy `ci_read_app_id` input ignored). Encapsulates checkout (SHA-pinned) + `jdx/mise-action@<sha>` + optional git private-modules config + run mise atom + step summary + enforce.
+- **`mise-task.yml`** — Reusable. Inputs: `task`, `name`, `runs_on` (JSON via `fromJSON()`), `fetch-depth`, `private-modules`. Secret: `ci_read_app_private_key` (client-id via `CI_READ_APP_CLIENT_ID` org var; legacy `ci_read_app_id` input removed). Encapsulates checkout (SHA-pinned) + `jdx/mise-action@<sha>` + optional git private-modules config + run mise atom + step summary + enforce.
 
 ### Release & Build
 - **`go-release.yml`** — Multi-arch Go binary release (cosign, macOS notarize via quill, GitHub Release).

--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ jobs:
 | `fetch-depth`     | number  | `1`              | git fetch depth                                               |
 | `private-modules` | boolean | `false`          | 啟用 ci-read App token git config for private modules         |
 
-App 認證（nics-dp-ci-read，用於 `private-modules=true`）：client-id 由 org **變數** `CI_READ_APP_CLIENT_ID` 提供（reusable workflow 經 `vars` context 自動取得，毋須傳遞）；caller 僅需以 secret 傳 `ci_read_app_private_key`（org secret `CI_READ_APP_PRIVATE_KEY`）。legacy `ci_read_app_id` 輸入已停用、保留相容但忽略。
+App 認證（nics-dp-ci-read，用於 `private-modules=true`）：client-id 由 org **變數** `CI_READ_APP_CLIENT_ID` 提供（reusable workflow 經 `vars` context 自動取得，毋須傳遞）；caller 僅需以 secret 傳 `ci_read_app_private_key`（org secret `CI_READ_APP_PRIVATE_KEY`）。legacy `ci_read_app_id` 輸入已移除（不再宣告,請勿再傳）。
 
 每 job 結尾自動 emit `## <name>` block 至 GitHub Actions step summary，含 ✅/❌ 狀態 + `<details>` 包 tail 300 行 stdout/stderr。
 


### PR DESCRIPTION
## 摘要

移除 5 個 reusable workflow 中已無人使用的 legacy `ci_read_app_id` workflow_call secret 宣告。client-id 改由 org 變數 `CI_READ_APP_CLIENT_ID` 提供後,全部 15 個 caller 都已停止傳 `ci_read_app_id`(僅傳 `ci_read_app_private_key`),此 optional input 已成 dead declaration。

## 變更

`go-release` / `image-release` / `sbom-source` / `mise-task` / `codeql-reusable`:
- 移除 `workflow_call.secrets.ci_read_app_id` 宣告(3 行)
- `ci_read_app_private_key` 宣告保留(private key 仍由 caller 傳)
- mise-task usage 範例註解的 `ci_read_app_id` 提及一併清除

## ⚠️ Release 前提(重要)

移除宣告後,任何**仍在傳** `ci_read_app_id` 的 caller workflow 會在 workflow load 時報錯(傳了未宣告的 secret)。

- 15 個 caller cleanup PR(移除傳遞)已合併到各 repo 的 **dev**;callers 預設分支=dev、release 事件走 dev workflow → 走 dev 的事件安全。
- **本 PR 發到 meta dev,不立即上 main → 目前零風險**(callers @main 仍用舊 meta)。
- **本變更隨下次 meta release 進 main 前**,需確認所有 caller **各分支(尤其 main)** 都已不傳 `ci_read_app_id`,否則 caller main 分支的 push/PR 事件會壞。

## 驗證

- actionlint 全 5 clean;無 `ci_read_app_id` 殘留(含範例註解)。
