### PR TITLE
ci(release): enable meta self-release (all task + self-caller)

### DIFF
--- a/.github/workflows/self-release.yml
+++ b/.github/workflows/self-release.yml
@@ -1,0 +1,31 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+# meta dogfoods its own reusable auto-release driver. This self-caller lets meta
+# cut its own patch release (snapshot dev -> `mise run all` validate -> merge to
+# main -> tag -> GitHub Release) the same way consumer repos do.
+name: Self-Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Release version (e.g. v0.2.5.5)"
+        required: true
+        type: string
+      dry_run:
+        description: "Validate only (skip merge/tag/release)"
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: write
+
+jobs:
+  self-release:
+    uses: nics-dp/meta/.github/workflows/auto-release.yml@main
+    with:
+      version: ${{ inputs.version }}
+      dry_run: ${{ inputs.dry_run }}
+    secrets:
+      ci_read_app_private_key:     ${{ secrets.CI_READ_APP_PRIVATE_KEY }}
+      pre_release_app_private_key: ${{ secrets.PRE_RELEASE_APP_PRIVATE_KEY }}

--- a/.github/workflows/self-release.yml
+++ b/.github/workflows/self-release.yml
@@ -18,10 +18,12 @@ on:
         default: false
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   self-release:
+    permissions:
+      contents: write # auto-release.yml's GITHUB_TOKEN creates the release snapshot branch + tag/release
     uses: nics-dp/meta/.github/workflows/auto-release.yml@main
     with:
       version: ${{ inputs.version }}

--- a/mise.toml
+++ b/mise.toml
@@ -27,6 +27,16 @@ depends = [
   "ci:semgrep",
 ]
 
+# Full validation gate. Entry point for the auto-release driver (`mise run all`)
+# so meta can dogfood its own reusable release workflow. Config repo has no
+# build/test — validation is actionlint (workflow YAML) + the ci scans. All
+# steps are read-only (no working-tree drift), so they run in parallel.
+# Secret/license scans (betterleaks/trufflehog/trivy-license) are run separately
+# by the driver itself, so they are not duplicated here.
+[tasks.all]
+description = "Validation gate: actionlint + ci scans (auto-release driver entry point)"
+depends = ["iac:actionlint", "ci"]
+
 # ==============================================================================
 #  SBOM Tasks
 # ==============================================================================

--- a/mise.toml
+++ b/mise.toml
@@ -23,7 +23,6 @@ includes = [
 description = "Run all CI checks"
 depends = [
   "iac:trivy",
-  "ci:trivy-license",
   "ci:semgrep",
 ]
 


### PR DESCRIPTION
## Summary
meta couldn't use its own auto-release driver because the driver runs `mise run all` and meta (a config repo) had no `all` task. This enables meta to dogfood the driver:

- **`[tasks.all]`** = `iac:actionlint` + `ci` (trivy + semgrep). Read-only, no working-tree drift. The license/secret scans (trivy-license/betterleaks/trufflehog) are run by the driver itself as separate steps, so they are deliberately kept OUT of `all`/`ci` to avoid double-scanning — matching the 13 consumer repos' pattern.
- **`.github/workflows/self-release.yml`** = `workflow_dispatch` caller (version + dry_run) of `auto-release.yml@main`, forwarding the ci-read + pre-release App secrets — same pattern as the 13 consumer callers.

## Follow-up (after merge)
Cut meta patch release via Self-Release (dry_run first, then `v0.2.5.5`). Real release needs the pre-release App in meta's main/dev ruleset `bypass_actors`.

Refs TMDs#239.

Closes #243
