### PR TITLE
feat(image): prebuilt build mode (no QEMU), branch-tagged snapshots, downloadable image tarballs

### DIFF
--- a/.github/workflows/artifacts-comment.yml
+++ b/.github/workflows/artifacts-comment.yml
@@ -71,7 +71,7 @@ jobs:
               if (name.startsWith('image-linux-')) {
                 const arch = name.slice('image-linux-'.length);
                 return `**Container image** (linux/${arch}) — load and run it locally, no registry needed: ` +
-                  `\`unzip ${name}.zip && docker load -i ${name}.tar.gz\`, then \`docker run\` the loaded tag.`;
+                  `\`unzip ${name}.zip && docker load -i ${name}.tar\`, then \`docker run\` the loaded tag.`;
               }
               if (name.startsWith('binary-')) {
                 const t = name.slice('binary-'.length);

--- a/.github/workflows/artifacts-comment.yml
+++ b/.github/workflows/artifacts-comment.yml
@@ -64,12 +64,34 @@ jobs:
               return;
             }
 
+            // Per-artifact "what is this / how to use it" note, keyed off the
+            // artifact name convention. GitHub wraps every artifact in a .zip on
+            // download, so the inner file is named without that wrapper.
+            const describe = (name) => {
+              if (name.startsWith('image-linux-')) {
+                const arch = name.slice('image-linux-'.length);
+                return `**Container image** (linux/${arch}) — load and run it locally, no registry needed: ` +
+                  `\`unzip ${name}.zip && docker load -i ${name}.tar.gz\`, then \`docker run\` the loaded tag.`;
+              }
+              if (name.startsWith('binary-')) {
+                const t = name.slice('binary-'.length);
+                return `**Standalone binary** (${t}) — \`unzip ${name}.zip\`, extract the inner \`.tar.gz\`, ` +
+                  `then run the executable directly (no container).`;
+              }
+              if (name.endsWith('.dockerbuild')) {
+                return `**Build record** (debug) — import into Docker Desktop -> Builds ` +
+                  `(or \`docker buildx history import\`) to inspect this build's steps and timings.`;
+              }
+              return `Build artifact — download and \`unzip\`.`;
+            };
+
             // Build comment body
             const marker = '<!-- bot: artifacts -->';
             const runUrl = `${context.serverUrl}/${owner}/${repo}/actions/runs/${context.runId}`;
             let body = `${marker}\n## Build Artifacts\n\n`;
             for (const art of artifacts) {
-              body += `* [\`${art.name}.zip\`](https://nightly.link/${owner}/${repo}/actions/artifacts/${art.id}.zip)\n`;
+              const url = `https://nightly.link/${owner}/${repo}/actions/artifacts/${art.id}.zip`;
+              body += `* [\`${art.name}.zip\`](${url})\n  ${describe(art.name)}\n`;
             }
             body += `\n*From [workflow run #${context.runNumber}](${runUrl})*`;
 

--- a/.github/workflows/artifacts-comment.yml
+++ b/.github/workflows/artifacts-comment.yml
@@ -53,7 +53,10 @@ jobs:
               {owner, repo, run_id: context.runId, per_page: 100}
             )).filter(art => {
               const name = typeof art?.name === 'string' ? art.name.trim() : '';
-              return art?.id && name && name !== 'undefined';
+              // Hide internal "prebuilt-*" binaries (image-release prebuilt-mode
+              // plumbing, 1-day retention) from the user-facing artifacts comment;
+              // they duplicate the build-* release archives.
+              return art?.id && name && name !== 'undefined' && !name.startsWith('prebuilt-');
             });
 
             if (!artifacts.length) {

--- a/.github/workflows/artifacts-comment.yml
+++ b/.github/workflows/artifacts-comment.yml
@@ -86,14 +86,18 @@ jobs:
             };
 
             // Build comment body
+            const fmt = (iso) => iso ? `${iso.slice(0, 16).replace('T', ' ')} UTC` : 'unknown';
             const marker = '<!-- bot: artifacts -->';
             const runUrl = `${context.serverUrl}/${owner}/${repo}/actions/runs/${context.runId}`;
             let body = `${marker}\n## Build Artifacts\n\n`;
             for (const art of artifacts) {
               const url = `https://nightly.link/${owner}/${repo}/actions/artifacts/${art.id}.zip`;
-              body += `* [\`${art.name}.zip\`](${url})\n  ${describe(art.name)}\n`;
+              // Retention differs per artifact type, so show each one's expiry.
+              body += `* [\`${art.name}.zip\`](${url})\n  ${describe(art.name)}\n  _expires ${fmt(art.expires_at)}_\n`;
             }
