### PR TITLE
fix(supply-chain): stop scorecard + go-deps failing caller CI

### DIFF
--- a/.github/workflows/go-dependency-submission.yml
+++ b/.github/workflows/go-dependency-submission.yml
@@ -99,14 +99,23 @@ jobs:
       # Two variants so go-build-target is genuinely OMITTED when go_build_target
       # is empty -- the action then applies its own default ('all', every build
       # target including tests and tools) instead of us hardcoding it here.
+      # continue-on-error: actions/go-dependency-submission (latest v2.0.3) has an
+      # unfixed bug where two modules whose final path element is identical (e.g.
+      # cloud.google.com/go and github.com/cncf/xds/go both -> PURL name "go")
+      # trip an internal "expected no more than one package in cache with
+      # namespace+name" assertion and crash. A repo whose graph happens to
+      # contain such a pair (e.g. libdcf) must not have its supply-chain CI fail;
+      # submission resumes automatically once upstream fixes the collision.
       - name: Submit Go dependency graph (all targets)
         if: inputs.go_build_target == ''
+        continue-on-error: true
         uses: actions/go-dependency-submission@f35d5c9af13ce9cc32f7930b171e315e878f6921 # v2.0.3
         with:
           go-mod-path: ${{ inputs.go_mod_path }}
 
       - name: Submit Go dependency graph (target)
         if: inputs.go_build_target != ''
+        continue-on-error: true
         uses: actions/go-dependency-submission@f35d5c9af13ce9cc32f7930b171e315e878f6921 # v2.0.3
         with:
           go-mod-path: ${{ inputs.go_mod_path }}

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -4,9 +4,17 @@ name: Scorecard
 
 # Runs OpenSSF Scorecard against the caller's repository and uploads the
 # findings to GitHub code scanning (Security > Code scanning) under the
-# `scorecard` category. NON-BLOCKING upload by design: a SARIF upload failure
-# never fails the caller's CI (mirrors security-sarif.yml). Callers add a job
-# that `uses:` this workflow.
+# `scorecard` category. NON-BLOCKING by design: neither a scorecard run error
+# nor a SARIF upload failure ever fails the caller's CI (mirrors
+# security-sarif.yml). Callers add a job that `uses:` this workflow.
+#
+# PRIVATE repos: scorecard's GraphQL queries (e.g. ListCommits) need repo read
+# that the default GITHUB_TOKEN lacks -- it errors with "Resource not accessible
+# by integration" and, without the non-blocking guard below, fails the job. To
+# get real scores on a private repo the caller passes ci_read_app_private_key
+# (+ the CI_READ_APP_CLIENT_ID org variable); the minted App token is handed to
+# scorecard as repo_token. Public repos (e.g. meta itself) need nothing -- the
+# default GITHUB_TOKEN suffices.
 on:
   workflow_call:
     inputs:
@@ -15,6 +23,10 @@ on:
         type: boolean
         default: false
         description: "Publish results to the public OpenSSF Scorecard API. Only works for PUBLIC repos; defaults false so it stays safe for the org's mostly-private repos."
+    secrets:
+      ci_read_app_private_key:
+        required: false
+        description: "Private key of the nics-dp-ci-read GitHub App (paired with the CI_READ_APP_CLIENT_ID org variable). Minted into a short-lived token passed to scorecard as repo_token so its GraphQL queries work on PRIVATE repos. Omit for public repos -- the default GITHUB_TOKEN is sufficient."
 
 permissions:
   contents: read
@@ -32,7 +44,26 @@ jobs:
       contents: read
       # scorecard reads branch-protection / workflow settings via the API
       actions: read
+    env:
+      # secrets cannot be used in step-level if:, so bridge to env here. Mirrors
+      # security-sarif.yml: the ci-read App is identified by the
+      # CI_READ_APP_CLIENT_ID org variable (client-id) plus the
+      # ci_read_app_private_key secret.
+      HAS_CI_APP: ${{ vars.CI_READ_APP_CLIENT_ID != '' && secrets.ci_read_app_private_key != '' }}
     steps:
+      # Mint a nics-dp-ci-read App token for scorecard's repo_token, but only
+      # when the App is configured. On private repos this lets scorecard's
+      # GraphQL queries (ListCommits etc.) succeed; public repos skip it and
+      # fall back to GITHUB_TOKEN below (mirrors security-sarif.yml).
+      - name: Mint scorecard repo-read token
+        id: scorecard-token
+        if: ${{ env.HAS_CI_APP == 'true' }}
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ vars.CI_READ_APP_CLIENT_ID }}
+          private-key: ${{ secrets.ci_read_app_private_key }}
+          owner: ${{ github.repository_owner }}
+
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -42,10 +73,19 @@ jobs:
           persist-credentials: false
 
       - name: Run OpenSSF Scorecard
+        # non-blocking: on a private repo without a ci-read App token, scorecard
+        # cannot complete its GraphQL queries (GITHUB_TOKEN -> "Resource not
+        # accessible by integration") and exits non-zero. That must not fail the
+        # caller's CI (mirrors the upload step below and security-sarif.yml).
+        continue-on-error: true
         uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
         with:
           results_format: sarif
           results_file: results.sarif
+          # repo_token: scorecard needs repo read via the GraphQL API that the
+          # default GITHUB_TOKEN lacks on PRIVATE repos. Use the ci-read App
+          # token when configured; fall back to GITHUB_TOKEN for public repos.
+          repo_token: ${{ steps.scorecard-token.outputs.token || github.token }}
           # Publishing to the public Scorecard API only works for public repos;
           # default false keeps it safe for the org's mostly-private repos.
           publish_results: ${{ inputs.publish }}


### PR DESCRIPTION
Both supply-chain reusables currently fail org-wide caller CI. Make them non-blocking, matching the documented "never fail the caller's CI" design they already claim.

## scorecard.yml
- **Symptom**: every private repo's `supply-chain` run fails on the `scorecard` job: `scorecard had an error: ... ListCommits ... Resource not accessible by integration`.
- **Cause**: scorecard's GraphQL queries need repo read the default `GITHUB_TOKEN` lacks on **private** repos.
- **Fix**: `continue-on-error: true` on the run step (mirrors the existing upload step). Also accept an optional `ci_read_app_private_key` secret, minted into a `repo_token`, so a caller that wires it gets real scores on private repos; falls back to `GITHUB_TOKEN` for public repos (e.g. meta itself).

## go-dependency-submission.yml
- **Symptom**: libdcf's `go-deps` job crashes: `assertion failed: expected no more than one package in cache with namespace+name ... for {"name":"go"}`.
- **Cause**: upstream `actions/go-dependency-submission` v2.0.3 (latest, no fix) collides two modules whose final path element is `go` (`cloud.google.com/go`, `github.com/cncf/xds/go`).
- **Fix**: `continue-on-error: true` on the submit steps. The post-step git noise is already non-fatal (proven on passing runs). Submission resumes automatically once upstream fixes the collision.

Validated with actionlint. Callers pin `@main`, so this takes effect via the next meta patch release (v0.2.4.14). No caller changes required to fix the failures; passing `ci_read_app_private_key` to the scorecard job is an optional follow-up to light up real scorecard data on private repos.