### PR TITLE
ci(go-release): pin actions/cache to commit SHA

### DIFF
--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -231,7 +231,7 @@ jobs:
 
       - name: Cache vendor directory
         if: contains(inputs.extra_build_flags, '-mod=vendor')
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: vendor
           key: go-vendor-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('go.sum') }}


### PR DESCRIPTION
## What

Pin `actions/cache` in `go-release.yml` from the floating `@v6` tag to the
`v6.1.0` commit SHA (`55cc8345863c7cc4c66a329aec7e433d2d1c52a9`).

## Why

OpenSSF Scorecard **Pinned-Dependencies** flags this as a code-scanning
alert ([#190](https://github.com/nics-dp/meta/security/code-scanning/190)):

> score is 9: GitHub-owned GitHubAction not pinned by hash

It was the only action in the repo still pinned by tag rather than SHA; every
other `uses:` already follows the `@<sha> # vX.Y.Z` convention.

## Verification

- `actionlint .github/workflows/go-release.yml` passes
- `v6` tag currently resolves to the same SHA as `v6.1.0`, so no behavioural change