### PR TITLE
perf(image-release): force amd64-only on snapshot builds

### DIFF
--- a/.github/workflows/image-release.yml
+++ b/.github/workflows/image-release.yml
@@ -591,8 +591,23 @@ jobs:
             exit 1
           fi
           echo "list=${PLATFORMS}" >> "$GITHUB_OUTPUT"
+          # QEMU (binfmt) is only needed to emulate a NON-native architecture.
+          # When the resolved platform list is exactly the runner's native arch
+          # there is nothing to emulate, so skip the otherwise-unconditional QEMU
+          # setup to save its fixed cost on amd64-only snapshot builds. Decide
+          # from the actual runner arch (uname), not just the platform string, so
+          # a non-x86_64 runner building linux/amd64 still gets QEMU. Any
+          # cross-arch / multi-arch target also keeps it.
+          if [[ "$PLATFORMS" == "linux/amd64" && "$(uname -m)" == "x86_64" ]]; then
+            echo "needs_qemu=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "needs_qemu=true" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Set up QEMU
+        # Skip emulation setup for native amd64-only builds (see the resolve
+        # step); required for every cross-arch / multi-arch build.
+        if: steps.platforms.outputs.needs_qemu == 'true'
         uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
 
       - name: Set up Buildx

--- a/.github/workflows/image-release.yml
+++ b/.github/workflows/image-release.yml
@@ -579,6 +579,17 @@ jobs:
           else
             PLATFORMS="$PLATFORMS_IN"
           fi
+          # PLATFORMS is interpolated into $GITHUB_OUTPUT below and consumed by
+          # build-push. inputs.platforms is a caller-supplied string; reject any
+          # character outside the platform-list charset (os/arch[/variant],
+          # comma-separated) so a stray newline/CR can't break the output-file
+          # format or inject an extra output key. Mirrors the whitespace/quote
+          # guard in "Compute version metadata"; don't echo the offending value
+          # (it would land in CI logs and could itself carry workflow commands).
+          if [[ "$PLATFORMS" =~ [^A-Za-z0-9/,._-] ]]; then
+            echo "::error::resolved platforms contains characters outside [A-Za-z0-9/,._-]"
+            exit 1
+          fi
           echo "list=${PLATFORMS}" >> "$GITHUB_OUTPUT"
 
       - name: Set up QEMU

--- a/.github/workflows/image-release.yml
+++ b/.github/workflows/image-release.yml
@@ -13,7 +13,10 @@ on:
         required: false
         type: string
         default: "linux/amd64,linux/arm64"
-        description: "Target platforms for multi-arch build"
+        description: >
+          Target platforms for multi-arch build. NOTE: ignored when
+          snapshot=true — snapshot builds are forced to linux/amd64 only to
+          skip emulated arm64 (see the "Resolve build platforms" step).
       runs_on:
         required: false
         type: string
@@ -553,6 +556,31 @@ jobs:
         run: |
           git config --global --remove-section "url.https://x-access-token:${GH_PAT}@github.com/nics-dp" 2>/dev/null || true
 
+      - name: Resolve build platforms
+        id: platforms
+        # runs_on is a caller-supplied JSON input that can resolve to a Windows
+        # runner (default shell pwsh); pin bash since this uses bash-only [[ ]]
+        # syntax. Mirrors the "Compute version metadata" step above.
+        shell: bash
+        env:
+          SNAPSHOT: ${{ inputs.snapshot }}
+          PLATFORMS_IN: ${{ inputs.platforms }}
+        run: |
+          # Snapshot builds are ephemeral, SHA-tagged dev images. Under the
+          # current deployment model only linux/amd64 is consumed from them
+          # (prod runs amd64; arm64 images are published only on real releases,
+          # for local dev on Apple Silicon). Building the linux/arm64 variant on
+          # snapshot means emulating arm64 under QEMU on the amd64 runners, which
+          # dominates snapshot build wall-clock. Force amd64-only on snapshot and
+          # ignore inputs.platforms; release builds (snapshot=false) honor
+          # inputs.platforms unchanged.
+          if [[ "$SNAPSHOT" == "true" ]]; then
+            PLATFORMS="linux/amd64"
+          else
+            PLATFORMS="$PLATFORMS_IN"
+          fi
+          echo "list=${PLATFORMS}" >> "$GITHUB_OUTPUT"
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
 
@@ -597,7 +625,7 @@ jobs:
           # stage (current behaviour). Service callers pass target: runtime to
           # ship the hardened runtime stage instead of the trailing debug stage.
           target: ${{ inputs.target }}
-          platforms: ${{ inputs.platforms }}
+          platforms: ${{ steps.platforms.outputs.list }}
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
## What

Snapshot image builds now build `linux/amd64` only; release builds are unchanged (full multi-arch).

## Why

`snapshot.yml` callers do not pass `platforms`, so they inherited the `linux/amd64,linux/arm64` default and built the arm64 variant under QEMU emulation on the amd64 `releasers` runners on every PR. That emulated arm64 build dominates snapshot wall-clock.

Under the current deployment model only `linux/amd64` is consumed from snapshots (prod is amd64; arm64 images are published only on real releases, for local dev on Apple Silicon), so the emulated arm64 snapshot build is pure overhead.

## How

A new `Resolve build platforms` step forces `linux/amd64` when `snapshot=true` and otherwise passes `inputs.platforms` through unchanged. `build-push` consumes the resolved value.

- Release path (`snapshot=false`): honors `inputs.platforms` default -> still amd64 + arm64.
- Snapshot path (`snapshot=true`): amd64 only, `inputs.platforms` ignored (documented on the input).

## Rollout note

Callers pin `@main`, so this only takes effect for them after a meta dev -> main release.

## Test plan

- `actionlint` clean, YAML parses.
- Verify on a snapshot run: build matrix shows only `linux/amd64`.
- Verify on a release run: manifest still lists amd64 + arm64.
