### PR TITLE
ci(workflows): set restrictive top-level token permissions

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -16,6 +16,9 @@ on:
     - cron: "0 0 * * 1" # Every Monday 08:00 on UTC+8
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   analyze:
     name: Analyze (actions)

--- a/.github/workflows/self-dependency-review.yml
+++ b/.github/workflows/self-dependency-review.yml
@@ -10,8 +10,10 @@ on:
 
 permissions:
   contents: read
-  pull-requests: write
 
 jobs:
   review:
+    permissions:
+      contents: read
+      pull-requests: write
     uses: nics-dp/meta/.github/workflows/dependency-review.yml@main


### PR DESCRIPTION
Improves OpenSSF Scorecard **Token-Permissions** for this repo.

Changes (only the files in this PR):
- .github/workflows/codeql.yml, .github/workflows/self-dependency-review.yml

For each workflow above: added a minimal top-level `permissions: contents: read` where none was declared, and/or moved any top-level write scope down to the specific job that needs it (top-level kept read-only). No legitimate job-level write scopes were removed.