### PR TITLE
release: v0.2.4.12

### DIFF
--- a/.github/workflows/codeql-reusable.yml
+++ b/.github/workflows/codeql-reusable.yml
@@ -24,6 +24,11 @@ on:
         required: false
         type: string
         default: "false"
+      runs_on:
+        description: 'Runner as JSON (e.g., ''"ubuntu-latest"'' or ''{"group":"releasers"}''). Defaults to the releasers 8-core group; CodeQL Go analysis is CPU/RAM-bound and benefits from it.'
+        required: false
+        type: string
+        default: '{"group":"releasers"}'
     secrets:
       ci_read_app_private_key:
         required: false
@@ -32,7 +37,7 @@ on:
 jobs:
   analyze:
     name: Analyze (${{ matrix.language }})
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(inputs.runs_on) }}
     permissions:
       security-events: write
       packages: read

--- a/.github/workflows/security-sarif.yml
+++ b/.github/workflows/security-sarif.yml
@@ -77,8 +77,13 @@ jobs:
       # mid-run failure. Enforces the "Must stay Linux" contract documented above.
       - name: Guard against non-Linux runner
         if: ${{ runner.os != 'Linux' }}
+        # This step runs ONLY on a non-Linux runner, where the default shell is
+        # not bash (pwsh on Windows). Pin shell: bash so the script is portable,
+        # and emit the ::error:: workflow command on stdout (the runner parses
+        # commands from stdout, so no stderr redirect is needed).
+        shell: bash
         run: |
-          echo "::error::security-sarif requires a Linux runner (got '$RUNNER_OS'); its Docker-based actions and bash scan steps are not portable. Set runs_on to a Linux runner." >&2
+          echo "::error::security-sarif requires a Linux runner (got '$RUNNER_OS'); its Docker-based actions and bash scan steps are not portable. Set runs_on to a Linux runner."
           exit 1
 
       # Mint a nics-dp-ci-read App token for private Go module access, but only

--- a/.github/workflows/security-sarif.yml
+++ b/.github/workflows/security-sarif.yml
@@ -71,6 +71,16 @@ jobs:
       # org variable (client-id) plus the ci_read_app_private_key secret.
       HAS_CI_APP: ${{ vars.CI_READ_APP_CLIENT_ID != '' && secrets.ci_read_app_private_key != '' }}
     steps:
+      # Fail fast with a clear message if a caller overrides runs_on to a
+      # non-Linux runner: the Docker-based actions (hadolint, trivy) and bash
+      # scan steps below are Linux-only, so an early guard beats a confusing
+      # mid-run failure. Enforces the "Must stay Linux" contract documented above.
+      - name: Guard against non-Linux runner
+        if: ${{ runner.os != 'Linux' }}
+        run: |
+          echo "::error::security-sarif requires a Linux runner (got '${{ runner.os }}'); its Docker-based actions and bash scan steps are not portable. Set runs_on to a Linux runner." >&2
+          exit 1
+
       # Mint a nics-dp-ci-read App token for private Go module access, but only
       # when the Go scanners run and the App is configured. The PAT model was
       # retired org-wide, so callers pass only ci_read_app_private_key and the

--- a/.github/workflows/security-sarif.yml
+++ b/.github/workflows/security-sarif.yml
@@ -40,6 +40,11 @@ on:
         type: boolean
         default: true
         description: "Run the semgrep SAST scan"
+      runs_on:
+        description: 'Runner as JSON (e.g., ''"ubuntu-latest"'' or ''{"group":"releasers"}''). Defaults to the releasers 8-core group; the scanners (trivy/semgrep/gosec) are CPU-bound and benefit from it. Must stay Linux (Docker-based actions).'
+        required: false
+        type: string
+        default: '{"group":"releasers"}'
     secrets:
       ci_read_app_private_key:
         required: false
@@ -50,10 +55,11 @@ env:
 
 jobs:
   security-sarif:
-    # Pinned to ubuntu-latest: this workflow depends on Linux/Docker-based
+    # runs_on must stay a Linux runner: this workflow depends on Linux/Docker-based
     # actions (hadolint-action, trivy-action) and bash scan steps, so it is not
-    # portable to Windows/macOS runners. No caller passes a custom runner.
-    runs-on: ubuntu-latest
+    # portable to Windows/macOS. Defaults to the releasers 8-core group (the
+    # scanners are CPU-bound); callers may override with '"ubuntu-latest"'.
+    runs-on: ${{ fromJSON(inputs.runs_on) }}
     permissions:
       contents: read
       # required by github/codeql-action/upload-sarif to write code-scanning results

--- a/.github/workflows/security-sarif.yml
+++ b/.github/workflows/security-sarif.yml
@@ -71,21 +71,6 @@ jobs:
       # org variable (client-id) plus the ci_read_app_private_key secret.
       HAS_CI_APP: ${{ vars.CI_READ_APP_CLIENT_ID != '' && secrets.ci_read_app_private_key != '' }}
     steps:
-      # Fail fast with a clear message if a caller overrides runs_on to a
-      # non-Linux runner: the Docker-based actions (hadolint, trivy) and bash
-      # scan steps below are Linux-only, so an early guard beats a confusing
-      # mid-run failure. Enforces the "Must stay Linux" contract documented above.
-      - name: Guard against non-Linux runner
-        if: ${{ runner.os != 'Linux' }}
-        # This step runs ONLY on a non-Linux runner, where the default shell is
-        # not bash (pwsh on Windows). Pin shell: bash so the script is portable,
-        # and emit the ::error:: workflow command on stdout (the runner parses
-        # commands from stdout, so no stderr redirect is needed).
-        shell: bash
-        run: |
-          echo "::error::security-sarif requires a Linux runner (got '$RUNNER_OS'); its Docker-based actions and bash scan steps are not portable. Set runs_on to a Linux runner."
-          exit 1
-
       # Mint a nics-dp-ci-read App token for private Go module access, but only
       # when the Go scanners run and the App is configured. The PAT model was
       # retired org-wide, so callers pass only ci_read_app_private_key and the

--- a/.github/workflows/security-sarif.yml
+++ b/.github/workflows/security-sarif.yml
@@ -78,7 +78,7 @@ jobs:
       - name: Guard against non-Linux runner
         if: ${{ runner.os != 'Linux' }}
         run: |
-          echo "::error::security-sarif requires a Linux runner (got '${{ runner.os }}'); its Docker-based actions and bash scan steps are not portable. Set runs_on to a Linux runner." >&2
+          echo "::error::security-sarif requires a Linux runner (got '$RUNNER_OS'); its Docker-based actions and bash scan steps are not portable. Set runs_on to a Linux runner." >&2
           exit 1
 
       # Mint a nics-dp-ci-read App token for private Go module access, but only


### PR DESCRIPTION
## Release v0.2.4.12

Promote `dev` -> `main` (patch).

### Change
- **ci: run CodeQL + security-sarif on the releasers 8-core runner by default** (#184). Both reusables now take a `runs_on` input defaulting to `{"group":"releasers"}` (overridable to `'"ubuntu-latest"'`), moving the two slowest CI checks off GitHub-hosted 2-core runners. No caller changes needed — callers inherit the new default. Measured baseline (dcf-service): security-sarif 5.28 min, CodeQL go 3.83 min, both on 2-core; expected to roughly halve on the 8-core larger runner.

(The intermediate non-Linux guard-step commits net out — the step was added then reverted; the effective diff is only the two `runs_on` parameterizations.)

No reusable input/secret/permission interface changes beyond the added optional `runs_on` input.
