### PR TITLE
feat(mise): add betterleaks and trufflehog secret-scan tasks

### DIFF
--- a/.mise/tasks/ci/betterleaks
+++ b/.mise/tasks/ci/betterleaks
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+#MISE description="Scan for leaked secrets (betterleaks; PR gate)"
+#MISE hide=true
+#MISE raw=true
+#MISE tools={"github:betterleaks/betterleaks"="latest"}
+set -euo pipefail
+
+# betterleaks: fast, configurable secret scanner from the Gitleaks authors. Used
+# as the PR gate -- its default `--exit-code 1` on findings makes the caller's
+# mise-task.yml "Enforce" step fail CI. --redact keeps secret values out of the
+# CI logs; --no-banner trims noise from the job summary.
+#
+# On a pull_request we scan ONLY the commits the PR introduces (base..HEAD) so a
+# pre-existing historical leak does not block every unrelated PR. On push /
+# workflow_dispatch we scan the full history. Both require the caller to checkout
+# with fetch-depth: 0 (so the base ref and full graph are present).
+common=(git . --redact --no-banner)
+
+if [ "${GITHUB_EVENT_NAME:-}" = "pull_request" ] && [ -n "${GITHUB_BASE_REF:-}" ]; then
+  # Bring the PR's base branch into the local graph; harmless if already present.
+  git fetch --no-tags --quiet origin \
+    "+refs/heads/${GITHUB_BASE_REF}:refs/remotes/origin/${GITHUB_BASE_REF}" || true
+  betterleaks "${common[@]}" --log-opts="--no-merges origin/${GITHUB_BASE_REF}..HEAD"
+else
+  betterleaks "${common[@]}"
+fi

--- a/.mise/tasks/ci/betterleaks
+++ b/.mise/tasks/ci/betterleaks
@@ -17,10 +17,19 @@ set -euo pipefail
 common=(git . --redact --no-banner)
 
 if [ "${GITHUB_EVENT_NAME:-}" = "pull_request" ] && [ -n "${GITHUB_BASE_REF:-}" ]; then
-  # Bring the PR's base branch into the local graph; harmless if already present.
-  git fetch --no-tags --quiet origin \
-    "+refs/heads/${GITHUB_BASE_REF}:refs/remotes/origin/${GITHUB_BASE_REF}" || true
-  betterleaks "${common[@]}" --log-opts="--no-merges origin/${GITHUB_BASE_REF}..HEAD"
+  # Bring the PR's base branch into the local graph so base..HEAD resolves
+  # (actions/checkout fetches only the checked-out ref, even at fetch-depth: 0).
+  # On fetch failure (missing ref / permissions) fall back to a full-history
+  # scan: running a range scan against an absent base ref would fail for a
+  # reason unrelated to any leak. Merge commits are intentionally NOT excluded
+  # so secrets introduced while resolving a conflict are still caught.
+  if git fetch --no-tags --quiet origin \
+      "+refs/heads/${GITHUB_BASE_REF}:refs/remotes/origin/${GITHUB_BASE_REF}"; then
+    betterleaks "${common[@]}" --log-opts="origin/${GITHUB_BASE_REF}..HEAD"
+  else
+    echo "::warning::could not fetch base ref '${GITHUB_BASE_REF}'; scanning full history instead"
+    betterleaks "${common[@]}"
+  fi
 else
   betterleaks "${common[@]}"
 fi

--- a/.mise/tasks/ci/trufflehog
+++ b/.mise/tasks/ci/trufflehog
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+#MISE description="Scan for verified live secrets (trufflehog; deep/release scan)"
+#MISE hide=true
+#MISE raw=true
+#MISE tools={"aqua:trufflesecurity/trufflehog"="latest"}
+set -euo pipefail
+
+# trufflehog: broad detector set (800+) plus ACTIVE verification. This is the
+# deep/release scan, not the per-PR gate. --results=verified reports only LIVE
+# credentials (verification confirmed via the issuing API), so historical dead
+# secrets do not fire. --fail exits 183 when a result is found, gating the
+# release. --no-update skips the self-update network call in CI;
+# --github-actions formats findings for the Actions log.
+#
+# Full-history sweep: we omit --since-commit/--branch so every commit is walked,
+# which requires the caller to checkout with fetch-depth: 0.
+trufflehog git file://. --results=verified --fail --no-update --github-actions


### PR DESCRIPTION
## What

Adds two shared mise tasks for downstream secret scanning, per the agreed split:

- **`ci:betterleaks`** (`github:betterleaks/betterleaks`) — the **PR gate**. On a `pull_request` it scopes the scan to `base..HEAD` (via `GITHUB_BASE_REF`) so a pre-existing historical leak doesn't block unrelated PRs; `push`/`workflow_dispatch` scan full history. Default `--exit-code 1` on findings gates the caller through `mise-task.yml`'s Enforce step. `--redact` keeps secret values out of CI logs.
- **`ci:trufflehog`** (`aqua:trufflesecurity/trufflehog`) — the **deep/release scan**. Full-history sweep reporting only **verified (live)** credentials (`--results=verified`); `--fail` exits 183 to gate the release.

Both require the caller to checkout with `fetch-depth: 0`.

## Why

No secret scanning existed org-wide. betterleaks (fast, low-FP, Gitleaks authors) fits a per-PR gate; trufflehog (800+ detectors + active verification) fits an infrequent deep sweep on release-promotion PRs and release tags.

## Verified locally

- `ci:betterleaks` on meta full history → `no leaks found`, exit 0.
- Planted a real-looking AWS key in a throwaway repo → `leaks found: 1`, **exit 1** (gate fires). The AWS docs `…EXAMPLE` key is correctly allow-listed (no false positive on docs).
- `ci:trufflehog` on meta full history → `0 verified_secrets`, exit 0.
- `github:` backend also verifies GitHub artifact attestations on install (supply-chain bonus); `ubi:` was avoided as mise has deprecated it.

## Downstream wiring (separate PR, after this reaches `main`)

`dcf-service` will add a `secret-scan` job (betterleaks, every PR) and a `deep-secret-scan` job (trufflehog, release-promotion PRs + release tag gate). Consumers must `mise cache clear` to pick up the new tasks (`@main` include).