### PR TITLE
release: v0.2.4.20

### DIFF
--- a/.github/workflows/codeql-reusable.yml
+++ b/.github/workflows/codeql-reusable.yml
@@ -101,6 +101,15 @@ jobs:
           git config --global url."https://x-access-token:${GH_PAT}@github.com/nics-dp".insteadOf "https://github.com/nics-dp"
           git config --global url."https://x-access-token:${GH_PAT}@github.com/nics-dp/".insteadOf "git@github.com:nics-dp/"
 
+      - name: Clear stale shallow Go module VCS cache
+        if: matrix.language == 'go'
+        run: |
+          # dependency-caching restores a shallow git module cache; validating a new
+          # pseudo-version then runs `git fetch --unshallow`, which races on the
+          # restored shallow state ("shallow file has changed since we read it").
+          # Drop the VCS cache so private modules are re-cloned cleanly each run.
+          rm -rf "$(go env GOMODCACHE)/cache/vcs" 2>/dev/null || true
+
       - name: Manual Go build for CodeQL
         if: matrix.language == 'go'
         env:

--- a/.github/workflows/codeql-reusable.yml
+++ b/.github/workflows/codeql-reusable.yml
@@ -108,7 +108,10 @@ jobs:
           # pseudo-version then runs `git fetch --unshallow`, which races on the
           # restored shallow state ("shallow file has changed since we read it").
           # Drop the VCS cache so private modules are re-cloned cleanly each run.
-          rm -rf "$(go env GOMODCACHE)/cache/vcs" 2>/dev/null || true
+          gomodcache="$(go env GOMODCACHE)"
+          if [ -n "$gomodcache" ]; then
+            rm -rf "${gomodcache}/cache/vcs" 2>/dev/null || true
+          fi
 
       - name: Manual Go build for CodeQL
         if: matrix.language == 'go'

--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -238,6 +238,16 @@ jobs:
           restore-keys: |
             go-vendor-${{ runner.os }}-${{ runner.arch }}-
 
+      - name: Clear stale shallow Go module VCS cache
+        if: contains(inputs.extra_build_flags, '-mod=vendor')
+        run: |
+          # setup-go's module cache can restore a shallow git clone of private
+          # modules; validating a new pseudo-version then runs `git fetch
+          # --unshallow`, which races on the restored shallow state ("shallow file
+          # has changed since we read it"). Drop the VCS cache (keeps the download
+          # zip cache) so private modules are re-cloned cleanly before vendoring.
+          rm -rf "$(go env GOMODCACHE)/cache/vcs" 2>/dev/null || true
+
       - name: Vendor Go modules
         if: contains(inputs.extra_build_flags, '-mod=vendor')
         run: go mod vendor

--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -246,7 +246,10 @@ jobs:
           # --unshallow`, which races on the restored shallow state ("shallow file
           # has changed since we read it"). Drop the VCS cache (keeps the download
           # zip cache) so private modules are re-cloned cleanly before vendoring.
-          rm -rf "$(go env GOMODCACHE)/cache/vcs" 2>/dev/null || true
+          gomodcache="$(go env GOMODCACHE)"
+          if [ -n "$gomodcache" ]; then
+            rm -rf "${gomodcache}/cache/vcs" 2>/dev/null || true
+          fi
 
       - name: Vendor Go modules
         if: contains(inputs.extra_build_flags, '-mod=vendor')

--- a/renovate-preset.json
+++ b/renovate-preset.json
@@ -37,7 +37,10 @@
         "go"
       ],
       "automerge": false,
-      "dependencyDashboardApproval": true
+      "dependencyDashboardApproval": true,
+      "postUpdateOptions": [
+        "gomodTidy"
+      ]
     },
     {
       "description": "Group GitHub Actions updates",


### PR DESCRIPTION
Promote dev to main. Includes: gomod preset gomodTidy (#211), codeql/go-release shallow module vcs cache fix (#213).