### PR TITLE
ci: self-consume dependency-review and scorecard reusables

### DIFF
--- a/.github/workflows/self-dependency-review.yml
+++ b/.github/workflows/self-dependency-review.yml
@@ -1,5 +1,5 @@
 # yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
-name: dependency-review
+name: self-dependency-review
 
 # PR-time dependency review (vulnerable / disallowed-license deps) via the meta
 # reusable. Uses the GitHub dependency graph; posts a summary comment on failure

--- a/.github/workflows/self-dependency-review.yml
+++ b/.github/workflows/self-dependency-review.yml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+name: dependency-review
+
+# PR-time dependency review (vulnerable / disallowed-license deps) via the meta
+# reusable. Uses the GitHub dependency graph; posts a summary comment on failure
+# (the reusable's comment_summary_in_pr default is on-failure).
+on:
+  pull_request:
+    branches: [main, dev, "release/**"]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  review:
+    uses: nics-dp/meta/.github/workflows/dependency-review.yml@main

--- a/.github/workflows/self-supply-chain.yml
+++ b/.github/workflows/self-supply-chain.yml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+name: self-supply-chain
+
+# meta self-consumes its own OpenSSF Scorecard reusable. meta is public, so
+# publish: true posts results to the public Scorecard API (badge / transparency).
+# No dependency-submission: meta has no compiled-language manifests (config only).
+on:
+  push:
+    branches: [dev]
+  schedule:
+    - cron: "39 11 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  scorecard:
+    permissions:
+      security-events: write
+      id-token: write
+      contents: read
+      actions: read
+    uses: nics-dp/meta/.github/workflows/scorecard.yml@main
+    with:
+      publish: true


### PR DESCRIPTION
Self-consume meta's own security reusables (dogfooding):

- self-dependency-review.yml - PR-time dependency-review (GitHub Actions deps).
- self-supply-chain.yml - OpenSSF Scorecard with publish: true (meta is public).

Distinct self- filenames avoid colliding with the reusable definitions of the same name. Reusables referenced @main per org convention. actionlint clean.
