### PR TITLE
fix(mise.facades): run init before Go tasks in `all` to kill vendor race

### DIFF
--- a/templates/facades/mise.go-lib.toml
+++ b/templates/facades/mise.go-lib.toml
@@ -65,8 +65,15 @@ depends = [
 ]
 
 [tasks.all]
-description = "init -> generate -> api-fix -> test -> ci"
-depends = ["init", "go:generate", "go:api-fix", "test", "ci"]
+description = "init -> {generate, api-fix, test, ci}"
+# See mise.go-service.toml: init (go mod tidy + vendor) must finish before any Go
+# task runs, since Go auto-selects -mod=vendor once vendor/ exists. A parallel
+# `depends` sibling raced consumers against a half-written vendor/ ->
+# "inconsistent vendoring". Run init first, then fan the rest out in parallel.
+run = [
+  "mise run init",
+  "mise run go:generate go:api-fix test ci",
+]
 
 [tasks.sbom]
 description = "Generate enriched SBOM and scan"

--- a/templates/facades/mise.go-service.toml
+++ b/templates/facades/mise.go-service.toml
@@ -103,5 +103,14 @@ description = "Generate enriched SBOM and scan"
 depends = ["sbom:trivy", "sbom:grype"]
 
 [tasks.all]
-description = "init -> generate -> api-fix -> build -> test -> ci"
-depends = ["init", "go:generate", "go:api-fix", "build", "test", "ci"]
+description = "init -> {generate, api-fix, build, test, ci}"
+# `init` runs go:install (go mod tidy + go mod vendor). Every Go task below builds
+# with -mod=vendor (EXTRA_BUILD_FLAGS pins it, and Go auto-selects vendor once
+# vendor/ exists), so none may start until vendoring has finished writing
+# vendor/modules.txt. Declaring init as a parallel `depends` sibling raced go:build
+# against a half-written vendor/ -> "inconsistent vendoring". Run init first, then
+# fan the rest out in parallel (same concurrency as the old depends list).
+run = [
+  "mise run init",
+  "mise run go:generate go:api-fix build test ci",
+]


### PR DESCRIPTION
Closes nics-dp/meta#239. Refs nics-dp/TMDs#580.

## Problem

The `all` facade task lists `init` as a **parallel `depends` sibling** of `build`/`test`/`ci`:

```toml
depends = ["init", "go:generate", "go:api-fix", "build", "test", "ci"]
```

`init` runs `go:install` (`go mod tidy` + `go mod vendor`). Every Go task builds with `-mod=vendor` (`EXTRA_BUILD_FLAGS` pins it, and Go auto-selects vendor once `vendor/` exists). Because mise runs the `depends` list in parallel, a consumer (`go:build`) can read a **half-written `vendor/modules.txt`** while `go mod vendor` is still writing it → `inconsistent vendoring`, an intermittent CI failure.

Reproduced on dcf-synth's auto-release dry-run (`go:build` failed with a full `inconsistent vendoring` dump while `go:test` — which started a few seconds later — passed).

## Fix

Sequence `init` first, then fan the rest out in parallel:

```toml
run = [
  "mise run init",
  "mise run go:generate go:api-fix build test ci",
]
```

Same concurrency as the old `depends` list (generate/api-fix/build/test/ci still run together), minus the init race. Applied to `mise.go-service.toml` and `mise.go-lib.toml` (the two Go facades; python/frontend/image don't use `-mod=vendor`, but share the analogous init→consumers ordering — can follow up if they show flakiness).

## Scope / rollout

- This fixes the **canonical facade templates**. Existing repos carry their own copies of `mise.toml` and need the same change rolled out — already tracked in **TMDs#583** (dcf-platform) and **TMDs#584** (dcf-access); dcf-synth already patched.
- Refs **TMDs#580** (Release CI 自動化).

🤖 Generated with [Claude Code](https://claude.com/claude-code)