### PR TITLE
fix(renovate): disable bumps for internal nics-dp Go modules

### DIFF
--- a/renovate-preset.json
+++ b/renovate-preset.json
@@ -193,6 +193,16 @@
       ],
       "automerge": true,
       "automergeType": "pr"
+    },
+    {
+      "description": "Do not let Renovate bump internal nics-dp Go modules (libdcf, ZenQuery, etc.). They are pinned via the go:lib-remote @dev mechanism during feature work, and Renovate cannot reliably compute their pseudo-versions in its runner (it writes a bare commit SHA, producing an invalid go.mod).",
+      "matchManagers": [
+        "gomod"
+      ],
+      "matchDepNames": [
+        "github.com/nics-dp/**"
+      ],
+      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
## 修法

在 org Renovate preset 的 gomod packageRules 末尾加一條,停用所有 `github.com/nics-dp/**` 內部 Go 模組的 Renovate 更新:

```json
{
  "matchManagers": ["gomod"],
  "matchDepNames": ["github.com/nics-dp/**"],
  "enabled": false
}
```

## 為什麼

內部模組 (libdcf、ZenQuery 等) 隨 feature 開發用 `go:lib-remote @dev` 機制 bump,不需要 Renovate 升級 PR。且 Renovate 在自身 runner 算不出這些模組的 pseudo-version,會把版本欄寫成裸 commit SHA → go.mod 無效 → CI 全垮 (dcf-platform-cli #190 反覆中招)。

preset 讀 meta default (dev),合 dev 即生效,不需 promote main。

Closes #216
