### PR TITLE
fix(ci): pin betterleaks to 1.5.0 over broken 1.6.0 attestation

### DIFF
--- a/.mise/tasks/ci/betterleaks
+++ b/.mise/tasks/ci/betterleaks
@@ -2,7 +2,14 @@
 #MISE description="Scan for leaked secrets (betterleaks; PR gate)"
 #MISE hide=true
 #MISE raw=true
-#MISE tools={"github:betterleaks/betterleaks"="latest"}
+# Pinned to 1.5.0: betterleaks 1.6.0's GitHub artifact attestation fails
+# mise's Sigstore verification ("TSA timestamp verification failed: no
+# certificate matches issuer and serial number"), which aborts the install and
+# breaks this secret-scan gate for every consumer. 1.5.0 is the latest release
+# whose attestation verifies cleanly. Revisit (bump toward latest) once an
+# upstream release with a valid TSA attestation — or a mise with an updated
+# Sigstore trust root — is available.
+#MISE tools={"github:betterleaks/betterleaks"="1.5.0"}
 set -euo pipefail
 
 # betterleaks: fast, configurable secret scanner from the Gitleaks authors. Used


### PR DESCRIPTION
## 問題

betterleaks **1.6.0**(2026-06-26 發布,目前 `latest`)的 GitHub artifact attestation 無法通過 mise 的 Sigstore 驗證,安裝階段直接中止:

```
GitHub artifact attestations verification error for github:betterleaks/betterleaks@1.6.0:
Verification failed: Sigstore error: Verification error:
TSA timestamp verification failed: Failed to verify timestamp signature:
no certificate matches issuer and serial number
```

`ci:betterleaks` 把 tool 釘成 `"latest"` → 解析到 1.6.0 → scanner 還沒跑就 exit 1,讓**所有 consumer** 的 secret-scan gate(含 dcf-service）紅燈。這是 attestation/Sigstore 信任根問題,與被掃的程式碼無關。

## 修正

把 `.mise/tasks/ci/betterleaks` 的 tool 由 `"latest"` 釘為 **`"1.5.0"`** —— 目前 attestation 能乾淨通過驗證的最新版,並加註原因與「待上游修好或 mise 信任根更新後再 bump」。

## 驗證(本機 mise 2026.6.13)

- `mise install github:betterleaks/betterleaks@1.6.0` → 重現 TSA 驗證失敗
- `mise install github:betterleaks/betterleaks@1.5.0 --force` → `✓ GitHub artifact attestations verified`
- `mise run ci:betterleaks`(本分支)→ 安裝驗證通過、掃描完成、`no leaks found`、exit 0
- `bash -n` 通過

## 生效範圍

meta 自家 CI 的 PR gate 在本分支即生效;下游 consumer(釘 `ref=main`)須 promote dev→main 並清 `remote-git-tasks-cache` 後才會吃到。