-            body += `\n*From [workflow run #${context.runNumber}](${runUrl})*`;
+            // All artifacts in a run are uploaded together, so one built time covers the batch.
+            const built = fmt(artifacts[0] && artifacts[0].created_at);
+            body += `\n*From [workflow run #${context.runNumber}](${runUrl}) - built ${built}*`;
 
             // Upsert comment
             const comments = await github.paginate(

--- a/.github/workflows/artifacts-comment.yml
+++ b/.github/workflows/artifacts-comment.yml
@@ -91,12 +91,15 @@ jobs:
             const runUrl = `${context.serverUrl}/${owner}/${repo}/actions/runs/${context.runId}`;
             let body = `${marker}\n## Build Artifacts\n\n`;
             for (const art of artifacts) {
+              // Use the same trimmed name the filter used, so the link label and
+              // describe() can't disagree if a name carries stray whitespace.
+              const name = (typeof art.name === 'string' ? art.name.trim() : '');
               const url = `https://nightly.link/${owner}/${repo}/actions/artifacts/${art.id}.zip`;
               // Retention differs per artifact type, so show each one's expiry.
-              body += `* [\`${art.name}.zip\`](${url})\n  ${describe(art.name)}\n  _expires ${fmt(art.expires_at)}_\n`;
+              body += `* [\`${name}.zip\`](${url})\n  ${describe(name)}\n  _expires ${fmt(art.expires_at)}_\n`;
             }
-            // All artifacts in a run are uploaded together, so one built time covers the batch.
-            const built = fmt(artifacts[0] && artifacts[0].created_at);
+            // API order isn't guaranteed, so take the earliest created_at as the batch built time.
+            const built = fmt(artifacts.map(a => a.created_at).filter(Boolean).sort()[0]);
             body += `\n*From [workflow run #${context.runNumber}](${runUrl}) - built ${built}*`;
 
             // Upsert comment

--- a/.github/workflows/artifacts-comment.yml
+++ b/.github/workflows/artifacts-comment.yml
@@ -55,7 +55,7 @@ jobs:
               const name = typeof art?.name === 'string' ? art.name.trim() : '';
               // Hide internal "prebuilt-*" binaries (image-release prebuilt-mode
               // plumbing, 1-day retention) from the user-facing artifacts comment;
-              // they duplicate the build-* release archives.
+              // they duplicate the binary-* release archives.
               return art?.id && name && name !== 'undefined' && !name.startsWith('prebuilt-');
             });
 
