### PR TITLE
release: v0.2.4.10

### DIFF
--- a/.github/workflows/artifacts-comment.yml
+++ b/.github/workflows/artifacts-comment.yml
@@ -41,11 +41,16 @@ jobs:
               return;
             }
 
-            // List artifacts for current workflow run
+            // List artifacts for current workflow run.
+            // NOTE: do NOT pass a map function here. octokit's paginate has a
+            // built-in normalizer that already unwraps the {total_count, artifacts}
+            // envelope, so `response.data` is the artifacts array inside the map —
+            // `response.data.artifacts` is then undefined and every page maps to []
+            // (silent "No valid artifacts found"). Paginate without a map returns
+            // the artifacts directly.
             const artifacts = (await github.paginate(
               github.rest.actions.listWorkflowRunArtifacts,
-              {owner, repo, run_id: context.runId},
-              (response) => response.data.artifacts || []
+              {owner, repo, run_id: context.runId, per_page: 100}
             )).filter(art => {
               const name = typeof art?.name === 'string' ? art.name.trim() : '';
               return art?.id && name && name !== 'undefined';

--- a/.github/workflows/self-dependency-review.yml
+++ b/.github/workflows/self-dependency-review.yml
@@ -1,5 +1,5 @@
 # yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
-name: dependency-review
+name: self-dependency-review
 
 # PR-time dependency review (vulnerable / disallowed-license deps) via the meta
 # reusable. Uses the GitHub dependency graph; posts a summary comment on failure

--- a/.github/workflows/self-dependency-review.yml
+++ b/.github/workflows/self-dependency-review.yml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+name: dependency-review
+
+# PR-time dependency review (vulnerable / disallowed-license deps) via the meta
+# reusable. Uses the GitHub dependency graph; posts a summary comment on failure
+# (the reusable's comment_summary_in_pr default is on-failure).
+on:
+  pull_request:
+    branches: [main, dev, "release/**"]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  review:
+    uses: nics-dp/meta/.github/workflows/dependency-review.yml@main

--- a/.github/workflows/self-supply-chain.yml
+++ b/.github/workflows/self-supply-chain.yml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+name: self-supply-chain
+
+# meta self-consumes its own OpenSSF Scorecard reusable. meta is public, so
+# publish: true posts results to the public Scorecard API (badge / transparency).
+# No dependency-submission: meta has no compiled-language manifests (config only).
+on:
+  push:
+    branches: [dev]
+  schedule:
+    - cron: "39 11 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  scorecard:
+    permissions:
+      security-events: write
+      id-token: write
+      contents: read
+      actions: read
+    uses: nics-dp/meta/.github/workflows/scorecard.yml@main
+    with:
+      publish: true


### PR DESCRIPTION
## Release v0.2.4.10

Promote `dev` -> `main` (patch).

### Caller-facing
- **fix(ci): artifacts-comment lists zero artifacts (paginate map-fn bug)** (#180) — the "Build Artifacts" PR comment was silently broken for every snapshot model; `github.paginate` was passed a map function that always yielded `[]`. Reaches `@main` callers with this release.

### meta-internal (no reusable contract change)
- ci: self-consume dependency-review and scorecard reusables (#179)
- ci: prefix self-dependency-review workflow name with `self-`

No reusable workflow input/secret/permission interface changes beyond the artifacts-comment internals.
