### PR TITLE
fix(go-deps): pin action to unreleased namespace-collision fix

### DIFF
--- a/.github/workflows/go-dependency-submission.yml
+++ b/.github/workflows/go-dependency-submission.yml
@@ -99,24 +99,25 @@ jobs:
       # Two variants so go-build-target is genuinely OMITTED when go_build_target
       # is empty -- the action then applies its own default ('all', every build
       # target including tests and tools) instead of us hardcoding it here.
-      # continue-on-error: actions/go-dependency-submission (latest v2.0.3) has an
-      # unfixed bug where two modules whose final path element is identical (e.g.
-      # cloud.google.com/go and github.com/cncf/xds/go both -> PURL name "go")
-      # trip an internal "expected no more than one package in cache with
-      # namespace+name" assertion and crash. A repo whose graph happens to
-      # contain such a pair (e.g. libdcf) must not have its supply-chain CI fail;
-      # submission resumes automatically once upstream fixes the collision.
+      #
+      # Pinned to an UNRELEASED main commit on purpose. The latest tag (v2.0.3,
+      # 2025-03) keys its package cache by PURL name only, so two modules whose
+      # final path element is identical (e.g. cloud.google.com/go and
+      # github.com/cncf/xds/go both -> name "go") trip an "expected no more than
+      # one package in cache with namespace+name" assertion and crash -- this hit
+      # libdcf. main fixes it (913bb85 "Fix shared namespace package bug", now
+      # matches on namespace+name). No tag carries the fix yet; revert to the
+      # next release tag once it is cut. This is why there is no continue-on-error
+      # here: the root cause is fixed, so a submission failure should now surface.
       - name: Submit Go dependency graph (all targets)
         if: inputs.go_build_target == ''
-        continue-on-error: true
-        uses: actions/go-dependency-submission@f35d5c9af13ce9cc32f7930b171e315e878f6921 # v2.0.3
+        uses: actions/go-dependency-submission@bc8bc528058f8783a71277e474972be5d8dc4f94 # main@2026-05-26 (unreleased namespace-collision fix 913bb85)
         with:
           go-mod-path: ${{ inputs.go_mod_path }}
 
       - name: Submit Go dependency graph (target)
         if: inputs.go_build_target != ''
-        continue-on-error: true
-        uses: actions/go-dependency-submission@f35d5c9af13ce9cc32f7930b171e315e878f6921 # v2.0.3
+        uses: actions/go-dependency-submission@bc8bc528058f8783a71277e474972be5d8dc4f94 # main@2026-05-26 (unreleased namespace-collision fix 913bb85)
         with:
           go-mod-path: ${{ inputs.go_mod_path }}
           go-build-target: ${{ inputs.go_build_target }}


### PR DESCRIPTION
Real fix for the libdcf `go-deps` crash that #188/#190 (v0.2.4.14) only papered over with `continue-on-error`.

## Root cause (confirmed in upstream source)
`actions/go-dependency-submission`'s `src/match.ts` at the latest tag **v2.0.3** (2025-03) looks up its package cache by PURL **name only**:
```ts
cache.packagesMatching({ name: childPkg.name })
```
Two modules whose final path element is identical — `cloud.google.com/go` and `github.com/cncf/xds/go`, both PURL name `go` — both match, tripping:
```
assertion failed: expected no more than one package in cache with namespace+name ... for {"name":"go"}
```
libdcf's graph contains exactly that pair, so its `go-deps` job crashed.

## Fix
Upstream **already fixed this on `main`** in commit `913bb85` ("Fix shared namespace package bug"): `findMatchingPackage()` now also filters by namespace, disambiguating modules that share a name. No release tag carries it yet (v2.0.3 predates it).

- Pin both submit steps to `actions/go-dependency-submission@bc8bc528058f8783a71277e474972be5d8dc4f94` (main @ 2026-05-26, `dist/` built, includes the fix).
- **Remove** the `continue-on-error` workaround from v0.2.4.14 — the root cause is fixed, so a real submission failure should surface again (restores the reusable's original blocking behaviour).
- Comment documents that this is an intentional unreleased-commit pin; revert to the next release tag once cut.

SHA-pinned (immutable). Validated with actionlint. Verified post-merge on libdcf + dcf-service.