### PR TITLE
feat(scorecard): split publish/private files, mint app token for private scores

### DIFF
--- a/.github/workflows/scorecard-publish.yml
+++ b/.github/workflows/scorecard-publish.yml
@@ -1,0 +1,66 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+
+name: Scorecard (publish)
+
+# PUBLIC-repo variant of OpenSSF Scorecard: runs Scorecard, uploads SARIF to
+# code scanning, AND publishes results to the public OpenSSF API (badge). Only
+# works for PUBLIC repos (meta). Callers add a job that `uses:` this workflow.
+#
+# The publish path is verified server-side by the OpenSSF API against a strict
+# allowlist: no global/job env or defaults, no global write permissions, only
+# the scorecard job may set id-token: write, and steps are limited to
+# {checkout, upload-artifact, codeql upload-sarif, scorecard-action,
+# harden-runner}. This file is therefore deliberately minimal and canonical --
+# do NOT add a job env, a token-mint step, or a second scorecard-action job
+# here. Private repos use the separate scorecard.yml (publish:false), which can
+# mint an App token precisely because it never hits this verification.
+on:
+  workflow_call:
+    inputs:
+      publish:
+        required: false
+        type: boolean
+        default: true
+        description: "Publish results to the public OpenSSF Scorecard API. Only works for PUBLIC repos. Defaults true (this is the publish variant)."
+
+permissions:
+  contents: read
+
+jobs:
+  scorecard:
+    # Pinned to ubuntu-latest: scorecard-action is a Linux/Docker-based action.
+    runs-on: ubuntu-latest
+    permissions:
+      # required by github/codeql-action/upload-sarif to write code-scanning results
+      security-events: write
+      # required for the publish path to authenticate to the Scorecard API via OIDC
+      id-token: write
+      contents: read
+      # scorecard reads branch-protection / workflow settings via the API
+      actions: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          fetch-depth: 1
+          # Do not persist the GITHUB_TOKEN into the checkout so later steps
+          # cannot be coerced into using it (CodeQL actions/untrusted-checkout).
+          persist-credentials: false
+
+      - name: Run OpenSSF Scorecard
+        # No continue-on-error: on the publish path scorecard succeeds (public
+        # repo) and a real failure must surface.
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
+        with:
+          results_format: sarif
+          results_file: results.sarif
+          publish_results: ${{ inputs.publish }}
+
+      - name: Upload Scorecard SARIF
+        if: always() && hashFiles('results.sarif') != ''
+        # non-blocking: a failed upload must not fail the job (mirrors security-sarif.yml).
+        continue-on-error: true
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        with:
+          sarif_file: results.sarif
+          category: scorecard

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -102,10 +102,14 @@ jobs:
       # plus the scorecard_app_private_key secret (mirrors mise-task.yml).
       HAS_SCORECARD_APP: ${{ vars.SCORECARD_APP_CLIENT_ID != '' && secrets.scorecard_app_private_key != '' }}
     steps:
-      # Mint a nics-dp-scorecard App token to use as repo_token. Scoped to the
-      # caller repo. Skipped when the App is not configured -- scorecard then
-      # falls back to GITHUB_TOKEN (queries fail on a private repo) and
-      # continue-on-error keeps CI green until the App is wired.
+      # Mint a nics-dp-scorecard App token to use as repo_token. With neither
+      # owner nor repositories set, create-github-app-token scopes the token to
+      # the current repository (least privilege) -- do not pass github.event.*,
+      # which is absent on some workflow_call triggers and would either error or,
+      # with owner set, widen the token to the whole owner installation. Skipped
+      # when the App is not configured -- scorecard then falls back to
+      # GITHUB_TOKEN (queries fail on a private repo) and continue-on-error keeps
+      # CI green until the App is wired.
       - name: Mint Scorecard repo-read token
         id: sc-token
         if: ${{ env.HAS_SCORECARD_APP == 'true' }}
