### PR TITLE
fix(renovate): add gomodTidy postUpdateOptions to gomod preset

### DIFF
--- a/renovate-preset.json
+++ b/renovate-preset.json
@@ -37,7 +37,10 @@
         "go"
       ],
       "automerge": false,
-      "dependencyDashboardApproval": true
+      "dependencyDashboardApproval": true,
+      "postUpdateOptions": [
+        "gomodTidy"
+      ]
     },
     {
       "description": "Group GitHub Actions updates",


### PR DESCRIPTION
## 修法

在 org Renovate preset 的 gomod packageRule 加入 `postUpdateOptions: ["gomodTidy"]`，讓 Renovate 更新 go.mod 後跑 `go mod tidy`，補齊 go.sum 的模組 zip `h1:` hash 並清除舊版殘留。

## 為什麼需要

全 org Go repo 沒 commit `vendor/`，CI 動態 `go mod vendor` 並以 `-mod=vendor` 編譯。先前 Renovate 產出的 go.sum 不完整(只有 `/go.mod` hash，缺 zip `h1:`），導致 CI `go mod vendor` 報 `missing go.sum entry` → CodeQL build / go:audit / go:lint 失敗。

驗證細節見 issue。

Closes #210
