### PR TITLE
ci: run codeql + security-sarif on releasers 8-core by default

### DIFF
--- a/.github/workflows/codeql-reusable.yml
+++ b/.github/workflows/codeql-reusable.yml
@@ -24,6 +24,11 @@ on:
         required: false
         type: string
         default: "false"
+      runs_on:
+        description: 'Runner as JSON (e.g., ''"ubuntu-latest"'' or ''{"group":"releasers"}''). Defaults to the releasers 8-core group; CodeQL Go analysis is CPU/RAM-bound and benefits from it.'
+        required: false
+        type: string
+        default: '{"group":"releasers"}'
     secrets:
       ci_read_app_private_key:
         required: false
@@ -32,7 +37,7 @@ on:
 jobs:
   analyze:
     name: Analyze (${{ matrix.language }})
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(inputs.runs_on) }}
     permissions:
       security-events: write
       packages: read

--- a/.github/workflows/security-sarif.yml
+++ b/.github/workflows/security-sarif.yml
@@ -77,8 +77,13 @@ jobs:
       # mid-run failure. Enforces the "Must stay Linux" contract documented above.
       - name: Guard against non-Linux runner
         if: ${{ runner.os != 'Linux' }}
+        # This step runs ONLY on a non-Linux runner, where the default shell is
+        # not bash (pwsh on Windows). Pin shell: bash so the script is portable,
+        # and emit the ::error:: workflow command on stdout (the runner parses
+        # commands from stdout, so no stderr redirect is needed).
+        shell: bash
         run: |
-          echo "::error::security-sarif requires a Linux runner (got '$RUNNER_OS'); its Docker-based actions and bash scan steps are not portable. Set runs_on to a Linux runner." >&2
+          echo "::error::security-sarif requires a Linux runner (got '$RUNNER_OS'); its Docker-based actions and bash scan steps are not portable. Set runs_on to a Linux runner."
           exit 1
 
       # Mint a nics-dp-ci-read App token for private Go module access, but only

--- a/.github/workflows/security-sarif.yml
+++ b/.github/workflows/security-sarif.yml
@@ -71,6 +71,16 @@ jobs:
       # org variable (client-id) plus the ci_read_app_private_key secret.
       HAS_CI_APP: ${{ vars.CI_READ_APP_CLIENT_ID != '' && secrets.ci_read_app_private_key != '' }}
     steps:
+      # Fail fast with a clear message if a caller overrides runs_on to a
+      # non-Linux runner: the Docker-based actions (hadolint, trivy) and bash
+      # scan steps below are Linux-only, so an early guard beats a confusing
+      # mid-run failure. Enforces the "Must stay Linux" contract documented above.
+      - name: Guard against non-Linux runner
+        if: ${{ runner.os != 'Linux' }}
+        run: |
+          echo "::error::security-sarif requires a Linux runner (got '${{ runner.os }}'); its Docker-based actions and bash scan steps are not portable. Set runs_on to a Linux runner." >&2
+          exit 1
+
       # Mint a nics-dp-ci-read App token for private Go module access, but only
       # when the Go scanners run and the App is configured. The PAT model was
       # retired org-wide, so callers pass only ci_read_app_private_key and the

--- a/.github/workflows/security-sarif.yml
+++ b/.github/workflows/security-sarif.yml
@@ -40,6 +40,11 @@ on:
         type: boolean
         default: true
         description: "Run the semgrep SAST scan"
+      runs_on:
+        description: 'Runner as JSON (e.g., ''"ubuntu-latest"'' or ''{"group":"releasers"}''). Defaults to the releasers 8-core group; the scanners (trivy/semgrep/gosec) are CPU-bound and benefit from it. Must stay Linux (Docker-based actions).'
+        required: false
+        type: string
+        default: '{"group":"releasers"}'
     secrets:
       ci_read_app_private_key:
         required: false
@@ -50,10 +55,11 @@ env:
 
 jobs:
   security-sarif:
-    # Pinned to ubuntu-latest: this workflow depends on Linux/Docker-based
+    # runs_on must stay a Linux runner: this workflow depends on Linux/Docker-based
     # actions (hadolint-action, trivy-action) and bash scan steps, so it is not
