### PR TITLE
ci(security-sarif): withhold ci-read token on untrusted triggers

### DIFF
--- a/.github/workflows/security-sarif.yml
+++ b/.github/workflows/security-sarif.yml
@@ -70,6 +70,15 @@ jobs:
       # mise-task.yml: the ci-read App is identified by the CI_READ_APP_CLIENT_ID
       # org variable (client-id) plus the ci_read_app_private_key secret.
       HAS_CI_APP: ${{ vars.CI_READ_APP_CLIENT_ID != '' && secrets.ci_read_app_private_key != '' }}
+      # Defense-in-depth against CodeQL actions/untrusted-checkout: in a reusable
+      # workflow github.event_name is the CALLER's triggering event. Every current
+      # caller runs this on `pull_request` (PR code is fork-isolated / authored by
+      # trusted org members on INTERNAL repos), but pull_request_target and
+      # workflow_run would run attacker-controllable code WITH secrets in scope.
+      # Flag those triggers so the privileged ci-read App token is never minted
+      # for them -- the Go scanners then degrade to public-module-only and stay
+      # non-blocking, rather than exposing a private-repo-read token to PR code.
+      UNTRUSTED_TRIGGER: ${{ github.event_name == 'pull_request_target' || github.event_name == 'workflow_run' }}
     steps:
       # Mint a nics-dp-ci-read App token for private Go module access, but only
       # when the Go scanners run and the App is configured. The PAT model was
@@ -77,7 +86,7 @@ jobs:
       # token is minted here (mirrors mise-task.yml).
       - name: Mint private-module token
         id: priv-token
-        if: ${{ env.HAS_CI_APP == 'true' && inputs.run_go }}
+        if: ${{ env.HAS_CI_APP == 'true' && inputs.run_go && env.UNTRUSTED_TRIGGER != 'true' }}
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           client-id: ${{ vars.CI_READ_APP_CLIENT_ID }}
@@ -178,6 +187,12 @@ jobs:
               echo "GOPRIVATE=github.com/nics-dp"
               echo "GONOSUMDB=github.com/nics-dp"
             } >> "$GITHUB_ENV"
+          elif [ "${UNTRUSTED_TRIGGER}" = "true" ]; then
+            # Token deliberately withheld: the caller ran this under an untrusted
+            # trigger (pull_request_target / workflow_run -- see the job env), so
+            # the privileged token is never minted for attacker-controllable code.
+            # gosec/govulncheck lose private-module access by design; non-blocking.
+            echo "::warning::ci-read App token withheld on ${GITHUB_EVENT_NAME} (untrusted trigger; defense-in-depth); gosec/govulncheck cannot fetch private github.com/nics-dp modules and may fail to build -- expected and non-blocking."
           else
             # No token: the ci-read App is not configured/inherited. Warn loudly
             # rather than skip silently -- gosec/govulncheck would otherwise fail

--- a/.github/workflows/security-sarif.yml
+++ b/.github/workflows/security-sarif.yml
@@ -187,10 +187,13 @@ jobs:
               echo "GOPRIVATE=github.com/nics-dp"
               echo "GONOSUMDB=github.com/nics-dp"
             } >> "$GITHUB_ENV"
-          elif [ "${UNTRUSTED_TRIGGER}" = "true" ]; then
-            # Token deliberately withheld: the caller ran this under an untrusted
-            # trigger (pull_request_target / workflow_run -- see the job env), so
-            # the privileged token is never minted for attacker-controllable code.
+          elif [ "${HAS_CI_APP}" = "true" ] && [ "${UNTRUSTED_TRIGGER}" = "true" ]; then
+            # Token deliberately withheld: the App IS configured but the caller ran
+            # this under an untrusted trigger (pull_request_target / workflow_run --
+            # see the job env), so the privileged token is never minted for
+            # attacker-controllable code. Guard on HAS_CI_APP so an unconfigured App
+            # still falls through to the generic "unavailable" warning below rather
+            # than misreporting a deliberate withholding.
             # gosec/govulncheck lose private-module access by design; non-blocking.
             echo "::warning::ci-read App token withheld on ${GITHUB_EVENT_NAME} (untrusted trigger; defense-in-depth); gosec/govulncheck cannot fetch private github.com/nics-dp modules and may fail to build -- expected and non-blocking."
           else


### PR DESCRIPTION
## What

Add a defense-in-depth guard to the shared `security-sarif.yml` reusable
workflow: the privileged **nics-dp-ci-read App token is no longer minted**
when the caller's triggering event is `pull_request_target` or `workflow_run`.

## Why

Follow-up to dismissing CodeQL `actions/untrusted-checkout` alert
[#189](https://github.com/nics-dp/meta/security/code-scanning/189).

The alert flagged the checkout of `inputs.ref` in this reusable workflow.
I verified it is a false positive in current use — an org-wide scan found
**16 callers** (`security-scan.yml`), every one of which:

- triggers on `pull_request` (never `pull_request_target`),
- passes **no** `ref` input (checkout uses the safe default event ref),
- lives in an **INTERNAL/PRIVATE** repo (no external forks).

So today the workflow never builds attacker-controllable code with secrets in
scope. But that safety currently relies entirely on **caller discipline**.
This PR moves one layer of protection into the shared workflow itself so a
future caller that wires it into `pull_request_target` / `workflow_run`
cannot leak the private-repo-read token to PR code.

## How

- New job-level `UNTRUSTED_TRIGGER` env (`github.event_name` is the caller's
  event inside a reusable workflow).
- The token-mint step gains `&& env.UNTRUSTED_TRIGGER != 'true'`.
- Under an untrusted trigger the Go scanners degrade to public-module-only and
  stay **non-blocking**; a distinct `::warning::` explains the deliberate
  withholding (vs. the existing "App not configured" warning).

## Impact

**No behaviour change for any current caller** — all run on `pull_request`,
where the token continues to be minted exactly as before.

## Verification

- `actionlint .github/workflows/security-sarif.yml` passes (incl. shellcheck)
- Org-wide caller audit (16 repos) confirms no `pull_request_target` /
  `workflow_run` usage