### PR TITLE
release: v0.2.5.4

### DIFF
--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -231,7 +231,7 @@ jobs:
 
       - name: Cache vendor directory
         if: contains(inputs.extra_build_flags, '-mod=vendor')
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: vendor
           key: go-vendor-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('go.sum') }}

--- a/.github/workflows/security-sarif.yml
+++ b/.github/workflows/security-sarif.yml
@@ -70,6 +70,15 @@ jobs:
       # mise-task.yml: the ci-read App is identified by the CI_READ_APP_CLIENT_ID
       # org variable (client-id) plus the ci_read_app_private_key secret.
       HAS_CI_APP: ${{ vars.CI_READ_APP_CLIENT_ID != '' && secrets.ci_read_app_private_key != '' }}
+      # Defense-in-depth against CodeQL actions/untrusted-checkout: in a reusable
+      # workflow github.event_name is the CALLER's triggering event. Every current
+      # caller runs this on `pull_request` (PR code is fork-isolated / authored by
+      # trusted org members on INTERNAL repos), but pull_request_target and
+      # workflow_run would run attacker-controllable code WITH secrets in scope.
+      # Flag those triggers so the privileged ci-read App token is never minted
+      # for them -- the Go scanners then degrade to public-module-only and stay
+      # non-blocking, rather than exposing a private-repo-read token to PR code.
+      UNTRUSTED_TRIGGER: ${{ github.event_name == 'pull_request_target' || github.event_name == 'workflow_run' }}
     steps:
       # Mint a nics-dp-ci-read App token for private Go module access, but only
       # when the Go scanners run and the App is configured. The PAT model was
@@ -77,7 +86,7 @@ jobs:
       # token is minted here (mirrors mise-task.yml).
       - name: Mint private-module token
         id: priv-token
-        if: ${{ env.HAS_CI_APP == 'true' && inputs.run_go }}
+        if: ${{ env.HAS_CI_APP == 'true' && inputs.run_go && env.UNTRUSTED_TRIGGER != 'true' }}
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           client-id: ${{ vars.CI_READ_APP_CLIENT_ID }}
@@ -178,6 +187,12 @@ jobs:
               echo "GOPRIVATE=github.com/nics-dp"
               echo "GONOSUMDB=github.com/nics-dp"
             } >> "$GITHUB_ENV"
+          elif [ "${UNTRUSTED_TRIGGER}" = "true" ]; then
+            # Token deliberately withheld: the caller ran this under an untrusted
+            # trigger (pull_request_target / workflow_run -- see the job env), so
+            # the privileged token is never minted for attacker-controllable code.
+            # gosec/govulncheck lose private-module access by design; non-blocking.
+            echo "::warning::ci-read App token withheld on ${GITHUB_EVENT_NAME} (untrusted trigger; defense-in-depth); gosec/govulncheck cannot fetch private github.com/nics-dp modules and may fail to build -- expected and non-blocking."
           else
             # No token: the ci-read App is not configured/inherited. Warn loudly
             # rather than skip silently -- gosec/govulncheck would otherwise fail

--- a/.github/workflows/security-sarif.yml
+++ b/.github/workflows/security-sarif.yml
@@ -187,10 +187,13 @@ jobs:
               echo "GOPRIVATE=github.com/nics-dp"
               echo "GONOSUMDB=github.com/nics-dp"
             } >> "$GITHUB_ENV"
-          elif [ "${UNTRUSTED_TRIGGER}" = "true" ]; then
-            # Token deliberately withheld: the caller ran this under an untrusted
-            # trigger (pull_request_target / workflow_run -- see the job env), so
-            # the privileged token is never minted for attacker-controllable code.
+          elif [ "${HAS_CI_APP}" = "true" ] && [ "${UNTRUSTED_TRIGGER}" = "true" ]; then
+            # Token deliberately withheld: the App IS configured but the caller ran
+            # this under an untrusted trigger (pull_request_target / workflow_run --
+            # see the job env), so the privileged token is never minted for
+            # attacker-controllable code. Guard on HAS_CI_APP so an unconfigured App
+            # still falls through to the generic "unavailable" warning below rather
+            # than misreporting a deliberate withholding.
             # gosec/govulncheck lose private-module access by design; non-blocking.
             echo "::warning::ci-read App token withheld on ${GITHUB_EVENT_NAME} (untrusted trigger; defense-in-depth); gosec/govulncheck cannot fetch private github.com/nics-dp modules and may fail to build -- expected and non-blocking."
           else


### PR DESCRIPTION
## release: v0.2.5.4

Promotes `dev` → `main`. Patch release.

### Changes
- **ci(go-release): pin actions/cache to commit SHA** (#233) — resolves OpenSSF Scorecard Pinned-Dependencies alert (the only unpinned GitHub-owned action).
- **ci(security-sarif): withhold ci-read token on untrusted triggers** (#234) — defense-in-depth for the shared reusable workflow; the privileged ci-read App token is no longer minted under `pull_request_target` / `workflow_run`. No behaviour change for current callers (all `pull_request`).
- **ci(security-sarif): guard withheld-token warning on HAS_CI_APP** (#234) — fixes a misleading warning when the App is unconfigured.

### Security housekeeping (no code change)
- All 8 CodeQL `actions/untrusted-checkout` alerts triaged: 7 release/sbom dismissed as false positives (reusable workflows, no PR data, `persist-credentials:false`); the security-sarif one dismissed after an org-wide audit confirmed all 16 callers use `pull_request` + INTERNAL repos + no `ref`.