### PR TITLE
ci(image-release): support submodule checkout for the build context

### DIFF
--- a/.github/workflows/image-release.yml
+++ b/.github/workflows/image-release.yml
@@ -206,7 +206,12 @@ jobs:
           case "$(printf '%s' "$SUBMODULES" | tr '[:upper:]' '[:lower:]')" in
             false | true | recursive) ;;
             *)
-              echo "::error::invalid submodules input '${SUBMODULES}'; expected one of: false, true, recursive"
+              # Sanitize before emitting: strip CR/LF (which would truncate or
+              # inject the ::error:: annotation) and percent-encode % per the
+              # runner's workflow-command encoding, so the annotation stays
+              # well-formed for any value.
+              safe=$(printf '%s' "$SUBMODULES" | tr -d '\r\n' | sed 's/%/%25/g')
+              echo "::error::invalid submodules input '${safe}'; expected one of: false, true, recursive"
               exit 1
               ;;
           esac

--- a/.github/workflows/image-release.yml
+++ b/.github/workflows/image-release.yml
@@ -88,6 +88,16 @@ on:
         type: string
         default: "stable"
         description: "Go version for vendor step (only used when go_vendor is true)"
+      submodules:
+        required: false
+        type: string
+        default: "false"
+        description: >
+          Submodule checkout mode for the build context: "false", "true", or
+          "recursive". Use "recursive" when the Dockerfile copies a git submodule
+          into the image. Private submodules are fetched with the minted ci-read
+          App token, so pass ci_read_app_private_key too. Typed as string (not
+          boolean) so callers can request recursive checkout.
       external_repo:
         required: false
         type: string
@@ -185,8 +195,15 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ inputs.ref }}
-          # No authenticated git is run against this checkout afterwards, and in
-          # non-external mode the workspace root is the docker build context.
+          submodules: ${{ inputs.submodules }}
+          # Private submodules need a token that can read other nics-dp repos;
+          # use the minted ci-read App token when submodules are requested, else
+          # fall back to the default token (current behaviour for non-submodule
+          # repos). checkout uses this only to fetch during the step.
+          token: ${{ (inputs.submodules != 'false' && steps.priv-token.outputs.token) || github.token }}
+          # The token above is used only to fetch (incl. submodules) during this
+          # step; no authenticated git is run against this checkout afterwards, and
+          # in non-external mode the workspace root is the docker build context.
           # Opt out of credential persistence (least privilege) so no token
           # material lingers in or near the build context.
           persist-credentials: false

--- a/.github/workflows/image-release.yml
+++ b/.github/workflows/image-release.yml
@@ -191,6 +191,26 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Validate submodules input
+        # actions/checkout silently treats any submodules value other than
+        # true/recursive (case-insensitive) as false rather than erroring, so a
+        # caller typo (e.g. "recursiv") would skip submodule fetch and only fail
+        # later at the Dockerfile COPY. Fail fast with an explicit message here.
+        # runs_on is caller-supplied JSON, so pin bash rather than rely on the
+        # runner default. submodules is passed via env, never interpolated into
+        # the script body.
+        shell: bash
+        env:
+          SUBMODULES: ${{ inputs.submodules }}
+        run: |
+          case "$(printf '%s' "$SUBMODULES" | tr '[:upper:]' '[:lower:]')" in
+            false | true | recursive) ;;
+            *)
+              echo "::error::invalid submodules input '${SUBMODULES}'; expected one of: false, true, recursive"
+              exit 1
+              ;;
+          esac
+
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:


### PR DESCRIPTION
## Bug

`image-release.yml`'s build-context checkout does not fetch git submodules and exposes no way for callers to request them. Repos whose Dockerfile copies a submodule into the image therefore fail the build. Surfaced on dcf-synth (PR #44): the Dockerfile does `COPY dcf-synth-core/ ./` then `RUN test -f ./pyproject.toml || (echo "submodule not initialised" && exit 1)`, which fails because `dcf-synth-core` is never checked out. The production `release.yml` image-build uses the identical meta call, so a real release would hit the same wall (no release.yml run exists yet, so it was latent).

## Fix

- New optional input `submodules` (string: `"false"` default / `"true"` / `"recursive"`), typed as string like `codeql-reusable.yml`'s submodules input.
- Wire it into the main build-context Checkout: `submodules: ${{ inputs.submodules }}`.
- Private submodules need a token that can read other nics-dp repos, so when submodules are requested the checkout uses the already-minted ci-read App token (`steps.priv-token.outputs.token`), else falls back to the default token (unchanged behaviour for non-submodule repos). `persist-credentials: false` is kept — the token is used only to fetch during the step and is not persisted near the build context.

Default `"false"` → zero behaviour change for every existing caller. Only the main (non-external) checkout is wired; external_repo checkout is unaffected.

## Follow-up (separate, after this releases to main)

dcf-synth's `ci.yml` (folded snapshot image-build, PR #44) and `release.yml` image-build must pass `submodules: recursive`. That can only land after this input exists on `@main`, otherwise the caller would startup-fail on an undeclared input.

actionlint clean.
