### PR TITLE
release: v0.2.4.11

### DIFF
--- a/.github/workflows/image-release.yml
+++ b/.github/workflows/image-release.yml
@@ -591,8 +591,23 @@ jobs:
             exit 1
           fi
           echo "list=${PLATFORMS}" >> "$GITHUB_OUTPUT"
+          # QEMU (binfmt) is only needed to emulate a NON-native architecture.
+          # When the resolved platform list is exactly the runner's native arch
+          # there is nothing to emulate, so skip the otherwise-unconditional QEMU
+          # setup to save its fixed cost on amd64-only snapshot builds. Decide
+          # from the actual runner arch (uname), not just the platform string, so
+          # a non-x86_64 runner building linux/amd64 still gets QEMU. Any
+          # cross-arch / multi-arch target also keeps it.
+          if [[ "$PLATFORMS" == "linux/amd64" && "$(uname -m)" == "x86_64" ]]; then
+            echo "needs_qemu=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "needs_qemu=true" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Set up QEMU
+        # Skip emulation setup for native amd64-only builds (see the resolve
+        # step); required for every cross-arch / multi-arch build.
+        if: steps.platforms.outputs.needs_qemu == 'true'
         uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
 
       - name: Set up Buildx

--- a/.github/workflows/image-release.yml
+++ b/.github/workflows/image-release.yml
@@ -579,6 +579,17 @@ jobs:
           else
             PLATFORMS="$PLATFORMS_IN"
           fi
+          # PLATFORMS is interpolated into $GITHUB_OUTPUT below and consumed by
+          # build-push. inputs.platforms is a caller-supplied string; reject any
+          # character outside the platform-list charset (os/arch[/variant],
+          # comma-separated) so a stray newline/CR can't break the output-file
+          # format or inject an extra output key. Mirrors the whitespace/quote
+          # guard in "Compute version metadata"; don't echo the offending value
+          # (it would land in CI logs and could itself carry workflow commands).
+          if [[ "$PLATFORMS" =~ [^A-Za-z0-9/,._-] ]]; then
+            echo "::error::resolved platforms contains characters outside [A-Za-z0-9/,._-]"
+            exit 1
+          fi
           echo "list=${PLATFORMS}" >> "$GITHUB_OUTPUT"
 
       - name: Set up QEMU

--- a/.github/workflows/image-release.yml
+++ b/.github/workflows/image-release.yml
@@ -13,7 +13,10 @@ on:
         required: false
         type: string
         default: "linux/amd64,linux/arm64"
-        description: "Target platforms for multi-arch build"
+        description: >
+          Target platforms for multi-arch build. NOTE: ignored when
+          snapshot=true — snapshot builds are forced to linux/amd64 only to
+          skip emulated arm64 (see the "Resolve build platforms" step).
       runs_on:
         required: false
         type: string
@@ -553,6 +556,31 @@ jobs:
         run: |
           git config --global --remove-section "url.https://x-access-token:${GH_PAT}@github.com/nics-dp" 2>/dev/null || true
 
+      - name: Resolve build platforms
+        id: platforms
+        # runs_on is a caller-supplied JSON input that can resolve to a Windows
+        # runner (default shell pwsh); pin bash since this uses bash-only [[ ]]
+        # syntax. Mirrors the "Compute version metadata" step above.
+        shell: bash
+        env:
+          SNAPSHOT: ${{ inputs.snapshot }}
+          PLATFORMS_IN: ${{ inputs.platforms }}
+        run: |
+          # Snapshot builds are ephemeral, SHA-tagged dev images. Under the
+          # current deployment model only linux/amd64 is consumed from them
+          # (prod runs amd64; arm64 images are published only on real releases,
+          # for local dev on Apple Silicon). Building the linux/arm64 variant on
+          # snapshot means emulating arm64 under QEMU on the amd64 runners, which
+          # dominates snapshot build wall-clock. Force amd64-only on snapshot and
+          # ignore inputs.platforms; release builds (snapshot=false) honor
+          # inputs.platforms unchanged.
+          if [[ "$SNAPSHOT" == "true" ]]; then
+            PLATFORMS="linux/amd64"
+          else
+            PLATFORMS="$PLATFORMS_IN"
+          fi
+          echo "list=${PLATFORMS}" >> "$GITHUB_OUTPUT"
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
 
@@ -597,7 +625,7 @@ jobs:
           # stage (current behaviour). Service callers pass target: runtime to
           # ship the hardened runtime stage instead of the trailing debug stage.
           target: ${{ inputs.target }}
-          platforms: ${{ inputs.platforms }}
+          platforms: ${{ steps.platforms.outputs.list }}
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
Patch release promoting `dev` to `main`.

## Included

- **image-release.yml — faster snapshot image builds** (PR #181)
  - `perf`: snapshot builds (`snapshot=true`) are forced to `linux/amd64`, skipping the QEMU-emulated `linux/arm64` variant that dominated snapshot wall-clock on the amd64 runners. Release builds (`snapshot=false`) still honor `inputs.platforms` and produce the full multi-arch manifest.
  - `fix`: validate the resolved platforms charset before writing to `$GITHUB_OUTPUT`, preventing a stray newline/CR in `inputs.platforms` from breaking the output file or injecting an extra output key.
  - `perf`: gate `Set up QEMU` on a `needs_qemu` output derived from the resolved platforms AND the runner arch (`uname -m`), so native amd64-only builds skip the redundant emulation setup while every cross-arch / non-x86_64-runner build keeps it.

## Scope

Single file changed: `.github/workflows/image-release.yml` (+56 / -2). No behavior change for release builds; callers pinned to `@main` pick up the snapshot speedup once this merges.

## Post-merge

Tag `v0.2.4.11` on the main merge commit and publish the GitHub release (lightweight tag, matching v0.2.4.10).
