### PR TITLE
ci(renovate): pin Dockerfile base image digests

### DIFF
--- a/renovate-preset.json
+++ b/renovate-preset.json
@@ -73,6 +73,13 @@
       ]
     },
     {
+      "description": "Pin Dockerfile base image digests (OpenSSF Scorecard Pinned-Dependencies). Scoped to the dockerfile manager only: docker-compose stays tag-based for dev convenience, and github-actions is intentionally left unpinned so the org's mutable nics-dp/meta reusables can keep using @main.",
+      "matchManagers": [
+        "dockerfile"
+      ],
+      "pinDigests": true
+    },
+    {
       "description": "Group npm and bun updates (dashboard-only, no PR until approved)",
       "matchManagers": [
         "npm",


### PR DESCRIPTION
Resolves the OpenSSF Scorecard **Pinned-Dependencies** `containerImage not pinned by hash` findings (10 repos, the Dockerfile `FROM` lines) by having Renovate pin and maintain base-image digests.

## Change
One packageRule in the org renovate-preset with `pinDigests: true`, **scoped to the `dockerfile` manager only**:
- `docker-compose` stays tag-based (dev convenience).
- `github-actions` is intentionally left unpinned so the org's mutable `nics-dp/meta/...@main` reusables keep working (pinning them to SHA would break the auto-update model and force re-pinning every caller on each meta release).

## Effect
Renovate will open "Pin dependencies" PRs across consumer repos pinning each `FROM image:tag` to `image:tag@sha256:...` (multi-arch manifest-list digest resolved correctly by Renovate) and keep them updated. Preset is read from meta's default branch (dev), so merging here makes it live — no release tag needed.

## Note
This does **not** make Pinned-Dependencies reach 10: the 13 `nics-dp/meta@main` reusable references remain by design. It clears the 6-per-repo Dockerfile findings (real supply-chain hardening). Renovate runs on the org schedule (earlyMondays); pins appear on the next run or when triggered via the Dependency Dashboard.