### PR TITLE
release: v0.2.4.21

### DIFF
--- a/.github/workflows/mise-task.yml
+++ b/.github/workflows/mise-task.yml
@@ -72,15 +72,16 @@ jobs:
     # invalid duration), and the self-hosted pool reuses cached mise binaries
     # of mixed versions, so the action below pins mise to 2026.6.3.
     #
-    # MISE_USE_VERSIONS_HOST=false: mise-versions.jdx.dev (the CDN that caches
-    # version listings) frequently 403s, spamming "outcome=failed status=403
-    # fallback=true" warnings even though the source-direct fallback already
-    # succeeds. Disabling the host makes mise resolve versions straight from
-    # each backend's source, so `latest` keeps working without the noise.
-    # Trade-off: a few more direct GitHub/aqua calls on version lookup.
+    # The mise-versions.jdx.dev host (CDN cache of version listings) is kept
+    # ENABLED (mise default). It occasionally 403s, but mise falls back to
+    # source-direct on a miss, so `latest` still resolves — that 403 line is
+    # cosmetic noise, not a failure. We previously set MISE_USE_VERSIONS_HOST=false
+    # to silence the noise, but that removed the cache/fallback layer: `latest`
+    # version lookups then hit GitHub/aqua APIs directly with no fallback, and a
+    # transient GitHub 504 hard-failed tool installs (e.g. trivy). Keeping the
+    # host on absorbs those transient errors via the cached listing.
     env:
       MISE_MINIMUM_RELEASE_AGE: "0"
-      MISE_USE_VERSIONS_HOST: "false"
       # secrets cannot be used in step-level if:, so bridge to env here.
       HAS_CI_APP: ${{ vars.CI_READ_APP_CLIENT_ID != '' && secrets.ci_read_app_private_key != '' }}
     steps:

--- a/.github/workflows/mise-task.yml
+++ b/.github/workflows/mise-task.yml
@@ -70,7 +70,7 @@ jobs:
     # tool installs such as semgrep. Setting the age to 0 disables that
     # injection. "0" requires mise >= 2026.6.3 (older mise rejects it as an
     # invalid duration), and the self-hosted pool reuses cached mise binaries
-    # of mixed versions, so the action below pins mise to 2026.6.3.
+    # of mixed versions, so the action below pins mise to 2026.6.9 (>= 2026.6.3).
     #
     # The mise-versions.jdx.dev host (CDN cache of version listings) is kept
     # ENABLED (mise default). It occasionally 403s, but mise falls back to

--- a/.mise/tasks/dc/clean
+++ b/.mise/tasks/dc/clean
@@ -2,7 +2,7 @@
 #MISE description="Clean Docker Compose resources"
 #MISE hide=true
 #MISE raw=true
-#MISE tools={gum="latest", jq="latest"}
+#MISE tools={"aqua:charmbracelet/gum"="0.17.0", "aqua:jqlang/jq"="1.8.1"}
 #USAGE arg "[target]" help="Resource to clean: vol, img, net, all" {
 #USAGE   choices "vol" "img" "net" "all"
 #USAGE }

--- a/.mise/tasks/go/lint-check
+++ b/.mise/tasks/go/lint-check
@@ -2,6 +2,6 @@
 #MISE description="Lint Go (read-only)"
 #MISE hide=true
 #MISE raw=true
-#MISE tools={golangci-lint="latest"}
+#MISE tools={"aqua:golangci/golangci-lint"="2.12.2"}
 
 golangci-lint run ./...

--- a/.mise/tasks/go/lint-fix
+++ b/.mise/tasks/go/lint-fix
@@ -3,7 +3,7 @@
 #MISE hide=true
 #MISE raw=true
 #MISE silent="stdout"
-#MISE tools={golangci-lint="latest"}
+#MISE tools={"aqua:golangci/golangci-lint"="2.12.2"}
 
 golangci-lint fmt ./...
 

--- a/.mise/tasks/iac/actionlint
+++ b/.mise/tasks/iac/actionlint
@@ -2,6 +2,6 @@
 #MISE description="Lint GitHub Actions workflow YAML files with actionlint"
 #MISE hide=true
 #MISE raw=true
