### PR TITLE
docs(ci): say OpenGrep in ci:semgrep description

### DIFF
--- a/.mise/tasks/ci/semgrep
+++ b/.mise/tasks/ci/semgrep
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-#MISE description="Run semgrep static analysis (p/ci baseline + lang packs)"
+#MISE description="Static analysis via OpenGrep (semgrep-compatible; p/ci baseline + lang packs)"
 #MISE hide=true
 #MISE raw=true
 #MISE tools={"aqua:opengrep/opengrep"="latest"}


### PR DESCRIPTION
## 修 Copilot review(#201)

`ci:semgrep` 的 task 名維持不變(對),但 `#MISE description` 仍寫 "Run semgrep static analysis",在引擎已改為 OpenGrep 後會誤導除錯者以為跑的是 semgrep binary。改為點出 OpenGrep:

```
Static analysis via OpenGrep (semgrep-compatible; p/ci baseline + lang packs)
```

合併進 `dev` 後,我會把 `release/v0.2.4.18`(#203 → main)resync 到含此修正的 `dev`。

> 另一則 review(`typecheck-tsgo` 的 `-p` 建議)經實測為誤判,詳見 #200 round 2 與我在 #201 的回覆 —— `-p` 不會繞過已安裝的 pinned 版本(實測印出本地版而非 @latest),且 npm 無 `tsgo` 套件,移除 `-p` 反而會壞;故保留。