@@ -113,8 +117,6 @@ jobs:
         with:
           client-id: ${{ vars.SCORECARD_APP_CLIENT_ID }}
           private-key: ${{ secrets.scorecard_app_private_key }}
-          owner: ${{ github.repository_owner }}
-          repositories: ${{ github.event.repository.name }}
 
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -113,6 +113,11 @@ jobs:
       - name: Mint Scorecard repo-read token
         id: sc-token
         if: ${{ env.HAS_SCORECARD_APP == 'true' }}
+        # non-blocking: if minting fails (App not installed on this repo, bad
+        # key, transient API error) the step must not fail the job -- the token
+        # output is then empty and repo_token below falls back to GITHUB_TOKEN
+        # (keeps the "CI green until the App is wired" guarantee).
+        continue-on-error: true
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           client-id: ${{ vars.SCORECARD_APP_CLIENT_ID }}

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -2,32 +2,22 @@
 
 name: Scorecard
 
-# Runs OpenSSF Scorecard against the caller's repository and uploads the
-# findings to GitHub code scanning (Security > Code scanning) under the
-# `scorecard` category. Callers add a job that `uses:` this workflow.
+# PRIVATE-repo variant of OpenSSF Scorecard: runs Scorecard, uploads SARIF to
+# GitHub code scanning (Security > Code scanning, category `scorecard`), and
+# NEVER publishes to the public OpenSSF API. Callers add a job that `uses:` this.
 #
-# Two mutually-exclusive jobs gated on `publish`, because Scorecard's publish
-# path and the private-repo token path have incompatible requirements:
+# Why a dedicated private file (see scorecard-publish.yml for the public one):
+# Scorecard's publish path (publish_results: true) is verified server-side by the
+# OpenSSF API, which scans the whole workflow and picks "the first job with a
+# scorecard-action step" via an UNORDERED map -- so a file with both a publish
+# job and a token-minting private job would intermittently fail verification
+# (env vars / non-allowlist step / another job's id-token). Keeping the two
+# paths in separate files means each file has exactly one scorecard-action job.
+# Because this file never publishes, it is free to mint an App token and use a
+# job env (neither is ever verified).
 #
-#   publish == true  (public repos, e.g. meta): posts to the public OpenSSF API
-#     for the badge. The API enforces a strict workflow allowlist -- no job-level
-#     env, steps limited to {checkout, upload-artifact, codeql upload-sarif,
-#     scorecard-action, harden-runner}. So the `publish` job stays canonical:
-#     no token-mint step, no env, default GITHUB_TOKEN (sufficient on public
-#     repos), and a real failure is allowed to surface (no continue-on-error).
-#
-#   publish == false (the org's private repos): no publish, no allowlist. The
-#     `private` job mints a dedicated nics-dp-scorecard App token and passes it
-#     as repo_token so Scorecard's queries work on a private repo and the
-#     Branch-Protection check (which needs Administration: Read) actually scores.
-#     Without the App it falls back to GITHUB_TOKEN (queries fail on a private
-#     repo) and continue-on-error keeps the caller's CI green. NON-BLOCKING:
-#     a scorecard/upload failure never fails the caller's CI (mirrors
-#     security-sarif.yml).
-#
-# These cannot share one job: a token-mint step or job env in the publish job
-# trips the OpenSSF API's workflow verification ("scorecard job contains env
-# vars" / step not on allowlist), which is what broke meta's self-supply-chain.
+# NON-BLOCKING throughout: a token-mint, scorecard, or upload failure never fails
+# the caller's CI (mirrors security-sarif.yml).
 on:
   workflow_call:
     inputs:
@@ -35,61 +25,18 @@ on:
         required: false
         type: boolean
         default: false
-        description: "Publish results to the public OpenSSF Scorecard API. Only works for PUBLIC repos; defaults false so it stays safe for the org's mostly-private repos."
+        description: "Retained for caller compatibility only. This file is the PRIVATE variant and never publishes; to publish (public repos) use scorecard-publish.yml. A truthy value here is ignored."
     secrets:
       scorecard_app_private_key:
         required: false