-    # portable to Windows/macOS runners. No caller passes a custom runner.
-    runs-on: ubuntu-latest
+    # portable to Windows/macOS. Defaults to the releasers 8-core group (the
+    # scanners are CPU-bound); callers may override with '"ubuntu-latest"'.
+    runs-on: ${{ fromJSON(inputs.runs_on) }}
     permissions:
       contents: read
       # required by github/codeql-action/upload-sarif to write code-scanning results

--- a/.github/workflows/security-sarif.yml
+++ b/.github/workflows/security-sarif.yml
@@ -71,21 +71,6 @@ jobs:
       # org variable (client-id) plus the ci_read_app_private_key secret.
       HAS_CI_APP: ${{ vars.CI_READ_APP_CLIENT_ID != '' && secrets.ci_read_app_private_key != '' }}
     steps:
-      # Fail fast with a clear message if a caller overrides runs_on to a
-      # non-Linux runner: the Docker-based actions (hadolint, trivy) and bash
-      # scan steps below are Linux-only, so an early guard beats a confusing
-      # mid-run failure. Enforces the "Must stay Linux" contract documented above.
-      - name: Guard against non-Linux runner
-        if: ${{ runner.os != 'Linux' }}
-        # This step runs ONLY on a non-Linux runner, where the default shell is
-        # not bash (pwsh on Windows). Pin shell: bash so the script is portable,
-        # and emit the ::error:: workflow command on stdout (the runner parses
-        # commands from stdout, so no stderr redirect is needed).
-        shell: bash
-        run: |
-          echo "::error::security-sarif requires a Linux runner (got '$RUNNER_OS'); its Docker-based actions and bash scan steps are not portable. Set runs_on to a Linux runner."
-          exit 1
-
       # Mint a nics-dp-ci-read App token for private Go module access, but only
       # when the Go scanners run and the App is configured. The PAT model was
       # retired org-wide, so callers pass only ci_read_app_private_key and the

--- a/.github/workflows/security-sarif.yml
+++ b/.github/workflows/security-sarif.yml
@@ -78,7 +78,7 @@ jobs:
       - name: Guard against non-Linux runner
         if: ${{ runner.os != 'Linux' }}
         run: |
-          echo "::error::security-sarif requires a Linux runner (got '${{ runner.os }}'); its Docker-based actions and bash scan steps are not portable. Set runs_on to a Linux runner." >&2
+          echo "::error::security-sarif requires a Linux runner (got '$RUNNER_OS'); its Docker-based actions and bash scan steps are not portable. Set runs_on to a Linux runner." >&2
           exit 1
 
       # Mint a nics-dp-ci-read App token for private Go module access, but only


### PR DESCRIPTION
## What

Add a `runs_on` input to `codeql-reusable.yml` and `security-sarif.yml`, **defaulting to the releasers 8-core group** (`{"group":"releasers"}`), and use `runs-on: ${{ fromJSON(inputs.runs_on) }}` — mirroring the existing `mise-task.yml` pattern. Callers can override back to `'"ubuntu-latest"'`.

## Why

These were the only CI jobs still pinned to GitHub-hosted `ubuntu-latest` (2-core / 7 GB). Measured on dcf-service:

| Job | Before (ubuntu-latest 2-core) |
|-----|-------------------------------|
| security-scan / sarif | 5.28 min |
| CodeQL / Analyze (go) | 3.83 min |

The whole `ci.yml` matrix (Go SAST, Test, etc.) already runs on the releasers larger runner (8-core / 32 GB, GitHub-hosted, max concurrency 50) in ~1-2 min/job. Moving CodeQL + the SARIF scanners there is consistent, removes the 2-core outliers, and is expected to cut the PR critical path by ~3-5 min. The scanners (trivy/semgrep/gosec) and CodeQL database build are CPU/RAM-bound, so they benefit directly.

## Trade-off

These two job types now bill at the larger-runner rate (same rate `ci.yml` already uses). No capacity concern: the releasers pool is a GitHub-hosted larger runner with max concurrency 50 and GitHub-managed ephemeral isolation (no self-hosted infra). `security-sarif` stays Linux-only (Docker-based actions); the comment was updated accordingly.

## Scope

Org-wide on the next meta release to `main`: every repo's CodeQL + security-scan picks up the 8-core runner. Any repo can opt back to standard via the `runs_on` input.

actionlint clean on both files.
