### PR TITLE
fix(mise): go atoms depend on go:install; sequence facade all tasks

### DIFF
--- a/.mise/tasks/go/api-fix
+++ b/.mise/tasks/go/api-fix
@@ -2,6 +2,7 @@
 #MISE description="Migrate Go source to new APIs via go fix (rewrites deprecated stdlib paths/calls)"
 #MISE hide=true
 #MISE raw=true
+#MISE depends=["go:install"]
 #MISE silent="stdout"
 
 set -euo pipefail

--- a/.mise/tasks/go/audit
+++ b/.mise/tasks/go/audit
@@ -2,6 +2,7 @@
 #MISE description="Run govulncheck vulnerability check"
 #MISE hide=true
 #MISE raw=true
+#MISE depends=["go:install"]
 #MISE tools={"go:golang.org/x/vuln/cmd/govulncheck"="latest"}
 
 govulncheck ./...

--- a/.mise/tasks/go/build
+++ b/.mise/tasks/go/build
@@ -2,6 +2,7 @@
 #MISE description="Build Go binary from cmd/"
 #MISE hide=true
 #MISE raw=true
+#MISE depends=["go:install"]
 #MISE silent="stdout"
 #USAGE arg "<name>" help="Binary name (auto-detected if cmd/ has only one entry)"
 # shellcheck disable=SC2154 # usage_name is set by mise USAGE

--- a/.mise/tasks/go/dead-code
+++ b/.mise/tasks/go/dead-code
@@ -2,6 +2,7 @@
 #MISE description="Find unreachable functions in production code; --whole-program also analyzes tests (golang.org/x/tools/cmd/deadcode)"
 #MISE hide=true
 #MISE raw=true
+#MISE depends=["go:install"]
 #MISE tools={"go:golang.org/x/tools/cmd/deadcode"="latest"}
 #USAGE arg "[entry]" help="Entry package(s) (default: ./... — roots at every main package, commonly cmd/*)"
 #USAGE flag "--filter <regex>" help="Only report functions matching regex"

--- a/.mise/tasks/go/generate
+++ b/.mise/tasks/go/generate
@@ -2,6 +2,7 @@
 #MISE description="Run go generate (code generation)"
 #MISE hide=true
 #MISE raw=true
+#MISE depends=["go:install"]
 #MISE silent="stdout"
 
 set -euo pipefail

--- a/.mise/tasks/go/lint-check
+++ b/.mise/tasks/go/lint-check
@@ -2,6 +2,7 @@
 #MISE description="Lint Go (read-only)"
 #MISE hide=true
 #MISE raw=true
+#MISE depends=["go:install"]
 #MISE tools={"aqua:golangci/golangci-lint"="2.12.2"}
 
 golangci-lint run ./...

--- a/.mise/tasks/go/sast
+++ b/.mise/tasks/go/sast
@@ -2,6 +2,7 @@
 #MISE description="Run gosec security scanner"
 #MISE hide=true
 #MISE raw=true
+#MISE depends=["go:install"]
 #MISE tools={"github:securego/gosec"="latest"}
 
 gosec -quiet ./...

--- a/.mise/tasks/go/test
+++ b/.mise/tasks/go/test
@@ -2,6 +2,7 @@
 #MISE description="Run Go tests. Modes: default=unit, --race, --coverage, --bench, --full=race+coverage+bench"
 #MISE hide=true
 #MISE raw=true
+#MISE depends=["go:install"]
 #USAGE flag "--race" help="Enable race detector"
 #USAGE flag "--coverage" help="Enable coverage (writes coverage.out)"
 #USAGE flag "--bench" help="Run benchmarks instead of tests"

--- a/templates/facades/mise.frontend.toml
+++ b/templates/facades/mise.frontend.toml
@@ -34,6 +34,7 @@ includes = ["git::https://github.com/nics-dp/meta.git//.mise/tasks?ref=main"]
 silent = "stdout"
 description = "Install JS deps + Playwright browsers"
 depends = ["node:install", "node:e2e-install"]
+depends_post = ["meta:bump"]
 
 [tasks.clean]
 silent = "stdout"
@@ -60,8 +61,11 @@ run = "bunx vitest bench --run"
 [tasks.update]
 silent = "stdout"
 description = "Bump deps and refresh shared atoms"
-depends = ["node:update", "meta:bump"]
-
+# meta:bump runs first in its OWN invocation (run array steps are separate
+# `mise run` processes): it refreshes the shared atom cache, then the deps
+# step re-resolves and runs against the latest upstream atoms. Separate
+# invocations also avoid the cache-clear race that depends/depends_post had.
+run = ["mise run meta:bump", "mise run node:update"]
 [tasks.ci]
 description = "Run all CI checks"
 # Native-binary toolchain (oxc/opengrep/tsgo): oxfmt replaces prettier; oxlint &