-        description: "Private key of the nics-dp-scorecard GitHub App (paired with the SCORECARD_APP_CLIENT_ID org variable). Minted into a short-lived repo_token so Scorecard's API queries (incl. Branch-Protection, which needs Administration: Read) score on PRIVATE repos. Ignored on the publish path; omit for public repos."
+        description: "Private key of the nics-dp-scorecard GitHub App (paired with the SCORECARD_APP_CLIENT_ID org variable). Minted into a short-lived repo_token so Scorecard's API queries (incl. Branch-Protection, which needs Administration: Read) score on PRIVATE repos. Without it scorecard falls back to GITHUB_TOKEN (queries fail on a private repo) and the run stays non-blocking."
 
 permissions:
   contents: read
 
 jobs:
-  # PUBLIC repos (publish: true, e.g. meta). Canonical Scorecard publish job:
-  # allowlisted steps only, no env, no token step -- required by the OpenSSF API.
-  publish:
-    if: ${{ inputs.publish }}
+  scorecard:
     # Pinned to ubuntu-latest: scorecard-action is a Linux/Docker-based action.
-    runs-on: ubuntu-latest
-    permissions:
-      # required by github/codeql-action/upload-sarif to write code-scanning results
-      security-events: write
-      # required for the publish path to authenticate to the Scorecard API via OIDC
-      id-token: write
-      contents: read
-      # scorecard reads branch-protection / workflow settings via the API
-      actions: read
-    steps:
-      - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-        with:
-          fetch-depth: 1
-          # Do not persist the GITHUB_TOKEN into the checkout so later steps
-          # cannot be coerced into using it (CodeQL actions/untrusted-checkout).
-          persist-credentials: false
-
-      - name: Run OpenSSF Scorecard
-        # No continue-on-error: on the publish path scorecard succeeds (public
-        # repo) and a real failure must surface.
-        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
-        with:
-          results_format: sarif
-          results_file: results.sarif
-          publish_results: true
-
-      - name: Upload Scorecard SARIF
-        if: always() && hashFiles('results.sarif') != ''
-        # non-blocking: a failed upload must not fail the job (mirrors security-sarif.yml).
-        continue-on-error: true
-        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
-        with:
-          sarif_file: results.sarif
-          category: scorecard
-
-  # PRIVATE repos (publish: false). Mints the nics-dp-scorecard App token for
-  # full scores; non-blocking throughout. Not subject to the publish allowlist.
-  private:
-    if: ${{ !inputs.publish }}
     runs-on: ubuntu-latest
     permissions:
       # checkout uses GITHUB_TOKEN; SARIF upload writes code-scanning results.
@@ -97,26 +44,21 @@ jobs:
       security-events: write
       actions: read
     env:
-      # secrets cannot be used in step-level if:, so bridge to env here. The App
-      # is identified by the SCORECARD_APP_CLIENT_ID org variable (client-id)
-      # plus the scorecard_app_private_key secret (mirrors mise-task.yml).
+      # secrets cannot be used in step-level if: (the secrets context is not
+      # available to if conditionals), so bridge to env here. The App is
+      # identified by the SCORECARD_APP_CLIENT_ID org variable (client-id) plus
+      # the scorecard_app_private_key secret (mirrors mise-task.yml).
       HAS_SCORECARD_APP: ${{ vars.SCORECARD_APP_CLIENT_ID != '' && secrets.scorecard_app_private_key != '' }}
     steps:
       # Mint a nics-dp-scorecard App token to use as repo_token. With neither
       # owner nor repositories set, create-github-app-token scopes the token to