-#MISE tools={actionlint="latest"}
+#MISE tools={"aqua:rhysd/actionlint"="1.7.12"}
 
 actionlint

--- a/.mise/tasks/iac/img/hadolint
+++ b/.mise/tasks/iac/img/hadolint
@@ -2,6 +2,6 @@
 #MISE description="Lint Dockerfiles with hadolint"
 #MISE hide=true
 #MISE raw=true
-#MISE tools={hadolint="latest"}
+#MISE tools={"aqua:hadolint/hadolint"="2.14.0"}
 
 hadolint Dockerfile*

--- a/.mise/tasks/node/audit
+++ b/.mise/tasks/node/audit
@@ -2,6 +2,6 @@
 #MISE description="Audit JS/TS deps for vulnerabilities"
 #MISE hide=true
 #MISE raw=true
-#MISE tools={bun="latest"}
+#MISE tools={bun="1.3.14"}
 
 bun audit

--- a/.mise/tasks/node/bench-compare
+++ b/.mise/tasks/node/bench-compare
@@ -2,7 +2,7 @@
 #MISE description="JS/TS benchmark + compare via vitest bench. --save <label> to capture (multiple runs); no flag to diff old vs new"
 #MISE hide=true
 #MISE raw=true
-#MISE tools={bun="latest"}
+#MISE tools={bun="1.3.14"}
 #MISE depends=["node:install"]
 #USAGE flag "--save <label>" help="Save bench results to bench-<label>.json (typically 'old' or 'new')"
 #USAGE flag "--count <n>" help="Number of runs for statistical significance" default="5"

--- a/.mise/tasks/node/build
+++ b/.mise/tasks/node/build
@@ -3,7 +3,7 @@
 #MISE hide=true
 #MISE raw=true
 #MISE silent="stdout"
-#MISE tools={bun="latest"}
+#MISE tools={bun="1.3.14"}
 #MISE depends=["node:install"]
 
 bun run build

--- a/.mise/tasks/node/bundle-size
+++ b/.mise/tasks/node/bundle-size
@@ -2,7 +2,7 @@
 #MISE description="Report bundle size (uses size-limit if .size-limit config exists, else du+gzip on dist/)"
 #MISE hide=true
 #MISE raw=true
-#MISE tools={bun="latest"}
+#MISE tools={bun="1.3.14"}
 #MISE depends=["node:build"]
 
 set -euo pipefail

--- a/.mise/tasks/node/deptree
+++ b/.mise/tasks/node/deptree
@@ -2,7 +2,7 @@
 #MISE description="Show JS/TS dep tree via bun pm ls / bun why"
 #MISE hide=true
 #MISE raw=true
-#MISE tools={bun="latest"}
+#MISE tools={bun="1.3.14"}
 #USAGE arg "[package]" help="Filter to substring (or use --why for reverse query)"
 #USAGE flag "--why" help="Show why <package> is installed (uses 'bun why')"
 #USAGE flag "--all" help="Include transitive deps (default: direct only)"

--- a/.mise/tasks/node/e2e
+++ b/.mise/tasks/node/e2e
@@ -2,7 +2,7 @@
 #MISE description="Run E2E tests via Playwright"
 #MISE hide=true
 #MISE raw=true
-#MISE tools={bun="latest"}
+#MISE tools={bun="1.3.14"}
 #MISE depends=["node:install", "node:e2e-install"]
 
 META_CONFIG_BASE="${META_CONFIG_BASE:-https://raw.githubusercontent.com/nics-dp/meta/main/configs}"

--- a/.mise/tasks/node/e2e-install
+++ b/.mise/tasks/node/e2e-install
@@ -3,6 +3,6 @@
 #MISE hide=true
 #MISE raw=true
 #MISE silent="stdout"
-#MISE tools={bun="latest"}
+#MISE tools={bun="1.3.14"}
 
 bunx playwright install --with-deps

--- a/.mise/tasks/node/format-check
+++ b/.mise/tasks/node/format-check
@@ -2,7 +2,7 @@
 #MISE description="Check JS/TS formatting (prettier)"
 #MISE hide=true
 #MISE raw=true
