### PR TITLE
feat(image-release): auto zstd compression for snapshot images

### DIFF
--- a/.github/workflows/image-release.yml
+++ b/.github/workflows/image-release.yml
@@ -843,7 +843,10 @@ jobs:
           # effective value comes from the "Resolve compression" step (auto:
           # zstd for snapshot, gzip for release).
           push: ${{ steps.compression.outputs.value == 'gzip' }}
-          outputs: ${{ steps.compression.outputs.value == 'gzip' && '' || format('type=image,push=true,oci-mediatypes=true,compression={0},compression-level=3', steps.compression.outputs.value) }}
+          # NB: GitHub Actions expressions treat '' as falsy, so the usual
+          # `cond && '' || B` idiom would ALWAYS yield B. Put the non-empty
+          # branch on the truthy side: non-gzip -> exporter string, gzip -> ''.
+          outputs: ${{ steps.compression.outputs.value != 'gzip' && format('type=image,push=true,oci-mediatypes=true,compression={0},compression-level=3', steps.compression.outputs.value) || '' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |

--- a/.github/workflows/image-release.yml
+++ b/.github/workflows/image-release.yml
@@ -728,7 +728,10 @@ jobs:
               echo "push=false" >> "$GITHUB_OUTPUT"
               echo "exporter=${EXPORTER_BASE},compression-level=3" >> "$GITHUB_OUTPUT" ;;
             *)
-              echo "::error::invalid compression '${COMPRESSION}' (expected gzip|zstd|estargz|uncompressed)"; exit 1 ;;
+              # Do NOT interpolate the raw (caller-controlled) value into the
+              # ::error:: workflow command — a CR/LF or % could inject/truncate
+              # the annotation. The accepted set is fixed and listed here.
+              echo "::error::invalid compression input (expected one of: gzip, zstd, estargz, uncompressed)"; exit 1 ;;
           esac
           echo "Resolved layer compression: ${COMPRESSION}"
 

--- a/.github/workflows/image-release.yml
+++ b/.github/workflows/image-release.yml
@@ -75,6 +75,21 @@ on:
         type: boolean
         default: false
         description: "Snapshot mode: tag images by source-branch name (no semver, no latest); pin a specific build by digest."
+      compression:
+        required: false
+        type: string
+        default: ""
+        description: >
+          Pushed-image layer compression: "" (auto) | gzip | zstd | estargz |
+          uncompressed. Auto (default, empty) resolves to zstd for snapshot
+          builds and gzip for release builds — see the "Resolve compression"
+          step. Rationale: snapshot images are pulled internally (reviewers on
+          docker 23+/podman, GHCR), where zstd's faster multi-threaded
+          compression shrinks push/export wall-clock; release images are consumed
+          in production and pushed to Docker Hub, whose zstd support is
+          incomplete, so they stay gzip for maximum compatibility. Pass an
+          explicit value to override the auto policy. Plain zstd only (never
+          zstd:chunked).
       ref:
         required: false
         type: string
@@ -676,6 +691,30 @@ jobs:
             echo "needs_qemu=true" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Resolve compression
+        id: compression
+        shell: bash
+        env:
+          COMPRESSION_IN: ${{ inputs.compression }}
+          SNAPSHOT: ${{ inputs.snapshot }}
+        run: |
+          set -euo pipefail
+          # Auto policy (empty input): zstd for snapshot (internal/GHCR, faster
+          # push), gzip for release (Docker Hub / production podman). An explicit
+          # input value overrides the policy.
+          if [[ -n "$COMPRESSION_IN" ]]; then
+            COMPRESSION="$COMPRESSION_IN"
+          elif [[ "$SNAPSHOT" == "true" ]]; then
+            COMPRESSION="zstd"
+          else
+            COMPRESSION="gzip"
+          fi
+          case "$COMPRESSION" in
+            gzip|zstd|estargz|uncompressed) ;;
+            *) echo "::error::invalid compression '${COMPRESSION}' (expected gzip|zstd|estargz|uncompressed)"; exit 1 ;;
+          esac
+          echo "value=${COMPRESSION}" >> "$GITHUB_OUTPUT"
+
       - name: Set up QEMU
         # Skip emulation setup for native amd64-only builds (see the resolve
         # step); required for every cross-arch / multi-arch build.