-      # the current repository (least privilege) -- do not pass github.event.*,
-      # which is absent on some workflow_call triggers and would either error or,
-      # with owner set, widen the token to the whole owner installation. Skipped
-      # when the App is not configured -- scorecard then falls back to
-      # GITHUB_TOKEN (queries fail on a private repo) and continue-on-error keeps
-      # CI green until the App is wired.
+      # the current repository (least privilege). Skipped when the App is not
+      # configured; non-blocking so a mint failure (App not installed on this
+      # repo, bad key, transient API error) leaves the token empty and
+      # repo_token below falls back to GITHUB_TOKEN.
       - name: Mint Scorecard repo-read token
         id: sc-token
         if: ${{ env.HAS_SCORECARD_APP == 'true' }}
-        # non-blocking: if minting fails (App not installed on this repo, bad
-        # key, transient API error) the step must not fail the job -- the token
-        # output is then empty and repo_token below falls back to GITHUB_TOKEN
-        # (keeps the "CI green until the App is wired" guarantee).
         continue-on-error: true
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
@@ -127,6 +69,8 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 1
+          # Do not persist the GITHUB_TOKEN into the checkout so later steps
+          # cannot be coerced into using it (CodeQL actions/untrusted-checkout).
           persist-credentials: false
 
       - name: Run OpenSSF Scorecard
@@ -142,6 +86,7 @@ jobs:
           # Administration: Read for Branch-Protection); falls back to the
           # default token when the App is not configured.
           repo_token: ${{ steps.sc-token.outputs.token || github.token }}
+          # This is the private variant: never publish (see scorecard-publish.yml).
           publish_results: false
 
       - name: Upload Scorecard SARIF

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -4,22 +4,30 @@ name: Scorecard
 
 # Runs OpenSSF Scorecard against the caller's repository and uploads the
 # findings to GitHub code scanning (Security > Code scanning) under the
-# `scorecard` category. NON-BLOCKING on the default publish: false path: a SARIF
-# upload failure never fails the caller's CI, and a scorecard run error is
-# swallowed too (mirrors security-sarif.yml). On the publish: true path (public
-# meta) a scorecard run error is intentionally NOT swallowed, so a real publish
-# failure surfaces. Callers add a job that `uses:` this workflow.
+# `scorecard` category. Callers add a job that `uses:` this workflow.
 #
-# PRIVATE repos: scorecard's GraphQL queries (e.g. ListCommits) need repo read
-# that the default GITHUB_TOKEN lacks, so it exits with "Resource not accessible
-# by integration". The non-blocking guard below keeps that from failing the
-# caller's CI -- but ONLY on the default publish: false path; a private repo
-# that sets publish: true would still fail (and also cannot publish). NOTE:
-# this reusable cannot mint a repo_token here -- scorecard's
-# publish path (used by public meta, publish: true) only permits an allowlisted
-# set of steps and forbids job-level env, so an App-token step is not possible
-# in the shared workflow. Real scores on private repos would need a separate,
-# publish:false-only variant.
+# Two mutually-exclusive jobs gated on `publish`, because Scorecard's publish
+# path and the private-repo token path have incompatible requirements:
+#
+#   publish == true  (public repos, e.g. meta): posts to the public OpenSSF API
+#     for the badge. The API enforces a strict workflow allowlist -- no job-level
+#     env, steps limited to {checkout, upload-artifact, codeql upload-sarif,
+#     scorecard-action, harden-runner}. So the `publish` job stays canonical:
+#     no token-mint step, no env, default GITHUB_TOKEN (sufficient on public
+#     repos), and a real failure is allowed to surface (no continue-on-error).
+#
+#   publish == false (the org's private repos): no publish, no allowlist. The
+#     `private` job mints a dedicated nics-dp-scorecard App token and passes it
+#     as repo_token so Scorecard's queries work on a private repo and the
+#     Branch-Protection check (which needs Administration: Read) actually scores.
+#     Without the App it falls back to GITHUB_TOKEN (queries fail on a private
+#     repo) and continue-on-error keeps the caller's CI green. NON-BLOCKING:
+#     a scorecard/upload failure never fails the caller's CI (mirrors
+#     security-sarif.yml).
+#
+# These cannot share one job: a token-mint step or job env in the publish job
+# trips the OpenSSF API's workflow verification ("scorecard job contains env
+# vars" / step not on allowlist), which is what broke meta's self-supply-chain.
 on:
   workflow_call:
     inputs:
@@ -28,14 +36,20 @@ on:
         type: boolean
         default: false
         description: "Publish results to the public OpenSSF Scorecard API. Only works for PUBLIC repos; defaults false so it stays safe for the org's mostly-private repos."
+    secrets:
+      scorecard_app_private_key:
+        required: false
+        description: "Private key of the nics-dp-scorecard GitHub App (paired with the SCORECARD_APP_CLIENT_ID org variable). Minted into a short-lived repo_token so Scorecard's API queries (incl. Branch-Protection, which needs Administration: Read) score on PRIVATE repos. Ignored on the publish path; omit for public repos."
 
 permissions:
   contents: read
 
 jobs:
-  scorecard:
-    # Pinned to ubuntu-latest: scorecard-action is a Linux/Docker-based action
-    # and no caller passes a custom runner.
+  # PUBLIC repos (publish: true, e.g. meta). Canonical Scorecard publish job:
+  # allowlisted steps only, no env, no token step -- required by the OpenSSF API.
+  publish:
+    if: ${{ inputs.publish }}
+    # Pinned to ubuntu-latest: scorecard-action is a Linux/Docker-based action.
     runs-on: ubuntu-latest
     permissions:
       # required by github/codeql-action/upload-sarif to write code-scanning results
@@ -55,26 +69,77 @@ jobs:
           persist-credentials: false
 
       - name: Run OpenSSF Scorecard
-        # non-blocking on the non-publish path: on a private repo scorecard's
-        # GraphQL queries fail (GITHUB_TOKEN -> "Resource not accessible by
-        # integration") and the action exits non-zero. That must not fail the
-        # caller's CI (mirrors the upload step below and security-sarif.yml).
-        # Gated to publish==false so the publish path (public meta) keeps its
-        # canonical behaviour, where scorecard succeeds and a real failure must
-        # surface.
-        continue-on-error: ${{ !inputs.publish }}
+        # No continue-on-error: on the publish path scorecard succeeds (public
+        # repo) and a real failure must surface.
         uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
         with:
           results_format: sarif
           results_file: results.sarif
-          # Publishing to the public Scorecard API only works for public repos;
-          # default false keeps it safe for the org's mostly-private repos.
-          publish_results: ${{ inputs.publish }}
+          publish_results: true
 
       - name: Upload Scorecard SARIF
         if: always() && hashFiles('results.sarif') != ''