-#MISE tools={bun="latest"}
+#MISE tools={bun="1.3.14"}
 #MISE depends=["node:install"]
 
 META_CONFIG_BASE="${META_CONFIG_BASE:-https://raw.githubusercontent.com/nics-dp/meta/main/configs}"

--- a/.mise/tasks/node/format-fix
+++ b/.mise/tasks/node/format-fix
@@ -3,7 +3,7 @@
 #MISE hide=true
 #MISE raw=true
 #MISE silent="stdout"
-#MISE tools={bun="latest"}
+#MISE tools={bun="1.3.14"}
 #MISE depends=["node:install"]
 
 META_CONFIG_BASE="${META_CONFIG_BASE:-https://raw.githubusercontent.com/nics-dp/meta/main/configs}"

--- a/.mise/tasks/node/install
+++ b/.mise/tasks/node/install
@@ -3,6 +3,6 @@
 #MISE hide=true
 #MISE raw=true
 #MISE silent="stdout"
-#MISE tools={bun="latest"}
+#MISE tools={bun="1.3.14"}
 
 bun install --frozen-lockfile

--- a/.mise/tasks/node/knip
+++ b/.mise/tasks/node/knip
@@ -2,7 +2,7 @@
 #MISE description="Detect unused JS/TS deps and exports (knip)"
 #MISE hide=true
 #MISE raw=true
-#MISE tools={bun="latest"}
+#MISE tools={bun="1.3.14"}
 #MISE depends=["node:install"]
 
 # knip config is repo-specific (entries / ignores differ per project), so it is

--- a/.mise/tasks/node/lighthouse
+++ b/.mise/tasks/node/lighthouse
@@ -2,7 +2,7 @@
 #MISE description="Run Lighthouse CI on built dist/"
 #MISE hide=true
 #MISE raw=true
-#MISE tools={bun="latest"}
+#MISE tools={bun="1.3.14"}
 #MISE depends=["node:build"]
 
 META_CONFIG_BASE="${META_CONFIG_BASE:-https://raw.githubusercontent.com/nics-dp/meta/main/configs}"

--- a/.mise/tasks/node/lint-check
+++ b/.mise/tasks/node/lint-check
@@ -2,7 +2,7 @@
 #MISE description="Lint JS/TS (read-only)"
 #MISE hide=true
 #MISE raw=true
-#MISE tools={bun="latest"}
+#MISE tools={bun="1.3.14"}
 #MISE depends=["node:install"]
 
 META_CONFIG_BASE="${META_CONFIG_BASE:-https://raw.githubusercontent.com/nics-dp/meta/main/configs}"

--- a/.mise/tasks/node/lint-fix
+++ b/.mise/tasks/node/lint-fix
@@ -3,7 +3,7 @@
 #MISE hide=true
 #MISE raw=true
 #MISE silent="stdout"
-#MISE tools={bun="latest"}
+#MISE tools={bun="1.3.14"}
 #MISE depends=["node:install"]
 
 META_CONFIG_BASE="${META_CONFIG_BASE:-https://raw.githubusercontent.com/nics-dp/meta/main/configs}"

--- a/.mise/tasks/node/oxfmt-check
+++ b/.mise/tasks/node/oxfmt-check
@@ -2,7 +2,7 @@
 #MISE description="Check JS/TS formatting (oxfmt; native binary, no Node)"
 #MISE hide=true
 #MISE raw=true
-#MISE tools={bun="latest"}
+#MISE tools={bun="1.3.14"}
 #MISE depends=["node:install"]
 
 # oxfmt (OXC) — native single-binary formatter, run through bun so no Node

--- a/.mise/tasks/node/oxfmt-fix
+++ b/.mise/tasks/node/oxfmt-fix
@@ -3,7 +3,7 @@
 #MISE hide=true
 #MISE raw=true
 #MISE silent="stdout"
-#MISE tools={bun="latest"}
+#MISE tools={bun="1.3.14"}
 #MISE depends=["node:install"]
 
 # oxfmt (OXC) — native single-binary formatter, run through bun so no Node