@@ -795,7 +834,16 @@ jobs:
           # under <runner.temp>/binctx) as the `binctx` named build context that
           # the Dockerfile's prebuilt stage COPYs from. Empty otherwise.
           build-contexts: ${{ inputs.prebuilt && format('binctx={0}/binctx', runner.temp) || '' }}
-          push: true
+          # gzip (resolved): keep the plain `push: true` path — byte-identical to
+          # prior behavior. Non-gzip: route the push through an explicit image
+          # exporter so the chosen layer compression actually applies (zstd needs
+          # oci-mediatypes=true; without this the algorithm is silently ignored).
+          # No force-compression: only newly built layers are re-compressed, so
+          # base/cache layers aren't needlessly re-encoded each build. The
+          # effective value comes from the "Resolve compression" step (auto:
+          # zstd for snapshot, gzip for release).
+          push: ${{ steps.compression.outputs.value == 'gzip' }}
+          outputs: ${{ steps.compression.outputs.value == 'gzip' && '' || format('type=image,push=true,oci-mediatypes=true,compression={0},compression-level=3', steps.compression.outputs.value) }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |

--- a/.github/workflows/image-release.yml
+++ b/.github/workflows/image-release.yml
@@ -709,11 +709,28 @@ jobs:
           else
             COMPRESSION="gzip"
           fi
+          # Emit the build-push-action push/outputs pair for the resolved value:
+          #   gzip         -> plain `push: true`, empty outputs (prior behavior).
+          #   uncompressed -> explicit exporter, NO compression-level (the level
+          #                   is meaningless for uncompressed and a future stricter
+          #                   buildx could reject it).
+          #   zstd|estargz -> explicit exporter WITH compression-level (oci-
+          #                   mediatypes is required for zstd to actually apply).
+          EXPORTER_BASE="type=image,push=true,oci-mediatypes=true,compression=${COMPRESSION}"
           case "$COMPRESSION" in
-            gzip|zstd|estargz|uncompressed) ;;
-            *) echo "::error::invalid compression '${COMPRESSION}' (expected gzip|zstd|estargz|uncompressed)"; exit 1 ;;
+            gzip)
+              echo "push=true" >> "$GITHUB_OUTPUT"
+              echo "exporter=" >> "$GITHUB_OUTPUT" ;;
+            uncompressed)
+              echo "push=false" >> "$GITHUB_OUTPUT"
+              echo "exporter=${EXPORTER_BASE}" >> "$GITHUB_OUTPUT" ;;
+            zstd|estargz)
+              echo "push=false" >> "$GITHUB_OUTPUT"
+              echo "exporter=${EXPORTER_BASE},compression-level=3" >> "$GITHUB_OUTPUT" ;;
+            *)
+              echo "::error::invalid compression '${COMPRESSION}' (expected gzip|zstd|estargz|uncompressed)"; exit 1 ;;
           esac
-          echo "value=${COMPRESSION}" >> "$GITHUB_OUTPUT"
+          echo "Resolved layer compression: ${COMPRESSION}"
 
       - name: Set up QEMU
         # Skip emulation setup for native amd64-only builds (see the resolve
@@ -834,19 +851,13 @@ jobs:
           # under <runner.temp>/binctx) as the `binctx` named build context that
           # the Dockerfile's prebuilt stage COPYs from. Empty otherwise.
           build-contexts: ${{ inputs.prebuilt && format('binctx={0}/binctx', runner.temp) || '' }}