-        # non-blocking: a failed upload (API / permissions / SARIF format) must
-        # not fail the job and break the caller's CI (mirrors security-sarif.yml).
+        # non-blocking: a failed upload must not fail the job (mirrors security-sarif.yml).
+        continue-on-error: true
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        with:
+          sarif_file: results.sarif
+          category: scorecard
+
+  # PRIVATE repos (publish: false). Mints the nics-dp-scorecard App token for
+  # full scores; non-blocking throughout. Not subject to the publish allowlist.
+  private:
+    if: ${{ !inputs.publish }}
+    runs-on: ubuntu-latest
+    permissions:
+      # checkout uses GITHUB_TOKEN; SARIF upload writes code-scanning results.
+      contents: read
+      security-events: write
+      actions: read
+    env:
+      # secrets cannot be used in step-level if:, so bridge to env here. The App
+      # is identified by the SCORECARD_APP_CLIENT_ID org variable (client-id)
+      # plus the scorecard_app_private_key secret (mirrors mise-task.yml).
+      HAS_SCORECARD_APP: ${{ vars.SCORECARD_APP_CLIENT_ID != '' && secrets.scorecard_app_private_key != '' }}
+    steps:
+      # Mint a nics-dp-scorecard App token to use as repo_token. Scoped to the
+      # caller repo. Skipped when the App is not configured -- scorecard then
+      # falls back to GITHUB_TOKEN (queries fail on a private repo) and
+      # continue-on-error keeps CI green until the App is wired.
+      - name: Mint Scorecard repo-read token
+        id: sc-token
+        if: ${{ env.HAS_SCORECARD_APP == 'true' }}
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ vars.SCORECARD_APP_CLIENT_ID }}
+          private-key: ${{ secrets.scorecard_app_private_key }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Run OpenSSF Scorecard
+        # non-blocking: a scorecard run error (e.g. no App token on a private
+        # repo) must not fail the caller's CI (mirrors security-sarif.yml).
+        continue-on-error: true
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
+        with:
+          results_format: sarif
+          results_file: results.sarif
+          # repo_token drives all of scorecard's GitHub API queries. The App
+          # token carries the reads scorecard needs on a private repo (incl.
+          # Administration: Read for Branch-Protection); falls back to the
+          # default token when the App is not configured.
+          repo_token: ${{ steps.sc-token.outputs.token || github.token }}
+          publish_results: false
+
+      - name: Upload Scorecard SARIF
+        if: always() && hashFiles('results.sarif') != ''
+        # non-blocking: a failed upload must not fail the job (mirrors security-sarif.yml).
         continue-on-error: true
         uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
         with:

--- a/.github/workflows/self-supply-chain.yml
+++ b/.github/workflows/self-supply-chain.yml
@@ -21,6 +21,6 @@ jobs:
       id-token: write
       contents: read
       actions: read
-    uses: nics-dp/meta/.github/workflows/scorecard.yml@main
+    uses: nics-dp/meta/.github/workflows/scorecard-publish.yml@main
     with:
       publish: true


### PR DESCRIPTION
Enables **real OpenSSF Scorecard scores on private repos** via a dedicated App, structured as **two separate reusable files** (not one file with two jobs).

## Why two files (not 方案 A)
Copilot flagged, and I verified in `ossf/scorecard-webapp/app/server/verify_workflow.go`, that the publish-path verifier:
1. `findScorecardJob()` ranges over the jobs **map (unordered)** → picks the first job with a scorecard-action step non-deterministically;
2. rejects if any **other** job has `id-token: write`, or the picked job has **env** / **non-allowlist steps**.

So one file with both a `publish` job and a token-minting `private` job would fail meta's publish ~50% of runs. Splitting gives each file exactly one scorecard-action job.

## Files
- **`scorecard.yml`** — PRIVATE variant (`publish_results: false`, never verified). Mints the **`nics-dp-scorecard` App token** as `repo_token` so scorecard's queries (incl. **Branch-Protection**, needs `Administration: Read`) score on private repos. Token-mint + scorecard + upload all `continue-on-error` → non-blocking; falls back to `GITHUB_TOKEN` when the App isn't wired. App token scoped to the current repo (no owner/repositories). Keeps the `publish` input for caller compat (ignored).
- **`scorecard-publish.yml`** — canonical PUBLIC/publish variant for meta: no env, no token step, allowlisted steps only.
- **`self-supply-chain.yml`** — meta now uses `scorecard-publish.yml`.

## Rollout
1. This PR (meta) — safe no-op until the App + secret exist.
2. 17 private callers add `scorecard_app_private_key` (keep `uses: scorecard.yml@main`).
3. Create + install the `nics-dp-scorecard` App; set `SCORECARD_APP_CLIENT_ID` org var + `SCORECARD_APP_PRIVATE_KEY` org secret (org admin, manual).

Check name unchanged (`scorecard / scorecard`). Validated with actionlint. Prior Copilot threads (token scoping, secrets-in-if, mint non-blocking, single-file verifier flaw) all addressed.