--- a/.mise/tasks/node/oxlint
+++ b/.mise/tasks/node/oxlint
@@ -2,7 +2,7 @@
 #MISE description="Shadow lint JS/TS via oxlint (Rust native); .ts + .vue script — ESLint stays authoritative"
 #MISE hide=true
 #MISE raw=true
-#MISE tools={bun="latest"}
+#MISE tools={bun="1.3.14"}
 #MISE depends=["node:install"]
 
 # oxlint (OXC) — Rust single-binary linter, run through bun (no Node runtime).

--- a/.mise/tasks/node/run
+++ b/.mise/tasks/node/run
@@ -2,7 +2,7 @@
 #MISE description="Run a bun script with optional args. Mirrors 'bun run <script> [args...]'"
 #MISE hide=true
 #MISE raw=true
-#MISE tools={bun="latest"}
+#MISE tools={bun="1.3.14"}
 #MISE depends=["node:install"]
 #USAGE arg "[args]" var=#true var_min=0 help="bun run args (default: 'dev'). e.g., 'start' or 'dev --port 3001'"
 

--- a/.mise/tasks/node/sast
+++ b/.mise/tasks/node/sast
@@ -2,7 +2,7 @@
 #MISE description="Node.js SAST via njsscan (NowSecure; OWASP Top 10 + npm/Express patterns)"
 #MISE hide=true
 #MISE raw=true
-#MISE tools={uv="latest"}
+#MISE tools={"aqua:astral-sh/uv"="0.11.21"}
 # FIX: njsscan depends on semgrep -> pydantic 2.8.2 -> pydantic-core 2.20.1 whose
 # bundled PyO3 0.22 caps at Python 3.13. Pin uv to 3.13 so the wheel build
 # (triggered when no prebuilt wheel matches) doesn't hit the 3.14 cap.

--- a/.mise/tasks/node/sast
+++ b/.mise/tasks/node/sast
@@ -4,8 +4,9 @@
 #MISE raw=true
 #MISE tools={"aqua:astral-sh/uv"="0.11.21"}
 # FIX: njsscan depends on semgrep -> pydantic 2.8.2 -> pydantic-core 2.20.1 whose
-# bundled PyO3 0.22 caps at Python 3.13. Pin uv to 3.13 so the wheel build
-# (triggered when no prebuilt wheel matches) doesn't hit the 3.14 cap.
+# bundled PyO3 0.22 caps at Python 3.13. UV_PYTHON below pins the Python that uv
+# uses to 3.13 so the wheel build (triggered when no prebuilt wheel matches)
+# doesn't hit the 3.14 cap. (The uv tool itself is pinned in the tools header.)
 #MISE env={UV_PYTHON="3.13"}
 #USAGE flag "--json" help="Emit JSON output to njsscan-report.json"
 

--- a/.mise/tasks/node/test
+++ b/.mise/tasks/node/test
@@ -2,7 +2,7 @@
 #MISE description="Run JS/TS tests via vitest"
 #MISE hide=true
 #MISE raw=true
-#MISE tools={bun="latest"}
+#MISE tools={bun="1.3.14"}
 #MISE depends=["node:install"]
 
 # vitest config is repo-specific (setup files, environment tweaks, per-repo

--- a/.mise/tasks/node/typecheck
+++ b/.mise/tasks/node/typecheck
@@ -2,7 +2,7 @@
 #MISE description="Type check JS/TS (vue-tsc when present, else tsc)"
 #MISE hide=true
 #MISE raw=true
-#MISE tools={bun="latest"}
+#MISE tools={bun="1.3.14"}
 #MISE depends=["node:install"]
 
 if [ -f package.json ] && grep -q '"vue-tsc"' package.json; then

--- a/.mise/tasks/node/typecheck-tsgo
+++ b/.mise/tasks/node/typecheck-tsgo
@@ -2,7 +2,7 @@
 #MISE description="Shadow type-check via tsgo (TS7 native); .ts only — vue-tsc stays authoritative"
 #MISE hide=true
 #MISE raw=true
-#MISE tools={bun="latest"}
+#MISE tools={bun="1.3.14"}
 #MISE depends=["node:install"]
 
 # tsgo (@typescript/native-preview, TypeScript 7 native, Go single binary), run