-          # gzip (resolved): keep the plain `push: true` path — byte-identical to
-          # prior behavior. Non-gzip: route the push through an explicit image
-          # exporter so the chosen layer compression actually applies (zstd needs
-          # oci-mediatypes=true; without this the algorithm is silently ignored).
-          # No force-compression: only newly built layers are re-compressed, so
-          # base/cache layers aren't needlessly re-encoded each build. The
-          # effective value comes from the "Resolve compression" step (auto:
-          # zstd for snapshot, gzip for release).
-          push: ${{ steps.compression.outputs.value == 'gzip' }}
-          # NB: GitHub Actions expressions treat '' as falsy, so the usual
-          # `cond && '' || B` idiom would ALWAYS yield B. Put the non-empty
-          # branch on the truthy side: non-gzip -> exporter string, gzip -> ''.
-          outputs: ${{ steps.compression.outputs.value != 'gzip' && format('type=image,push=true,oci-mediatypes=true,compression={0},compression-level=3', steps.compression.outputs.value) || '' }}
+          # push/outputs come from the "Resolve compression" step: gzip keeps the
+          # plain push path (empty outputs, byte-identical to prior behavior);
+          # other algorithms push via an explicit image exporter so the layer
+          # compression actually applies (zstd needs oci-mediatypes). No
+          # force-compression, so only newly built layers are re-encoded.
+          push: ${{ steps.compression.outputs.push }}
+          outputs: ${{ steps.compression.outputs.exporter }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |

--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ App 認證（nics-dp-ci-read，用於 `private-modules=true`）：client-id 由 
 | Workflow             | 用途                                                                                                                       |
 | -------------------- | -------------------------------------------------------------------------------------------------------------------------- |
 | `go-release.yml`     | Go binary 跨平台建置 + cosign 簽章 + 多平台 SBOM；3 jobs：`prepare` → `build` (matrix) → `release`                          |
-| `image-release.yml`  | Docker image dual registry (DockerHub + GHCR) + BuildKit SBOM + SLSA provenance + Sigstore attestation + cosign 簽章       |
+| `image-release.yml`  | Docker image dual registry (DockerHub + GHCR) + BuildKit SBOM + SLSA provenance + Sigstore attestation + cosign 簽章；layer 壓縮 auto：snapshot→zstd、release→gzip（`compression` input 可覆寫） |
 | `sbom-source.yml`    | Source 端 CycloneDX SBOM (anchore/sbom-action) + parlay 增強 + Trivy/Grype 漏洞掃描 → release-mode 上傳至 GitHub Release / snapshot-mode 留 workflow artifact |
 | `sbom-image.yml`     | Container image CycloneDX 1.6 SBOM + parlay 增強 + Trivy/Grype 漏洞掃描 → GitHub Release + Security tab                    |
 


### PR DESCRIPTION
## What

Add a `compression` input to `image-release.yml` that sets the **pushed-image layer compression**, defaulting to an **auto policy**:

- **snapshot builds → `zstd`**
- **release builds → `gzip`**

A new *Resolve compression* step computes the effective algorithm (an explicit input value overrides the policy). Non-gzip routes the push through an explicit image exporter with `oci-mediatypes=true` so zstd actually applies (it is silently ignored otherwise). No `force-compression`, so only newly built layers are re-encoded.

## Why

zstd compresses multi-threaded and faster than gzip, cutting the layer export/push wall-clock — most visible on large images (e.g. `dcf-synth`'s python venv: jax/pyarrow/scipy). Applying it org-wide to **snapshots only** keeps the win where it's safe:

- Snapshot images are pulled internally by reviewers (docker 23+/podman, GHCR).
- Release images go to Docker Hub (incomplete zstd support) and production podman, so they stay **gzip** for maximum compatibility.

This needs **no per-caller change** — every existing snapshot caller gets zstd automatically; every release caller stays gzip.

## Compatibility notes (zstd)

- Pull client must be docker 23+ / podman (podman detects via magic bytes — robust).
- Plain `zstd` only, never `zstd:chunked` (docker interop bug).
- The snapshot tarball step (`docker pull` + `docker save` on the ubuntu-24.04 runner) must read zstd — supported by the runner's docker. Will confirm on the first live snapshot run.

## First consumer

`dcf-synth` also moves its snapshot image to prebuilt mode (separate PR) — it inherits zstd from this auto policy with no extra input.
