### PR TITLE
fix(ci): artifacts-comment lists zero artifacts (paginate map-fn bug)

### DIFF
--- a/.github/workflows/artifacts-comment.yml
+++ b/.github/workflows/artifacts-comment.yml
@@ -41,11 +41,16 @@ jobs:
               return;
             }
 
-            // List artifacts for current workflow run
+            // List artifacts for current workflow run.
+            // NOTE: do NOT pass a map function here. octokit's paginate has a
+            // built-in normalizer that already unwraps the {total_count, artifacts}
+            // envelope, so `response.data` is the artifacts array inside the map —
+            // `response.data.artifacts` is then undefined and every page maps to []
+            // (silent "No valid artifacts found"). Paginate without a map returns
+            // the artifacts directly.
             const artifacts = (await github.paginate(
               github.rest.actions.listWorkflowRunArtifacts,
-              {owner, repo, run_id: context.runId},
-              (response) => response.data.artifacts || []
+              {owner, repo, run_id: context.runId, per_page: 100}
             )).filter(art => {
               const name = typeof art?.name === 'string' ? art.name.trim() : '';
               return art?.id && name && name !== 'undefined';


### PR DESCRIPTION
## Bug

`artifacts-comment` always logged `No valid artifacts found, skipping comment` and never posted the build-artifacts comment — even on runs that do have artifacts. This affected both the old `workflow_run`-triggered snapshot and any new caller.

## Root cause

The artifact listing passed a **map function** to `github.paginate`:

```js
github.paginate(github.rest.actions.listWorkflowRunArtifacts,
  {owner, repo, run_id}, (response) => response.data.artifacts || [])
```

octokit's `paginate` has a built-in normalizer that already unwraps the `{total_count, artifacts}` envelope, so inside the map function `response.data` **is** the artifacts array. `response.data.artifacts` is therefore `undefined`, `|| []` makes every page map to `[]`, and the result is always empty. No throw, so the job stays green and silently skips.

## Fix

Drop the map function (and add `per_page: 100`); paginate without a map returns the artifacts directly.

## Verification (empirical)

On dcf-service run `27479235733` (3 artifacts):

- single call `listWorkflowRunArtifacts({run_id})` -> `total_count=3, arr=3`
- old `paginate(..., mapFn)` -> `arr=0`  (the bug)
- fixed `paginate(...)` (no map) -> `arr=3`, and the full script then posted the comment with all 3 `nightly.link` links on a test PR.

actionlint clean.