--- a/.mise/tasks/node/update
+++ b/.mise/tasks/node/update
@@ -3,6 +3,6 @@
 #MISE hide=true
 #MISE raw=true
 #MISE silent="stdout"
-#MISE tools={bun="latest"}
+#MISE tools={bun="1.3.14"}
 
 bun update

--- a/.mise/tasks/py/sbom-custom
+++ b/.mise/tasks/py/sbom-custom
@@ -2,7 +2,7 @@
 #MISE description="Generate Python-native CycloneDX SBOM via cyclonedx-py (better PURL/wheel metadata than syft)"
 #MISE hide=true
 #MISE raw=true
-#MISE tools={"github:snyk/parlay"="latest", trivy="latest", grype="latest"}
+#MISE tools={"github:snyk/parlay"="0.11.0", trivy="latest", grype="latest"}
 #USAGE flag "--output <path>" help="Output file path" default="sbom-py.json"
 #USAGE flag "--source <type>" help="Source: environment / requirements / poetry / pipenv" default="environment"
 

--- a/.mise/tasks/ruler
+++ b/.mise/tasks/ruler
@@ -2,6 +2,6 @@
 #MISE description="Compile ruler to AGENTS.md and CLAUDE.md"
 #MISE hide=true
 #MISE silent="stdout"
-#MISE tools={bun="latest"}
+#MISE tools={bun="1.3.14"}
 
 bunx @intellectronica/ruler apply

--- a/.mise/tasks/sbom/enrich
+++ b/.mise/tasks/sbom/enrich
@@ -3,6 +3,6 @@
 #MISE hide=true
 #MISE depends=["sbom:source"]
 #MISE silent="stdout"
-#MISE tools={"github:snyk/parlay"="latest"}
+#MISE tools={"github:snyk/parlay"="0.11.0"}
 
 parlay ecosystems enrich sbom-source.cdx.json > enriched-source.cdx.json

--- a/.mise/tasks/sbom/source
+++ b/.mise/tasks/sbom/source
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #MISE description="Generate CycloneDX SBOM for source"
 #MISE hide=true
-#MISE tools={syft="latest"}
+#MISE tools={"aqua:anchore/syft"="1.45.1"}
 
 syft scan . -o cyclonedx-json=sbom-source.cdx.json

--- a/renovate-preset.json
+++ b/renovate-preset.json
@@ -193,6 +193,16 @@
       ],
       "automerge": true,
       "automergeType": "pr"
+    },
+    {
+      "description": "Do not let Renovate bump internal nics-dp Go modules (libdcf, ZenQuery, etc.). They are pinned via the go:lib-remote @dev mechanism during feature work, and Renovate cannot reliably compute their pseudo-versions in its runner (it writes a bare commit SHA, producing an invalid go.mod).",
+      "matchManagers": [
+        "gomod"
+      ],
+      "matchDepNames": [
+        "github.com/nics-dp/**"
+      ],
+      "enabled": false
     }
   ]
 }

--- a/renovate-preset.json
+++ b/renovate-preset.json
@@ -22,6 +22,33 @@
       ],
       "depNameTemplate": "air-verse/air",
       "datasourceTemplate": "github-releases"
+    },
+    {
+      "customType": "regex",
+      "description": "Update aqua:/github:-prefixed tool versions pinned in mise task headers (#MISE tools={...}). Only matches digit-leading versions so `=\"latest\"` scanners are left alone.",
+      "managerFilePatterns": [
+        "/(^|/)\\.mise/tasks/.+$/"
+      ],
+      "matchStringsStrategy": "any",
+      "matchStrings": [
+        "\"aqua:(?<packageName>[^\"]+)\"=\"(?<currentValue>\\d[^\"]*)\"",
+        "\"github:(?<packageName>[^\"]+)\"=\"(?<currentValue>\\d[^\"]*)\""
+      ],
+      "depNameTemplate": "{{{packageName}}}",
+      "datasourceTemplate": "github-releases"
+    },
+    {
+      "customType": "regex",
+      "description": "Update bun version pinned in mise task headers (core:bun maps to oven-sh/bun, whose tags are bun-v<ver>)",
+      "managerFilePatterns": [
+        "/(^|/)\\.mise/tasks/.+$/"
+      ],
+      "matchStrings": [
+        "bun=\"(?<currentValue>\\d[^\"]*)\""
+      ],
+      "depNameTemplate": "oven-sh/bun",
+      "datasourceTemplate": "github-releases",
+      "extractVersion": "^bun-v(?<version>.+)$"
     }
   ],
   "packageRules": [
@@ -120,6 +147,49 @@
       ],
       "groupName": "mise dev tools",
       "commitMessagePrefix": "chore(mise.tools):",
