### PR TITLE
fix(node): force bun runtime for oxfmt/oxlint + drop inert oxfmtrc setting

### DIFF
--- a/.mise/tasks/node/oxfmt-check
+++ b/.mise/tasks/node/oxfmt-check
@@ -31,4 +31,4 @@ if [ ! -d "node_modules/oxfmt" ] && ! grep -q '"oxfmt"' package.json 2>/dev/null
   echo ""
 fi
 
-bunx oxfmt --check .
+bunx --bun oxfmt --check .

--- a/.mise/tasks/node/oxfmt-fix
+++ b/.mise/tasks/node/oxfmt-fix
@@ -32,7 +32,7 @@ if [ ! -d "node_modules/oxfmt" ] && ! grep -q '"oxfmt"' package.json 2>/dev/null
   echo ""
 fi
 
-bunx oxfmt --write .
+bunx --bun oxfmt --write .
 
 if ! git diff --exit-code -- . >/dev/null; then
   echo ""

--- a/.mise/tasks/node/oxlint
+++ b/.mise/tasks/node/oxlint
@@ -27,4 +27,4 @@ fi
 VUE_FLAG=""
 grep -q '"vue"' package.json 2>/dev/null && VUE_FLAG="--vue-plugin"
 
-bunx oxlint $VUE_FLAG .
+bunx --bun oxlint $VUE_FLAG .

--- a/configs/.oxfmtrc.json
+++ b/configs/.oxfmtrc.json
@@ -8,6 +8,5 @@
   "arrowParens": "always",
   "endOfLine": "lf",
   "sortTailwindcss": {},
-  "sortPackageJson": false,
   "ignorePatterns": ["dist", "node_modules", "bun.lock", "*.min.js", "*.min.css", "*.yml", "*.json"]
 }


### PR DESCRIPTION
## 修 Copilot review(#203 的 review,4 則 inline comments)

### 1–3. oxfmt / oxlint atom 強制 bun runtime(`--bun`)— 採納
實測 oxfmt / oxlint 的 npm bin 都是 `#!/usr/bin/env node` launcher script:

```
$ head -1 node_modules/.bin/oxfmt   # #!/usr/bin/env node
$ head -1 node_modules/.bin/oxlint  # #!/usr/bin/env node
```

沒加 `--bun` 時 bunx 會尊重 node shebang、用 node 跑 launcher → 在 node-less 環境會失敗,也與 atom header「native binary, no Node」不符。加上 `--bun` 後由 bun 跑 launcher(launcher 仍 spawn 原生 binary),與 `node:typecheck-tsgo` 一致。實測 `bunx --bun oxfmt --version` / `oxlint --version` 皆正常。

### 4. `.oxfmtrc.json` 的 `*.json` 與 `sortPackageJson` — 部分採納
- **保留 `*.json` ignore**:這是刻意對齊 prettier(原 `.prettierignore` 就含 `*.json`),且 atom 的賣點是「與 prettier 輸出位元級相同」。移除會讓所有 json 被重新格式化 → 破壞 parity、產生 churn。
- **移除 `sortPackageJson: false`**:因 `*.json` 已被忽略,package.json 永不會被處理,此設定是 dead config、只會誤導 —— 已移除(json 維持與 prettier 下相同、不格式化)。

合併進 `dev` 後,我會把 `release/v0.2.4.18`(#203 → main)rebase/resync 到含這些修正的 `dev`,再於 #203 跑完整 review loop。
