### PR TITLE
fix(ci): clear stale shallow go module vcs cache to fix pseudo-version unshallow race

### DIFF
--- a/.github/workflows/codeql-reusable.yml
+++ b/.github/workflows/codeql-reusable.yml
@@ -101,6 +101,15 @@ jobs:
           git config --global url."https://x-access-token:${GH_PAT}@github.com/nics-dp".insteadOf "https://github.com/nics-dp"
           git config --global url."https://x-access-token:${GH_PAT}@github.com/nics-dp/".insteadOf "git@github.com:nics-dp/"
 
+      - name: Clear stale shallow Go module VCS cache
+        if: matrix.language == 'go'
+        run: |
+          # dependency-caching restores a shallow git module cache; validating a new
+          # pseudo-version then runs `git fetch --unshallow`, which races on the
+          # restored shallow state ("shallow file has changed since we read it").
+          # Drop the VCS cache so private modules are re-cloned cleanly each run.
+          rm -rf "$(go env GOMODCACHE)/cache/vcs" 2>/dev/null || true
+
       - name: Manual Go build for CodeQL
         if: matrix.language == 'go'
         env:

--- a/.github/workflows/codeql-reusable.yml
+++ b/.github/workflows/codeql-reusable.yml
@@ -108,7 +108,10 @@ jobs:
           # pseudo-version then runs `git fetch --unshallow`, which races on the
           # restored shallow state ("shallow file has changed since we read it").
           # Drop the VCS cache so private modules are re-cloned cleanly each run.
-          rm -rf "$(go env GOMODCACHE)/cache/vcs" 2>/dev/null || true
+          gomodcache="$(go env GOMODCACHE)"
+          if [ -n "$gomodcache" ]; then
+            rm -rf "${gomodcache}/cache/vcs" 2>/dev/null || true
+          fi
 
       - name: Manual Go build for CodeQL
         if: matrix.language == 'go'

--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -238,6 +238,16 @@ jobs:
           restore-keys: |
             go-vendor-${{ runner.os }}-${{ runner.arch }}-
 
+      - name: Clear stale shallow Go module VCS cache
+        if: contains(inputs.extra_build_flags, '-mod=vendor')
+        run: |
+          # setup-go's module cache can restore a shallow git clone of private
+          # modules; validating a new pseudo-version then runs `git fetch
+          # --unshallow`, which races on the restored shallow state ("shallow file
+          # has changed since we read it"). Drop the VCS cache (keeps the download
+          # zip cache) so private modules are re-cloned cleanly before vendoring.
+          rm -rf "$(go env GOMODCACHE)/cache/vcs" 2>/dev/null || true
+
       - name: Vendor Go modules
         if: contains(inputs.extra_build_flags, '-mod=vendor')
         run: go mod vendor

--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -246,7 +246,10 @@ jobs:
           # --unshallow`, which races on the restored shallow state ("shallow file
           # has changed since we read it"). Drop the VCS cache (keeps the download
           # zip cache) so private modules are re-cloned cleanly before vendoring.
-          rm -rf "$(go env GOMODCACHE)/cache/vcs" 2>/dev/null || true
+          gomodcache="$(go env GOMODCACHE)"
+          if [ -n "$gomodcache" ]; then
+            rm -rf "${gomodcache}/cache/vcs" 2>/dev/null || true
+          fi
 
       - name: Vendor Go modules
         if: contains(inputs.extra_build_flags, '-mod=vendor')


### PR DESCRIPTION
## 修法

在 Go 的 build/vendor 之前清掉 stale 的 vcs module cache,強制私有模組乾淨重新 clone,避免新 pseudo-version 觸發的 `git fetch --unshallow` 撞上「被還原的 shallow 狀態」:

```bash
rm -rf "$(go env GOMODCACHE)/cache/vcs" 2>/dev/null || true
```

涵蓋兩支有持久 module cache 的 workflow:
- `codeql-reusable.yml`(`dependency-caching: true`，**必現**失敗的來源)— 加在 `Manual Go build for CodeQL` 之前
- `go-release.yml`(`setup-go cache: true`，go.sum-keyed 故偶發）— 加在 `Vendor Go modules` 之前(防禦性）

## 為什麼只清 cache/vcs

`GOMODCACHE/cache/download`(公開 tagged 模組 zip 的大宗）保留不動 → CI/編譯時間幾乎不受影響;只有 nics-dp 私有模組(libdcf / ZenQuery）會重新 shallow clone(數秒)。

## 不需修的

`mise-task.yml`(Go Audit/Lint/Test）與 `go-dependency-submission.yml` 無持久 GOMODCACHE(mise-action 只快取工具、runner ephemeral),僅偶發 flaky、重跑即過。

詳見 issue。

Closes #212