+      "labels": [
+        "dependencies",
+        "mise"
+      ],
+      "automerge": false,
+      "assignees": [
+        "charliie-dev"
+      ]
+    },
+    {
+      "description": "mise task-header tools (custom regex): strip leading v from release tags",
+      "matchDepNames": [
+        "golangci/golangci-lint",
+        "hadolint/hadolint",
+        "rhysd/actionlint",
+        "anchore/syft",
+        "charmbracelet/gum",
+        "snyk/parlay"
+      ],
+      "extractVersion": "^v(?<version>.+)$"
+    },
+    {
+      "description": "mise task-header tools (custom regex): strip jq- prefix from jq tags",
+      "matchDepNames": [
+        "jqlang/jq"
+      ],
+      "extractVersion": "^jq-(?<version>.+)$"
+    },
+    {
+      "description": "Group mise task-header tool pins (.mise/tasks/* #MISE tools={...}); scanners stay latest and are not pinned",
+      "matchDepNames": [
+        "golangci/golangci-lint",
+        "hadolint/hadolint",
+        "rhysd/actionlint",
+        "anchore/syft",
+        "charmbracelet/gum",
+        "jqlang/jq",
+        "astral-sh/uv",
+        "snyk/parlay",
+        "oven-sh/bun"
+      ],
+      "groupName": "mise task tools",
+      "commitMessagePrefix": "chore(mise.tasks):",
       "labels": [
         "dependencies",
         "mise"

--- a/renovate-preset.json
+++ b/renovate-preset.json
@@ -47,8 +47,7 @@
         "bun=\"(?<currentValue>\\d[^\"]*)\""
       ],
       "depNameTemplate": "oven-sh/bun",
-      "datasourceTemplate": "github-releases",
-      "extractVersion": "^bun-v(?<version>.+)$"
+      "datasourceTemplate": "github-releases"
     }
   ],
   "packageRules": [
@@ -174,6 +173,13 @@
         "jqlang/jq"
       ],
       "extractVersion": "^jq-(?<version>.+)$"
+    },
+    {
+      "description": "mise task-header tools (custom regex): strip bun-v prefix from bun tags",
+      "matchDepNames": [
+        "oven-sh/bun"
+      ],
+      "extractVersion": "^bun-v(?<version>.+)$"
     },
     {
       "description": "Group mise task-header tool pins (.mise/tasks/* #MISE tools={...}); scanners stay latest and are not pinned",


### PR DESCRIPTION
Promote dev to main as v0.2.4.21. Consumers pull atoms/workflows from `@main`, so this is what makes the changes live org-wide.

## Included

- **fix(ci): re-enable mise versions host** (#215) - removes `MISE_USE_VERSIONS_HOST=false`, restoring the mise-versions cache + source-direct fallback. This is the fix for the transient GitHub 504 that hard-failed `trivy` (and other `latest`) tool installs (observed in dcf-data-catalog Trivy License job).
- **chore(mise): pin deterministic task-atom tools** (#215) - golangci-lint, hadolint, actionlint, syft, gum, jq, uv, parlay, bun pinned (aqua:-qualified) for reproducible CI; security scanners stay `latest`.
- **ci(renovate): track pinned mise task-tool versions** (#215) - regex customManagers + `mise task tools` group so the pins do not rot.
- **fix(renovate): disable bumps for internal nics-dp Go modules** (#217).

## Verification
- #215 passed CI + 3 rounds of Copilot review (all threads resolved).
- Promotion of already-reviewed dev commits; no review-loop required per convention.

After merge: create lightweight tag `v0.2.4.21` on the main merge commit.