--- a/templates/facades/mise.frontend.toml
+++ b/templates/facades/mise.frontend.toml
@@ -91,4 +91,4 @@ depends = ["sbom:trivy", "sbom:grype"]
 
 [tasks.all]
 description = "init -> build -> test -> ci"
-run = ["mise run init", "mise run build test ci"]
+run = ["mise run init", "mise run build", "mise run test", "mise run ci"]

--- a/templates/facades/mise.frontend.toml
+++ b/templates/facades/mise.frontend.toml
@@ -91,4 +91,4 @@ depends = ["sbom:trivy", "sbom:grype"]
 
 [tasks.all]
 description = "init -> build -> test -> ci"
-depends = ["init", "build", "test", "ci"]
+run = ["mise run init", "mise run build test ci"]

--- a/templates/facades/mise.frontend.toml
+++ b/templates/facades/mise.frontend.toml
@@ -90,5 +90,5 @@ description = "Generate enriched SBOM and scan"
 depends = ["sbom:trivy", "sbom:grype"]
 
 [tasks.all]
-description = "init -> build -> test -> ci"
-run = ["mise run init", "mise run build", "mise run test", "mise run ci"]
+description = "init first, then build/test/ci in parallel"
+run = ["mise run init", "mise run build test ci"]

--- a/templates/facades/mise.go-lib.toml
+++ b/templates/facades/mise.go-lib.toml
@@ -66,7 +66,7 @@ depends = [
 
 [tasks.all]
 description = "init -> generate -> api-fix -> test -> ci"
-depends = ["init", "go:generate", "go:api-fix", "test", "ci"]
+run = ["mise run init", "mise run go:generate", "mise run go:api-fix", "mise run test ci"]
 
 [tasks.sbom]
 description = "Generate enriched SBOM and scan"

--- a/templates/facades/mise.go-lib.toml
+++ b/templates/facades/mise.go-lib.toml
@@ -65,8 +65,8 @@ depends = [
 ]
 
 [tasks.all]
-description = "init -> generate -> api-fix -> test -> ci"
-run = ["mise run init", "mise run go:generate", "mise run go:api-fix", "mise run test", "mise run ci"]
+description = "init -> generate -> api-fix sequentially, then test/ci in parallel"
+run = ["mise run init", "mise run go:generate", "mise run go:api-fix", "mise run test ci"]
 
 [tasks.sbom]
 description = "Generate enriched SBOM and scan"

--- a/templates/facades/mise.go-lib.toml
+++ b/templates/facades/mise.go-lib.toml
@@ -66,7 +66,7 @@ depends = [
 
 [tasks.all]
 description = "init -> generate -> api-fix -> test -> ci"
-run = ["mise run init", "mise run go:generate", "mise run go:api-fix", "mise run test ci"]
+run = ["mise run init", "mise run go:generate", "mise run go:api-fix", "mise run test", "mise run ci"]
 
 [tasks.sbom]
 description = "Generate enriched SBOM and scan"

--- a/templates/facades/mise.go-lib.toml
+++ b/templates/facades/mise.go-lib.toml
@@ -36,6 +36,7 @@ includes = ["git::https://github.com/nics-dp/meta.git//.mise/tasks?ref=main"]
 silent = "stdout"
 description = "Tidy and vendor Go modules"
 depends = ["go:install"]
+depends_post = ["meta:bump"]
 
 [tasks.clean]
 silent = "stdout"
@@ -50,9 +51,11 @@ depends_post = ["go:report"]
 [tasks.update]
 silent = "stdout"
 description = "Bump deps, update submodules, and refresh shared atoms"
-depends = ["go:update", "gs:update"]
-depends_post = ["meta:bump"]
-
+# meta:bump runs first in its OWN invocation (run array steps are separate
+# `mise run` processes): it refreshes the shared atom cache, then the deps
+# step re-resolves and runs against the latest upstream atoms. Separate
+# invocations also avoid the cache-clear race that depends/depends_post had.
+run = ["mise run meta:bump", "mise run go:update gs:update"]
 [tasks.ci]
 description = "Run all CI checks"
 depends = [

--- a/templates/facades/mise.go-service.toml
+++ b/templates/facades/mise.go-service.toml
@@ -103,5 +103,5 @@ description = "Generate enriched SBOM and scan"
 depends = ["sbom:trivy", "sbom:grype"]
 
 [tasks.all]
-description = "init -> generate -> api-fix -> build -> test -> ci"
-run = ["mise run init", "mise run go:generate", "mise run go:api-fix", "mise run build", "mise run test", "mise run ci"]
+description = "init -> generate -> api-fix sequentially, then build/test/ci in parallel"
+run = ["mise run init", "mise run go:generate", "mise run go:api-fix", "mise run build test ci"]

--- a/templates/facades/mise.go-service.toml
+++ b/templates/facades/mise.go-service.toml
@@ -104,4 +104,4 @@ depends = ["sbom:trivy", "sbom:grype"]
 
 [tasks.all]
 description = "init -> generate -> api-fix -> build -> test -> ci"
-run = ["mise run init", "mise run go:generate", "mise run go:api-fix", "mise run build test ci"]
+run = ["mise run init", "mise run go:generate", "mise run go:api-fix", "mise run build", "mise run test", "mise run ci"]

--- a/templates/facades/mise.go-service.toml
+++ b/templates/facades/mise.go-service.toml
@@ -104,4 +104,4 @@ depends = ["sbom:trivy", "sbom:grype"]
 
 [tasks.all]
 description = "init -> generate -> api-fix -> build -> test -> ci"
-depends = ["init", "go:generate", "go:api-fix", "build", "test", "ci"]
+run = ["mise run init", "mise run go:generate", "mise run go:api-fix", "mise run build test ci"]

--- a/templates/facades/mise.go-service.toml
+++ b/templates/facades/mise.go-service.toml
@@ -40,6 +40,7 @@ includes = ["git::https://github.com/nics-dp/meta.git//.mise/tasks?ref=main"]
 silent = "stdout"
 description = "Bootstrap deps and submodules"
 depends = ["go:install", "gs:clone"]
+depends_post = ["meta:bump"]
 
 [tasks.clean]
 silent = "stdout"
@@ -82,9 +83,11 @@ depends = ["go:lib-remote"]
 [tasks.update]
 silent = "stdout"
 description = "Bump deps, refresh shared atoms, update submodules"
-depends = ["go:update", "gs:update"]
-depends_post = ["meta:bump"]
-
+# meta:bump runs first in its OWN invocation (run array steps are separate
+# `mise run` processes): it refreshes the shared atom cache, then the deps
+# step re-resolves and runs against the latest upstream atoms. Separate
+# invocations also avoid the cache-clear race that depends/depends_post had.
+run = ["mise run meta:bump", "mise run go:update gs:update"]
 [tasks.ci]
 description = "Run all CI checks"
 depends = [

--- a/templates/facades/mise.python.toml
+++ b/templates/facades/mise.python.toml
@@ -97,4 +97,4 @@ depends = [
 
 [tasks.all]
 description = "init -> build -> test -> ci"
-run = ["mise run init", "mise run build test ci"]
+run = ["mise run init", "mise run build", "mise run test", "mise run ci"]

--- a/templates/facades/mise.python.toml
+++ b/templates/facades/mise.python.toml
@@ -96,5 +96,5 @@ depends = [
 ]
 
 [tasks.all]
-description = "init -> build -> test -> ci"
-run = ["mise run init", "mise run build", "mise run test", "mise run ci"]
+description = "init first, then build/test/ci in parallel"
+run = ["mise run init", "mise run build test ci"]

--- a/templates/facades/mise.python.toml
+++ b/templates/facades/mise.python.toml
@@ -97,4 +97,4 @@ depends = [
 
 [tasks.all]
 description = "init -> build -> test -> ci"
-depends = ["init", "build", "test", "ci"]
+run = ["mise run init", "mise run build test ci"]

--- a/templates/facades/mise.python.toml
+++ b/templates/facades/mise.python.toml
@@ -42,6 +42,7 @@ includes = ["git::https://github.com/nics-dp/meta.git//.mise/tasks?ref=main"]
 silent = "stdout"
 description = "Install Python deps"
 depends = ["py:install"]
+depends_post = ["meta:bump"]
 
 [tasks.clean]
 silent = "stdout"
@@ -70,8 +71,11 @@ depends = ["py:test --bench"]
 [tasks.update]
 silent = "stdout"
 description = "Bump deps and refresh shared atoms"
-depends = ["py:update", "meta:bump"]
-
+# meta:bump runs first in its OWN invocation (run array steps are separate
+# `mise run` processes): it refreshes the shared atom cache, then the deps
+# step re-resolves and runs against the latest upstream atoms. Separate
+# invocations also avoid the cache-clear race that depends/depends_post had.
+run = ["mise run meta:bump", "mise run py:update"]
 [tasks.ci]
 description = "Run all CI checks"
 depends = [


### PR DESCRIPTION
## Summary
- Declare `depends=["go:install"]` on the 8 vendor/compile-requiring go atoms (build, test, generate, api-fix, lint-check, sast, audit, dead-code). Go atoms run with `-mod=vendor` but never depended on `go:install`, so parallel invocation (the all/ci facade, or per-job CI) could start before `go mod vendor` finished writing — causing intermittent `inconsistent vendoring`. This mirrors how every node atom already depends on `node:install`; py needs none because `uv run` auto-syncs the venv (only uvx-based `py:typecheck` declares it).
- Sequence the `all` task in the 4 facade templates (frontend, go-lib, go-service, python) to the same `run` form as the consumer repos, so new repos copied from them do not reintroduce the parallel `depends` (which would bring back the generate/api-fix -> build source race).

## Context
Root-cause fix for the vendor race that the consumer repos also guard with a sequential `all`. Part of the auto-release rollout + mise race fixes (TMDs#584).

Refs TMDs#239.

Closes #241