### PR TITLE
release: v0.2.4.14

### DIFF
--- a/.github/workflows/go-dependency-submission.yml
+++ b/.github/workflows/go-dependency-submission.yml
@@ -99,14 +99,23 @@ jobs:
       # Two variants so go-build-target is genuinely OMITTED when go_build_target
       # is empty -- the action then applies its own default ('all', every build
       # target including tests and tools) instead of us hardcoding it here.
+      # continue-on-error: actions/go-dependency-submission (latest v2.0.3) has an
+      # unfixed bug where two modules whose final path element is identical (e.g.
+      # cloud.google.com/go and github.com/cncf/xds/go both -> PURL name "go")
+      # trip an internal "expected no more than one package in cache with
+      # namespace+name" assertion and crash. A repo whose graph happens to
+      # contain such a pair (e.g. libdcf) must not have its supply-chain CI fail;
+      # submission resumes automatically once upstream fixes the collision.
       - name: Submit Go dependency graph (all targets)
         if: inputs.go_build_target == ''
+        continue-on-error: true
         uses: actions/go-dependency-submission@f35d5c9af13ce9cc32f7930b171e315e878f6921 # v2.0.3
         with:
           go-mod-path: ${{ inputs.go_mod_path }}
 
       - name: Submit Go dependency graph (target)
         if: inputs.go_build_target != ''
+        continue-on-error: true
         uses: actions/go-dependency-submission@f35d5c9af13ce9cc32f7930b171e315e878f6921 # v2.0.3
         with:
           go-mod-path: ${{ inputs.go_mod_path }}

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -11,7 +11,9 @@ name: Scorecard
 # PRIVATE repos: scorecard's GraphQL queries (e.g. ListCommits) need repo read
 # that the default GITHUB_TOKEN lacks, so it exits with "Resource not accessible
 # by integration". The non-blocking guard below keeps that from failing the
-# caller's CI. NOTE: this reusable cannot mint a repo_token here -- scorecard's
+# caller's CI -- but ONLY on the default publish: false path; a private repo
+# that sets publish: true would still fail (and also cannot publish). NOTE:
+# this reusable cannot mint a repo_token here -- scorecard's
 # publish path (used by public meta, publish: true) only permits an allowlisted
 # set of steps and forbids job-level env, so an App-token step is not possible
 # in the shared workflow. Real scores on private repos would need a separate,

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -4,9 +4,11 @@ name: Scorecard
 
 # Runs OpenSSF Scorecard against the caller's repository and uploads the
 # findings to GitHub code scanning (Security > Code scanning) under the
-# `scorecard` category. NON-BLOCKING by design: neither a scorecard run error
-# nor a SARIF upload failure ever fails the caller's CI (mirrors
-# security-sarif.yml). Callers add a job that `uses:` this workflow.
+# `scorecard` category. NON-BLOCKING on the default publish: false path: a SARIF
+# upload failure never fails the caller's CI, and a scorecard run error is
+# swallowed too (mirrors security-sarif.yml). On the publish: true path (public
+# meta) a scorecard run error is intentionally NOT swallowed, so a real publish
+# failure surfaces. Callers add a job that `uses:` this workflow.
 #
 # PRIVATE repos: scorecard's GraphQL queries (e.g. ListCommits) need repo read
 # that the default GITHUB_TOKEN lacks, so it exits with "Resource not accessible

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -9,12 +9,13 @@ name: Scorecard
 # security-sarif.yml). Callers add a job that `uses:` this workflow.
 #
 # PRIVATE repos: scorecard's GraphQL queries (e.g. ListCommits) need repo read
-# that the default GITHUB_TOKEN lacks -- it errors with "Resource not accessible
-# by integration" and, without the non-blocking guard below, fails the job. To
-# get real scores on a private repo the caller passes ci_read_app_private_key
-# (+ the CI_READ_APP_CLIENT_ID org variable); the minted App token is handed to
-# scorecard as repo_token. Public repos (e.g. meta itself) need nothing -- the
-# default GITHUB_TOKEN suffices.
+# that the default GITHUB_TOKEN lacks, so it exits with "Resource not accessible
+# by integration". The non-blocking guard below keeps that from failing the
+# caller's CI. NOTE: this reusable cannot mint a repo_token here -- scorecard's
+# publish path (used by public meta, publish: true) only permits an allowlisted
+# set of steps and forbids job-level env, so an App-token step is not possible
+# in the shared workflow. Real scores on private repos would need a separate,
+# publish:false-only variant.
 on:
   workflow_call:
     inputs:
@@ -23,10 +24,6 @@ on:
         type: boolean
         default: false
         description: "Publish results to the public OpenSSF Scorecard API. Only works for PUBLIC repos; defaults false so it stays safe for the org's mostly-private repos."
-    secrets:
-      ci_read_app_private_key:
-        required: false
-        description: "Private key of the nics-dp-ci-read GitHub App (paired with the CI_READ_APP_CLIENT_ID org variable). Minted into a short-lived token passed to scorecard as repo_token so its GraphQL queries work on PRIVATE repos. Omit for public repos -- the default GITHUB_TOKEN is sufficient."
 
 permissions:
   contents: read
@@ -44,26 +41,7 @@ jobs:
       contents: read
       # scorecard reads branch-protection / workflow settings via the API
       actions: read
-    env:
-      # secrets cannot be used in step-level if:, so bridge to env here. Mirrors
-      # security-sarif.yml: the ci-read App is identified by the
-      # CI_READ_APP_CLIENT_ID org variable (client-id) plus the
-      # ci_read_app_private_key secret.
-      HAS_CI_APP: ${{ vars.CI_READ_APP_CLIENT_ID != '' && secrets.ci_read_app_private_key != '' }}
     steps:
-      # Mint a nics-dp-ci-read App token for scorecard's repo_token, but only
-      # when the App is configured. On private repos this lets scorecard's
-      # GraphQL queries (ListCommits etc.) succeed; public repos skip it and
-      # fall back to GITHUB_TOKEN below (mirrors security-sarif.yml).
-      - name: Mint scorecard repo-read token
-        id: scorecard-token
-        if: ${{ env.HAS_CI_APP == 'true' }}
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
-        with:
-          client-id: ${{ vars.CI_READ_APP_CLIENT_ID }}
-          private-key: ${{ secrets.ci_read_app_private_key }}
-          owner: ${{ github.repository_owner }}
-
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -73,19 +51,18 @@ jobs:
           persist-credentials: false
 
       - name: Run OpenSSF Scorecard
-        # non-blocking: on a private repo without a ci-read App token, scorecard
-        # cannot complete its GraphQL queries (GITHUB_TOKEN -> "Resource not
-        # accessible by integration") and exits non-zero. That must not fail the
+        # non-blocking on the non-publish path: on a private repo scorecard's
+        # GraphQL queries fail (GITHUB_TOKEN -> "Resource not accessible by
+        # integration") and the action exits non-zero. That must not fail the
         # caller's CI (mirrors the upload step below and security-sarif.yml).
-        continue-on-error: true
+        # Gated to publish==false so the publish path (public meta) keeps its
+        # canonical behaviour, where scorecard succeeds and a real failure must
+        # surface.
+        continue-on-error: ${{ !inputs.publish }}
         uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
         with:
           results_format: sarif
           results_file: results.sarif
-          # repo_token: scorecard needs repo read via the GraphQL API that the
-          # default GITHUB_TOKEN lacks on PRIVATE repos. Use the ci-read App
-          # token when configured; fall back to GITHUB_TOKEN for public repos.
-          repo_token: ${{ steps.scorecard-token.outputs.token || github.token }}
           # Publishing to the public Scorecard API only works for public repos;
           # default false keeps it safe for the org's mostly-private repos.
           publish_results: ${{ inputs.publish }}

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -4,9 +4,17 @@ name: Scorecard
 
 # Runs OpenSSF Scorecard against the caller's repository and uploads the
 # findings to GitHub code scanning (Security > Code scanning) under the
-# `scorecard` category. NON-BLOCKING upload by design: a SARIF upload failure
-# never fails the caller's CI (mirrors security-sarif.yml). Callers add a job
-# that `uses:` this workflow.
+# `scorecard` category. NON-BLOCKING by design: neither a scorecard run error
+# nor a SARIF upload failure ever fails the caller's CI (mirrors
+# security-sarif.yml). Callers add a job that `uses:` this workflow.
+#
+# PRIVATE repos: scorecard's GraphQL queries (e.g. ListCommits) need repo read
+# that the default GITHUB_TOKEN lacks -- it errors with "Resource not accessible
+# by integration" and, without the non-blocking guard below, fails the job. To
+# get real scores on a private repo the caller passes ci_read_app_private_key
+# (+ the CI_READ_APP_CLIENT_ID org variable); the minted App token is handed to
+# scorecard as repo_token. Public repos (e.g. meta itself) need nothing -- the
+# default GITHUB_TOKEN suffices.
 on:
   workflow_call:
     inputs:
@@ -15,6 +23,10 @@ on:
         type: boolean
         default: false
         description: "Publish results to the public OpenSSF Scorecard API. Only works for PUBLIC repos; defaults false so it stays safe for the org's mostly-private repos."
+    secrets:
+      ci_read_app_private_key:
+        required: false
+        description: "Private key of the nics-dp-ci-read GitHub App (paired with the CI_READ_APP_CLIENT_ID org variable). Minted into a short-lived token passed to scorecard as repo_token so its GraphQL queries work on PRIVATE repos. Omit for public repos -- the default GITHUB_TOKEN is sufficient."
 
 permissions:
   contents: read
@@ -32,7 +44,26 @@ jobs:
       contents: read
       # scorecard reads branch-protection / workflow settings via the API
       actions: read
+    env:
+      # secrets cannot be used in step-level if:, so bridge to env here. Mirrors
+      # security-sarif.yml: the ci-read App is identified by the
+      # CI_READ_APP_CLIENT_ID org variable (client-id) plus the
+      # ci_read_app_private_key secret.
+      HAS_CI_APP: ${{ vars.CI_READ_APP_CLIENT_ID != '' && secrets.ci_read_app_private_key != '' }}
     steps:
+      # Mint a nics-dp-ci-read App token for scorecard's repo_token, but only
+      # when the App is configured. On private repos this lets scorecard's
+      # GraphQL queries (ListCommits etc.) succeed; public repos skip it and
+      # fall back to GITHUB_TOKEN below (mirrors security-sarif.yml).
+      - name: Mint scorecard repo-read token
+        id: scorecard-token
+        if: ${{ env.HAS_CI_APP == 'true' }}
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ vars.CI_READ_APP_CLIENT_ID }}
+          private-key: ${{ secrets.ci_read_app_private_key }}
+          owner: ${{ github.repository_owner }}
+
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -42,10 +73,19 @@ jobs:
           persist-credentials: false
 
       - name: Run OpenSSF Scorecard
+        # non-blocking: on a private repo without a ci-read App token, scorecard
+        # cannot complete its GraphQL queries (GITHUB_TOKEN -> "Resource not
+        # accessible by integration") and exits non-zero. That must not fail the
+        # caller's CI (mirrors the upload step below and security-sarif.yml).
+        continue-on-error: true
         uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
         with:
           results_format: sarif
           results_file: results.sarif
+          # repo_token: scorecard needs repo read via the GraphQL API that the
+          # default GITHUB_TOKEN lacks on PRIVATE repos. Use the ci-read App
+          # token when configured; fall back to GITHUB_TOKEN for public repos.
+          repo_token: ${{ steps.scorecard-token.outputs.token || github.token }}
           # Publishing to the public Scorecard API only works for public repos;
           # default false keeps it safe for the org's mostly-private repos.
           publish_results: ${{ inputs.publish }}


### PR DESCRIPTION
## Release v0.2.4.14

Promote `dev` -> `main` (patch). Fixes org-wide supply-chain CI failures.

### Changes
- **fix(scorecard): non-blocking on private repos, publish path kept canonical** (#188, corrected by #190). Every PRIVATE repo's `supply-chain` run failed on the `scorecard` job (`ListCommits ... Resource not accessible by integration`). The run step is now `continue-on-error: ${{ !inputs.publish }}` -> private callers (`publish: false`) are non-blocking; public meta (`publish: true`) keeps canonical behaviour so a real failure surfaces. The first attempt added a job `env` + `create-github-app-token` step, which violated Scorecard's publish-path restrictions and broke meta's own `self-supply-chain` (verified fixed: self-supply-chain now green on `dev`).
- **fix(go-deps): tolerate upstream purl name-collision crash** (#188). `actions/go-dependency-submission` v2.0.3 (latest) crashes on a `namespace+name` assertion when two modules share a final path element (`cloud.google.com/go` + `github.com/cncf/xds/go` -> PURL name `go`), failing libdcf's supply-chain CI. The submit steps are now `continue-on-error`; submission resumes once upstream fixes the collision.

### Validation
- actionlint clean; Copilot review-loop run on #190 to convergence (no new comments).
- meta `self-supply-chain` (publish path) verified green on dev HEAD before this promotion.

### Known limitation
Real Scorecard scores on private repos need a `repo_token`, but the publish-path step allowlist forbids a token-mint step in this shared reusable. A `publish:false`-only variant would be required — tracked as follow-up.

Callers pin `@main`, so this release clears the supply-chain failures across all 17 caller repos.