@@ -75,8 +75,8 @@ jobs:
               }
               if (name.startsWith('binary-')) {
                 const t = name.slice('binary-'.length);
-                return `**Standalone binary** (${t}) — \`unzip ${name}.zip\`, extract the inner \`.tar.gz\`, ` +
-                  `then run the executable directly (no container).`;
+                return `**Standalone binary** (${t}) — \`unzip ${name}.zip\`, extract the inner archive ` +
+                  `(\`.tar.gz\`, or \`.zip\` on Windows), then run the executable directly (no container).`;
               }
               if (name.endsWith('.dockerbuild')) {
                 return `**Build record** (debug) — import into Docker Desktop -> Builds ` +

--- a/.github/workflows/artifacts-comment.yml
+++ b/.github/workflows/artifacts-comment.yml
@@ -68,10 +68,10 @@ jobs:
             // artifact name convention. GitHub wraps every artifact in a .zip on
             // download, so the inner file is named without that wrapper.
             const describe = (name) => {
-              if (name.startsWith('image-linux-')) {
-                const arch = name.slice('image-linux-'.length);
-                return `**Container image** (linux/${arch}) — load and run it locally, no registry needed: ` +
-                  `\`unzip ${name}.zip && docker load -i ${name}.tar\`, then \`docker run\` the loaded tag.`;
+              if (name === 'images') {
+                return `**Container images** (one \`.tar\` per built arch) — load and run locally, no registry ` +
+                  `needed: \`unzip images.zip\`, then \`docker load -i image-linux-<arch>.tar\` for your arch and ` +
+                  `\`docker run\` the loaded tag.`;
               }
               if (name.startsWith('binary-')) {
                 const t = name.slice('binary-'.length);

--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -351,7 +351,7 @@ jobs:
       - name: Upload build artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: build-${{ matrix.goos }}-${{ matrix.goarch }}${{ matrix.goarm && format('-v{0}', matrix.goarm) || '' }}
+          name: binary-${{ matrix.goos }}-${{ matrix.goarch }}${{ matrix.goarm && format('-v{0}', matrix.goarm) || '' }}
           path: ${{ steps.archive.outputs.file }}
           retention-days: ${{ inputs.snapshot && 7 || 30 }}
 
@@ -403,7 +403,7 @@ jobs:
       - name: Download all build artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          pattern: build-*
+          pattern: binary-*
           path: dist
           merge-multiple: true
 

--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -366,8 +366,9 @@ jobs:
         with:
           # "prebuilt-" prefix marks this as internal plumbing for image-release's
           # prebuilt mode (not a user-facing release download); artifacts-comment
-          # filters this prefix out of the PR comment.
-          name: prebuilt-${{ matrix.goos }}-${{ matrix.goarch }}
+          # filters this prefix out of the PR comment. Include the GOARM suffix
+          # (same as binary-*) so multiple 32-bit arm variants don't collide.
+          name: prebuilt-${{ matrix.goos }}-${{ matrix.goarch }}${{ matrix.goarm && format('-v{0}', matrix.goarm) || '' }}
           path: output/
           retention-days: 1
 

--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -355,6 +355,19 @@ jobs:
           path: ${{ steps.archive.outputs.file }}
           retention-days: ${{ inputs.snapshot && 7 || 30 }}
 
+      # Raw (unarchived) linux binaries so image-release's prebuilt mode can
+      # COPY them straight into the container without unpacking an archive. Linux
+      # only — container images are linux; darwin/windows binaries ship as
+      # release archives, not images. Short retention: consumed within the same
+      # run by the image-build job.
+      - name: Upload raw binary for image prebuilt
+        if: matrix.goos == 'linux'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: bin-${{ matrix.goos }}-${{ matrix.goarch }}
+          path: output/
+          retention-days: 1
+
       - name: Revoke private git repository access
         if: ${{ always() && env.HAS_CI_APP == 'true' }}
         env:

--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -364,7 +364,10 @@ jobs:
         if: matrix.goos == 'linux'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: bin-${{ matrix.goos }}-${{ matrix.goarch }}
+          # "prebuilt-" prefix marks this as internal plumbing for image-release's
+          # prebuilt mode (not a user-facing release download); artifacts-comment
+          # filters this prefix out of the PR comment.
+          name: prebuilt-${{ matrix.goos }}-${{ matrix.goarch }}
           path: output/
           retention-days: 1
 

--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -348,7 +348,7 @@ jobs:
             echo "file=${ARCHIVE_DIR}.tar.gz" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Upload build artifact
+      - name: Upload binary archive
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: binary-${{ matrix.goos }}-${{ matrix.goarch }}${{ matrix.goarm && format('-v{0}', matrix.goarm) || '' }}

--- a/.github/workflows/image-release.yml
+++ b/.github/workflows/image-release.yml
@@ -74,7 +74,7 @@ on:
         required: false
         type: boolean
         default: false
-        description: "Snapshot mode: use SHA-based tags only (no semver, no latest)"
+        description: "Snapshot mode: tag images by source-branch name (no semver, no latest); pin a specific build by digest."
       ref:
         required: false
         type: string

--- a/.github/workflows/image-release.yml
+++ b/.github/workflows/image-release.yml
@@ -96,8 +96,8 @@ on:
         default: false
         description: >
           Prebuilt mode: instead of compiling in-image, download the raw linux
-          binaries the go-release job uploaded (artifacts bin-linux-amd64 /
-          bin-linux-arm64) and feed them to the build as a `binctx` build context
+          binaries the go-release job uploaded (artifacts prebuilt-linux-amd64 /
+          prebuilt-linux-arm64) and feed them to the build as a `binctx` build context
           with BIN_STAGE=prebuilt. The caller's image-build job MUST set
           needs:[go-release] so the artifacts exist, and the Dockerfile MUST have
           the dual-mode prebuilt stage (COPY --from=binctx ${TARGETARCH}/<bin>).
@@ -693,14 +693,20 @@ jobs:
         env:
           BINROOT: ${{ runner.temp }}/binroot
           BINCTX: ${{ runner.temp }}/binctx
+          PLATFORMS: ${{ steps.platforms.outputs.list }}
         run: |
           # go-release uploads raw linux binaries as prebuilt-linux-<arch>
           # artifacts; download-artifact placed each under
           # <binroot>/prebuilt-linux-<arch>/. Re-key them by Docker TARGETARCH
-          # (amd64/arm64) so the Dockerfile's prebuilt stage
-          # (COPY --from=binctx ${TARGETARCH}/<bin>) resolves.
+          # so the Dockerfile's prebuilt stage (COPY --from=binctx
+          # ${TARGETARCH}/<bin>) resolves. Only require the linux arches actually
+          # being built (the resolved platform list), so a single-arch caller
+          # doesn't fail for a missing other-arch artifact.
           set -euo pipefail
-          for arch in amd64 arm64; do
+          IFS=',' read -ra PLATS <<< "$PLATFORMS"
+          for p in "${PLATS[@]}"; do
+            [[ "$p" == linux/* ]] || continue
+            arch="${p#linux/}"; arch="${arch%%/*}"   # drop any /variant -> TARGETARCH
             src="${BINROOT}/prebuilt-linux-${arch}"
             dest="${BINCTX}/${arch}"
             mkdir -p "$dest"
@@ -725,9 +731,13 @@ jobs:
           # of a bare commit SHA per push). On pull_request the source branch is
           # github.head_ref; on workflow_dispatch fall back to github.ref_name.
           raw="${HEAD_REF:-$REF_NAME}"
-          # Docker tags allow [A-Za-z0-9_.-] only: map every other char to '-'
-          # (so "feature/x" -> "feature-x") and cap at 128 chars.
-          san="$(printf '%s' "$raw" | tr -c 'A-Za-z0-9_.-' '-' | cut -c1-128)"
+          # Docker tags allow [A-Za-z0-9_.-] and the FIRST char must be
+          # [A-Za-z0-9_]. Map other chars to '-' (so "feature/x" -> "feature-x"),
+          # strip any leading '.'/'-', cap at 128, and fall back to "snapshot" if
+          # nothing valid remains.
+          san="$(printf '%s' "$raw" | tr -c 'A-Za-z0-9_.-' '-' | sed 's/^[.-]*//')"
+          san="${san:0:128}"
+          [ -z "$san" ] && san="snapshot"
           echo "tag=${san}" >> "$GITHUB_OUTPUT"
 
       - name: Extract metadata (tags, labels)
@@ -812,7 +822,7 @@ jobs:
           IFS=',' read -ra PLATS <<< "$PLATFORMS"
           for p in "${PLATS[@]}"; do
             [[ "$p" == linux/* ]] || continue
-            arch="${p#linux/}"
+            arch="${p#linux/}"; arch="${arch//\//-}"   # variant-safe filename (arm/v7 -> arm-v7)
             # Pull the arch-specific image from the manifest list by digest, then
             # re-tag to the branch tag so `docker load` restores a usable name.
             docker pull --quiet --platform "$p" "$REF"

--- a/.github/workflows/image-release.yml
+++ b/.github/workflows/image-release.yml
@@ -100,10 +100,15 @@ on:
           prebuilt-linux-arm64) and feed them to the build as a `binctx` build context
           with BIN_STAGE=prebuilt. The caller's image-build job MUST set
           needs:[go-release] so the artifacts exist, and the Dockerfile MUST have
-          the dual-mode prebuilt stage (COPY --from=binctx ${TARGETARCH}/<bin>).
-          Eliminates the in-image compile, so the RUN-free runtime stage builds
-          every arch with no QEMU (snapshot can then stay multi-arch). go_vendor
-          is unnecessary in this mode.
+          the dual-mode prebuilt stage. binctx is keyed by
+          ${TARGETARCH}${TARGETVARIANT} (amd64, arm64, armv7, ...), so the
+          Dockerfile COPYs `--from=binctx ${TARGETARCH}${TARGETVARIANT}/<bin>`
+          (declare both ARGs in the stage). For amd64/arm64 the variant is empty,
+          so a plain `${TARGETARCH}/<bin>` still resolves; only same-arch variant
+          builds (e.g. arm/v6 + arm/v7) need the variant in the path. Eliminates
+          the in-image compile, so the RUN-free runtime stage builds every arch
+          with no QEMU (snapshot can then stay multi-arch). go_vendor is
+          unnecessary in this mode.
       submodules:
         required: false
         type: string
@@ -706,18 +711,17 @@ jobs:
           IFS=',' read -ra PLATS <<< "$PLATFORMS"
           for p in "${PLATS[@]}"; do
             [[ "$p" == linux/* ]] || continue
-            full="${p#linux/}"                       # e.g. arm64  or  arm/v7
-            arch="${full%%/*}"                       # TARGETARCH: arm64 / arm
-            srcname="prebuilt-linux-${full//\//-}"   # artifact: prebuilt-linux-arm64 / prebuilt-linux-arm-v7
+            full="${p#linux/}"                       # e.g. amd64 | arm64 | arm/v7
+            # Key the build-context dir by Docker's ${TARGETARCH}${TARGETVARIANT}
+            # (arm/v7 -> armv7, arm64 -> arm64, amd64 -> amd64) so two variants of
+            # the same arch don't collide and the Dockerfile can resolve any of
+            # them. (For amd64/arm64 this equals ${TARGETARCH}, so a Dockerfile
+            # that COPYs ${TARGETARCH}/<bin> still works; variant builds need it to
+            # COPY ${TARGETARCH}${TARGETVARIANT}/<bin>.)
+            key="${full//\//}"                       # armv7 | arm64 | amd64
+            srcname="prebuilt-linux-${full//\//-}"   # artifact: prebuilt-linux-arm-v7 | -arm64 | -amd64
             src="${BINROOT}/${srcname}"
-            dest="${BINCTX}/${arch}"                 # keyed by TARGETARCH for the Dockerfile's COPY
-            # binctx is keyed by TARGETARCH, which can't distinguish two variants
-            # of the same arch (e.g. arm/v6 + arm/v7). Fail loudly rather than
-            # silently overwrite one with the other.
-            if [[ -d "$dest" && -n "$(ls -A "$dest" 2>/dev/null)" ]]; then
-              echo "::error::prebuilt: platforms '${PLATFORMS}' map more than one variant onto TARGETARCH '${arch}'; binctx can't disambiguate. Build a single variant per arch."
-              exit 1
-            fi
+            dest="${BINCTX}/${key}"
             mkdir -p "$dest"
             if [[ ! -d "$src" ]] || [[ -z "$(ls -A "$src" 2>/dev/null)" ]]; then
               echo "::error::prebuilt: missing binaries for ${p} (expected go-release artifact ${srcname}; ensure image-build needs:[go-release] and go-release builds ${p})"
@@ -831,11 +835,7 @@ jobs:
           IFS=',' read -ra PLATS <<< "$PLATFORMS"
           for p in "${PLATS[@]}"; do
             [[ "$p" == linux/* ]] || continue
-            arch="${p#linux/}"; arch="${arch//\//-}"   # variant-safe filename (arm/v7 -> arm-v7)
-            # Downloadable image tarballs are published only for amd64/arm64 (the
-            # arches the fleet ships and the only ones with upload steps below).
-            # Skip anything else so we don't save a tarball that never uploads.
-            case "$arch" in amd64|arm64) ;; *) echo "skip image tarball for linux/${arch} (only amd64/arm64 are published)"; continue ;; esac
+            arch="${p#linux/}"; arch="${arch//\//-}"   # filename-safe (arm/v7 -> arm-v7)
             # Pull the arch-specific image from the manifest list by digest, then
             # re-tag to the branch tag so `docker load` restores a usable name.
             docker pull --quiet --platform "$p" "$REF"
@@ -846,21 +846,18 @@ jobs:
             docker rmi "$NAMED" >/dev/null 2>&1 || true
           done
 
-      - name: Upload image tarball (amd64)
-        if: inputs.snapshot && contains(steps.platforms.outputs.list, 'linux/amd64')
+      - name: Upload image tarballs
+        # One artifact holding every built arch's docker-loadable tar
+        # (image-linux-<arch>.tar inside). A single dir upload works for any
+        # platform set — amd64/arm64, other arches, or arm variants — without a
+        # per-arch step. GitHub wraps it in a .zip on download.
+        if: inputs.snapshot
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: image-linux-amd64
-          path: ${{ runner.temp }}/images/image-linux-amd64.tar
+          name: images
+          path: ${{ runner.temp }}/images/
           retention-days: 7
-
-      - name: Upload image tarball (arm64)
-        if: inputs.snapshot && contains(steps.platforms.outputs.list, 'linux/arm64')
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: image-linux-arm64
-          path: ${{ runner.temp }}/images/image-linux-arm64.tar
-          retention-days: 7
+          if-no-files-found: ignore
 
       - name: Generate artifact attestation (DockerHub)
         if: inputs.attest

--- a/.github/workflows/image-release.yml
+++ b/.github/workflows/image-release.yml
@@ -785,8 +785,12 @@ jobs:
             ${{ steps.env-args.outputs.build_args }}
           secrets: |
             github_token=${{ steps.priv-token.outputs.token || secrets.GITHUB_TOKEN }}
-          cache-from: type=registry,ref=${{ env.REGISTRY_GHCR }}/${{ env.GHCR_NAMESPACE }}/${{ env.IMAGE_NAME }}:buildcache
-          cache-to: type=registry,ref=${{ env.REGISTRY_GHCR }}/${{ env.GHCR_NAMESPACE }}/${{ env.IMAGE_NAME }}:buildcache,mode=max
+          # Push the BuildKit cache manifest to a SEPARATE package
+          # (<image>-buildcache), not a :buildcache tag on the image package —
+          # otherwise GitHub shows that non-runnable cache tag as the package's
+          # "Latest" because it's pushed last, hiding the real image tags.
+          cache-from: type=registry,ref=${{ env.REGISTRY_GHCR }}/${{ env.GHCR_NAMESPACE }}/${{ env.IMAGE_NAME }}-buildcache:cache
+          cache-to: type=registry,ref=${{ env.REGISTRY_GHCR }}/${{ env.GHCR_NAMESPACE }}/${{ env.IMAGE_NAME }}-buildcache:cache,mode=max
           sbom: ${{ inputs.sbom }}
           provenance: ${{ inputs.provenance && 'mode=max' || 'false' }}
 

--- a/.github/workflows/image-release.yml
+++ b/.github/workflows/image-release.yml
@@ -790,6 +790,50 @@ jobs:
           sbom: ${{ inputs.sbom }}
           provenance: ${{ inputs.provenance && 'mode=max' || 'false' }}
 
+      - name: Export downloadable image tarballs (snapshot)
+        # Snapshot only: publish per-arch `docker load`-able image tarballs as PR
+        # artifacts (shown in the artifacts comment) so a reviewer can pull a
+        # branch's image and run it locally without registry access. Re-pulls the
+        # just-pushed image per arch by digest and `docker save`s it — no rebuild.
+        # Release images are consumed from the registry, so skip there.
+        if: inputs.snapshot
+        shell: bash
+        env:
+          REF: ${{ env.REGISTRY_GHCR }}/${{ env.GHCR_NAMESPACE }}/${{ env.IMAGE_NAME }}@${{ steps.build-and-push.outputs.digest }}
+          NAMED: ${{ env.REGISTRY_GHCR }}/${{ env.GHCR_NAMESPACE }}/${{ env.IMAGE_NAME }}:${{ steps.snaptag.outputs.tag }}
+          PLATFORMS: ${{ steps.platforms.outputs.list }}
+          OUT: ${{ runner.temp }}/images
+        run: |
+          set -euo pipefail
+          mkdir -p "$OUT"
+          IFS=',' read -ra PLATS <<< "$PLATFORMS"
+          for p in "${PLATS[@]}"; do
+            [[ "$p" == linux/* ]] || continue
+            arch="${p#linux/}"
+            # Pull the arch-specific image from the manifest list by digest, then
+            # re-tag to the branch tag so `docker load` restores a usable name.
+            docker pull --quiet --platform "$p" "$REF"
+            docker tag "$REF" "$NAMED"
+            docker save "$NAMED" | gzip > "${OUT}/image-linux-${arch}.tar.gz"
+            docker rmi "$NAMED" >/dev/null 2>&1 || true
+          done
+
+      - name: Upload image tarball (amd64)
+        if: inputs.snapshot && contains(steps.platforms.outputs.list, 'linux/amd64')
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: image-linux-amd64
+          path: ${{ runner.temp }}/images/image-linux-amd64.tar.gz
+          retention-days: 7
+
+      - name: Upload image tarball (arm64)
+        if: inputs.snapshot && contains(steps.platforms.outputs.list, 'linux/arm64')
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: image-linux-arm64
+          path: ${{ runner.temp }}/images/image-linux-arm64.tar.gz
+          retention-days: 7
+
       - name: Generate artifact attestation (DockerHub)
         if: inputs.attest
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4

--- a/.github/workflows/image-release.yml
+++ b/.github/workflows/image-release.yml
@@ -14,9 +14,11 @@ on:
         type: string
         default: "linux/amd64,linux/arm64"
         description: >
-          Target platforms for multi-arch build. NOTE: ignored when
-          snapshot=true — snapshot builds are forced to linux/amd64 only to
-          skip emulated arm64 (see the "Resolve build platforms" step).
+          Target platforms for multi-arch build. NOTE: in compiled mode it is
+          ignored when snapshot=true — snapshot builds are forced to linux/amd64
+          only to skip emulated arm64. In prebuilt=true mode it is always
+          honored (the RUN-free runtime needs no QEMU, so multi-arch is free even
+          on snapshot). See the "Resolve build platforms" step.
       runs_on:
         required: false
         type: string
@@ -88,6 +90,20 @@ on:
         type: string
         default: "stable"
         description: "Go version for vendor step (only used when go_vendor is true)"
+      prebuilt:
+        required: false
+        type: boolean
+        default: false
+        description: >
+          Prebuilt mode: instead of compiling in-image, download the raw linux
+          binaries the go-release job uploaded (artifacts bin-linux-amd64 /
+          bin-linux-arm64) and feed them to the build as a `binctx` build context
+          with BIN_STAGE=prebuilt. The caller's image-build job MUST set
+          needs:[go-release] so the artifacts exist, and the Dockerfile MUST have
+          the dual-mode prebuilt stage (COPY --from=binctx ${TARGETARCH}/<bin>).
+          Eliminates the in-image compile, so the RUN-free runtime stage builds
+          every arch with no QEMU (snapshot can then stay multi-arch). go_vendor
+          is unnecessary in this mode.
       submodules:
         required: false
         type: string
@@ -606,17 +622,22 @@ jobs:
         shell: bash
         env:
           SNAPSHOT: ${{ inputs.snapshot }}
+          PREBUILT: ${{ inputs.prebuilt }}
           PLATFORMS_IN: ${{ inputs.platforms }}
         run: |
-          # Snapshot builds are ephemeral, SHA-tagged dev images. Under the
-          # current deployment model only linux/amd64 is consumed from them
-          # (prod runs amd64; arm64 images are published only on real releases,
-          # for local dev on Apple Silicon). Building the linux/arm64 variant on
-          # snapshot means emulating arm64 under QEMU on the amd64 runners, which
-          # dominates snapshot build wall-clock. Force amd64-only on snapshot and
-          # ignore inputs.platforms; release builds (snapshot=false) honor
-          # inputs.platforms unchanged.
-          if [[ "$SNAPSHOT" == "true" ]]; then
+          # Prebuilt mode COPYs host-built binaries into a RUN-free runtime, so
+          # every arch assembles with no foreign-arch RUN and thus no QEMU.
+          # Honor the caller's full platform list even on snapshot (multi-arch is
+          # free), and never set up QEMU below.
+          #
+          # Compiled mode (no prebuilt): snapshot builds emulate arm64 under QEMU
+          # on the amd64 runners, which dominates wall-clock, and under the
+          # deployment model only linux/amd64 is consumed from snapshots. So
+          # force amd64-only on snapshot and ignore inputs.platforms; release
+          # builds honor inputs.platforms unchanged.
+          if [[ "$PREBUILT" == "true" ]]; then
+            PLATFORMS="$PLATFORMS_IN"
+          elif [[ "$SNAPSHOT" == "true" ]]; then
             PLATFORMS="linux/amd64"
           else
             PLATFORMS="$PLATFORMS_IN"
@@ -640,7 +661,11 @@ jobs:
           # from the actual runner arch (uname), not just the platform string, so
           # a non-x86_64 runner building linux/amd64 still gets QEMU. Any
           # cross-arch / multi-arch target also keeps it.
-          if [[ "$PLATFORMS" == "linux/amd64" && "$(uname -m)" == "x86_64" ]]; then
+          if [[ "$PREBUILT" == "true" ]]; then
+            # RUN-free runtime: no foreign-arch execution, so no emulation even
+            # for multi-arch.
+            echo "needs_qemu=false" >> "$GITHUB_OUTPUT"
+          elif [[ "$PLATFORMS" == "linux/amd64" && "$(uname -m)" == "x86_64" ]]; then
             echo "needs_qemu=false" >> "$GITHUB_OUTPUT"
           else
             echo "needs_qemu=true" >> "$GITHUB_OUTPUT"
@@ -654,6 +679,37 @@ jobs:
 
       - name: Set up Buildx
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+
+      - name: Download prebuilt binaries
+        if: inputs.prebuilt
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: bin-linux-*
+          path: ${{ runner.temp }}/binroot
+
+      - name: Assemble binctx build context
+        if: inputs.prebuilt
+        shell: bash
+        env:
+          BINROOT: ${{ runner.temp }}/binroot
+          BINCTX: ${{ runner.temp }}/binctx
+        run: |
+          # go-release uploads raw linux binaries as bin-linux-<arch> artifacts;
+          # download-artifact placed each under <binroot>/bin-linux-<arch>/.
+          # Re-key them by Docker TARGETARCH (amd64/arm64) so the Dockerfile's
+          # prebuilt stage (COPY --from=binctx ${TARGETARCH}/<bin>) resolves.
+          set -euo pipefail
+          for arch in amd64 arm64; do
+            src="${BINROOT}/bin-linux-${arch}"
+            dest="${BINCTX}/${arch}"
+            mkdir -p "$dest"
+            if [[ ! -d "$src" ]] || [[ -z "$(ls -A "$src" 2>/dev/null)" ]]; then
+              echo "::error::prebuilt: missing binaries for linux/${arch} (expected go-release artifact bin-linux-${arch}; ensure image-build needs:[go-release] and go-release builds linux/${arch})"
+              exit 1
+            fi
+            cp -a "${src}/." "${dest}/"
+            chmod +x "${dest}"/*
+          done
 
       - name: Extract metadata (tags, labels)
         id: meta
@@ -694,6 +750,10 @@ jobs:
           # ship the hardened runtime stage instead of the trailing debug stage.
           target: ${{ inputs.target }}
           platforms: ${{ steps.platforms.outputs.list }}
+          # In prebuilt mode, expose the host-built binaries (laid out by arch
+          # under <runner.temp>/binctx) as the `binctx` named build context that
+          # the Dockerfile's prebuilt stage COPYs from. Empty otherwise.
+          build-contexts: ${{ inputs.prebuilt && format('binctx={0}/binctx', runner.temp) || '' }}
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
@@ -701,6 +761,7 @@ jobs:
             VERSION=${{ steps.version.outputs.version }}
             COMMIT=${{ steps.version.outputs.commit }}
             BUILD_DATE=${{ steps.version.outputs.build_date }}
+            ${{ inputs.prebuilt && 'BIN_STAGE=prebuilt' || '' }}
             ${{ inputs.build_args }}
             ${{ steps.env-args.outputs.build_args }}
           secrets: |

--- a/.github/workflows/image-release.yml
+++ b/.github/workflows/image-release.yml
@@ -814,7 +814,9 @@ jobs:
             # re-tag to the branch tag so `docker load` restores a usable name.
             docker pull --quiet --platform "$p" "$REF"
             docker tag "$REF" "$NAMED"
-            docker save "$NAMED" | gzip > "${OUT}/image-linux-${arch}.tar.gz"
+            # Save a plain tar (no gzip): upload-artifact always wraps the file in
+            # a .zip, so gzipping first would be redundant double-compression.
+            docker save "$NAMED" > "${OUT}/image-linux-${arch}.tar"
             docker rmi "$NAMED" >/dev/null 2>&1 || true
           done
 
@@ -823,7 +825,7 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: image-linux-amd64
-          path: ${{ runner.temp }}/images/image-linux-amd64.tar.gz
+          path: ${{ runner.temp }}/images/image-linux-amd64.tar
           retention-days: 7
 
       - name: Upload image tarball (arm64)
@@ -831,7 +833,7 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: image-linux-arm64
-          path: ${{ runner.temp }}/images/image-linux-arm64.tar.gz
+          path: ${{ runner.temp }}/images/image-linux-arm64.tar
           retention-days: 7
 
       - name: Generate artifact attestation (DockerHub)

--- a/.github/workflows/image-release.yml
+++ b/.github/workflows/image-release.yml
@@ -739,7 +739,6 @@ jobs:
             ${{ env.REGISTRY_GHCR }}/${{ env.GHCR_NAMESPACE }}/${{ env.IMAGE_NAME }}
           tags: |
             type=raw,value=${{ steps.snaptag.outputs.tag }},enable=${{ inputs.snapshot }}
-            type=sha,prefix=,format=short,enable=${{ inputs.snapshot }}
             type=semver,pattern=v{{version}},enable=${{ !inputs.snapshot }}
             type=semver,pattern=v{{major}}.{{minor}},enable=${{ !inputs.snapshot }}
             type=semver,pattern=v{{major}},enable=${{ !inputs.snapshot }}

--- a/.github/workflows/image-release.yml
+++ b/.github/workflows/image-release.yml
@@ -711,6 +711,13 @@ jobs:
             srcname="prebuilt-linux-${full//\//-}"   # artifact: prebuilt-linux-arm64 / prebuilt-linux-arm-v7
             src="${BINROOT}/${srcname}"
             dest="${BINCTX}/${arch}"                 # keyed by TARGETARCH for the Dockerfile's COPY
+            # binctx is keyed by TARGETARCH, which can't distinguish two variants
+            # of the same arch (e.g. arm/v6 + arm/v7). Fail loudly rather than
+            # silently overwrite one with the other.
+            if [[ -d "$dest" && -n "$(ls -A "$dest" 2>/dev/null)" ]]; then
+              echo "::error::prebuilt: platforms '${PLATFORMS}' map more than one variant onto TARGETARCH '${arch}'; binctx can't disambiguate. Build a single variant per arch."
+              exit 1
+            fi
             mkdir -p "$dest"
             if [[ ! -d "$src" ]] || [[ -z "$(ls -A "$src" 2>/dev/null)" ]]; then
               echo "::error::prebuilt: missing binaries for ${p} (expected go-release artifact ${srcname}; ensure image-build needs:[go-release] and go-release builds ${p})"
@@ -825,6 +832,10 @@ jobs:
           for p in "${PLATS[@]}"; do
             [[ "$p" == linux/* ]] || continue
             arch="${p#linux/}"; arch="${arch//\//-}"   # variant-safe filename (arm/v7 -> arm-v7)
+            # Downloadable image tarballs are published only for amd64/arm64 (the
+            # arches the fleet ships and the only ones with upload steps below).
+            # Skip anything else so we don't save a tarball that never uploads.
+            case "$arch" in amd64|arm64) ;; *) echo "skip image tarball for linux/${arch} (only amd64/arm64 are published)"; continue ;; esac
             # Pull the arch-specific image from the manifest list by digest, then
             # re-tag to the branch tag so `docker load` restores a usable name.
             docker pull --quiet --platform "$p" "$REF"

--- a/.github/workflows/image-release.yml
+++ b/.github/workflows/image-release.yml
@@ -684,7 +684,7 @@ jobs:
         if: inputs.prebuilt
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          pattern: bin-linux-*
+          pattern: prebuilt-linux-*
           path: ${{ runner.temp }}/binroot
 
       - name: Assemble binctx build context
@@ -694,22 +694,41 @@ jobs:
           BINROOT: ${{ runner.temp }}/binroot
           BINCTX: ${{ runner.temp }}/binctx
         run: |
-          # go-release uploads raw linux binaries as bin-linux-<arch> artifacts;
-          # download-artifact placed each under <binroot>/bin-linux-<arch>/.
-          # Re-key them by Docker TARGETARCH (amd64/arm64) so the Dockerfile's
-          # prebuilt stage (COPY --from=binctx ${TARGETARCH}/<bin>) resolves.
+          # go-release uploads raw linux binaries as prebuilt-linux-<arch>
+          # artifacts; download-artifact placed each under
+          # <binroot>/prebuilt-linux-<arch>/. Re-key them by Docker TARGETARCH
+          # (amd64/arm64) so the Dockerfile's prebuilt stage
+          # (COPY --from=binctx ${TARGETARCH}/<bin>) resolves.
           set -euo pipefail
           for arch in amd64 arm64; do
-            src="${BINROOT}/bin-linux-${arch}"
+            src="${BINROOT}/prebuilt-linux-${arch}"
             dest="${BINCTX}/${arch}"
             mkdir -p "$dest"
             if [[ ! -d "$src" ]] || [[ -z "$(ls -A "$src" 2>/dev/null)" ]]; then
-              echo "::error::prebuilt: missing binaries for linux/${arch} (expected go-release artifact bin-linux-${arch}; ensure image-build needs:[go-release] and go-release builds linux/${arch})"
+              echo "::error::prebuilt: missing binaries for linux/${arch} (expected go-release artifact prebuilt-linux-${arch}; ensure image-build needs:[go-release] and go-release builds linux/${arch})"
               exit 1
             fi
             cp -a "${src}/." "${dest}/"
             chmod +x "${dest}"/*
           done
+
+      - name: Compute snapshot branch tag
+        id: snaptag
+        if: inputs.snapshot
+        shell: bash
+        env:
+          HEAD_REF: ${{ github.head_ref }}
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          # Snapshot images are dev builds; tag them by the source branch so
+          # they're human-readable and a branch's tag updates in place (instead
+          # of a bare commit SHA per push). On pull_request the source branch is
+          # github.head_ref; on workflow_dispatch fall back to github.ref_name.
+          raw="${HEAD_REF:-$REF_NAME}"
+          # Docker tags allow [A-Za-z0-9_.-] only: map every other char to '-'
+          # (so "feature/x" -> "feature-x") and cap at 128 chars.
+          san="$(printf '%s' "$raw" | tr -c 'A-Za-z0-9_.-' '-' | cut -c1-128)"
+          echo "tag=${san}" >> "$GITHUB_OUTPUT"
 
       - name: Extract metadata (tags, labels)
         id: meta
@@ -719,8 +738,8 @@ jobs:
             ${{ env.REGISTRY_DH }}/${{ env.DH_NAMESPACE }}/${{ env.IMAGE_NAME }}
             ${{ env.REGISTRY_GHCR }}/${{ env.GHCR_NAMESPACE }}/${{ env.IMAGE_NAME }}
           tags: |
+            type=raw,value=${{ steps.snaptag.outputs.tag }},enable=${{ inputs.snapshot }}
             type=sha,prefix=,format=short,enable=${{ inputs.snapshot }}
-            type=sha,prefix=,format=long,enable=${{ inputs.snapshot }}
             type=semver,pattern=v{{version}},enable=${{ !inputs.snapshot }}
             type=semver,pattern=v{{major}}.{{minor}},enable=${{ !inputs.snapshot }}
             type=semver,pattern=v{{major}},enable=${{ !inputs.snapshot }}

--- a/.github/workflows/image-release.yml
+++ b/.github/workflows/image-release.yml
@@ -706,12 +706,14 @@ jobs:
           IFS=',' read -ra PLATS <<< "$PLATFORMS"
           for p in "${PLATS[@]}"; do
             [[ "$p" == linux/* ]] || continue
-            arch="${p#linux/}"; arch="${arch%%/*}"   # drop any /variant -> TARGETARCH
-            src="${BINROOT}/prebuilt-linux-${arch}"
-            dest="${BINCTX}/${arch}"
+            full="${p#linux/}"                       # e.g. arm64  or  arm/v7
+            arch="${full%%/*}"                       # TARGETARCH: arm64 / arm
+            srcname="prebuilt-linux-${full//\//-}"   # artifact: prebuilt-linux-arm64 / prebuilt-linux-arm-v7
+            src="${BINROOT}/${srcname}"
+            dest="${BINCTX}/${arch}"                 # keyed by TARGETARCH for the Dockerfile's COPY
             mkdir -p "$dest"
             if [[ ! -d "$src" ]] || [[ -z "$(ls -A "$src" 2>/dev/null)" ]]; then
-              echo "::error::prebuilt: missing binaries for linux/${arch} (expected go-release artifact prebuilt-linux-${arch}; ensure image-build needs:[go-release] and go-release builds linux/${arch})"
+              echo "::error::prebuilt: missing binaries for ${p} (expected go-release artifact ${srcname}; ensure image-build needs:[go-release] and go-release builds ${p})"
               exit 1
             fi
             cp -a "${src}/." "${dest}/"


### PR DESCRIPTION
Gate-0: add a **prebuilt** image-build mode and the artifacts/tagging cleanups validated via a dcf-service pilot (multi-arch snapshot with no QEMU, CGO ABI confirmed, image+binary both run).

## image-release.yml
- **`prebuilt` input**: download the raw linux binaries go-release uploads (`prebuilt-linux-amd64/arm64`), re-key by `TARGETARCH` into a `binctx` build context, build with `BIN_STAGE=prebuilt`. The RUN-free runtime then assembles every arch with no foreign-arch RUN -> **no QEMU**, so snapshot can stay multi-arch. `go_vendor` is unnecessary in this mode.
- **Snapshot platforms**: in prebuilt mode honor the full platform list even on snapshot (compiled mode keeps the amd64-only fast path).
- **Snapshot tag = branch name** (sanitized `head_ref`), dropping the short/long SHA tags so the package headline is the branch, not a commit SHA (pin precisely via digest).
- **Downloadable image tarballs**: snapshot builds export per-arch `docker load`-able images (`image-linux-<arch>`) by re-pulling the pushed image per arch and `docker save` (plain `.tar`, single compression — upload-artifact already zips).
- **BuildKit cache** moved to a separate `<image>-buildcache:cache` package so the cache manifest no longer shows up as the image package's "Latest".

## go-release.yml
- Upload raw linux binaries as `prebuilt-linux-<arch>` (1-day) to feed prebuilt mode.
- Release archive artifact renamed `build-*` -> `binary-*` (and the release-job download pattern) for a clearer artifacts comment.

## artifacts-comment.yml
- Hide internal `prebuilt-*` artifacts.
- Annotate each artifact with **what it is / how to use it** and its **expiry**, plus the batch **built** time.

Compiled mode is unchanged and remains the default, so prebuilt is opt-in and falls back safely.
