### PR TITLE
release: promote dev to main (bootstrap auto-release + atom/template changes)

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -40,7 +40,7 @@
 #       # CI_READ_APP_CLIENT_ID / PRE_RELEASE_APP_CLIENT_ID org variables, which are
 #       # auto-available in reusable workflows — no passing needed.
 
-name: auto-release
+name: Auto-Release
 
 on:
   workflow_call:

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -111,8 +111,8 @@ jobs:
       # secrets cannot be referenced in step-level if:, so bridge to env here.
       HAS_CI_APP: ${{ vars.CI_READ_APP_CLIENT_ID != '' && secrets.ci_read_app_private_key != '' }}
       # Pass github.repository via env (not ${{ }} inline in run:) — keeps it out of
-      # the shell script body so CodeQL's actions-injection rule stays clean. gh also
-      # reads GH_REPO natively, but we reference $REPO explicitly in API paths.
+      # the shell script body so CodeQL's actions-injection rule stays clean. We
+      # reference $GH_REPO in the gh API paths; gh also reads GH_REPO natively.
       GH_REPO: ${{ github.repository }}
     steps:
       # Fail fast if the runner lacks the GitHub CLI: every API/release step below

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -22,7 +22,6 @@
 #         dry_run:    { description: "Validate only", required: false, type: boolean, default: false }
 #   permissions:
 #     contents: write
-#     pull-requests: read
 #   jobs:
 #     auto-release:
 #       uses: nics-dp/meta/.github/workflows/auto-release.yml@main
@@ -81,7 +80,6 @@ concurrency:
 
 permissions:
   contents: write # GITHUB_TOKEN creates the release/<version> or ci/release/<version> snapshot (unprotected)
-  pull-requests: read
 
 jobs:
   release:
@@ -335,7 +333,11 @@ jobs:
       # self-hosted runner's global git config across jobs. always() = runs even if a
       # step above failed. Paired with the self-healing cleanup in "Configure git".
       - name: Revoke private module git config
-        if: ${{ always() && steps.ci-read.outputs.token != '' }}
+        # Unconditional (always, not gated on this run minting a token): on a self-hosted
+        # runner a prior interrupted run may have left a token-bearing section behind, and
+        # a run that mints no token would otherwise never clean it. The regex removal needs
+        # no token, so sweeping every time is safe (a no-op on ephemeral runners).
+        if: ${{ always() }}
         run: |
           # Remove every url.*@github.com/nics-dp insteadOf section (both the trailing-
           # slash and no-slash variants, regardless of token) so nothing token-bearing

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -96,6 +96,12 @@ jobs:
   release:
     name: auto-release ${{ inputs.version }}${{ inputs.dry_run && ' (dry-run)' || '' }}
     runs-on: ${{ fromJSON(inputs.runs_on) }}
+    # This driver targets Linux runners (ubuntu-latest, or a Linux self-hosted group
+    # via runs_on); every run: step uses POSIX/bash. Pin bash so a runner whose default
+    # shell differs still works. Full cross-OS (Windows) is not a goal.
+    defaults:
+      run:
+        shell: bash
     env:
       VERSION: ${{ inputs.version }}
       DRY_RUN: ${{ inputs.dry_run }}
@@ -203,6 +209,10 @@ jobs:
           ref: ${{ env.TARGET_BRANCH }}
           fetch-depth: ${{ inputs.fetch-depth }}
           token: ${{ github.token }}
+          # Don't leave the token in .git/config — `mise run all` runs repo code after
+          # this, and private fetches use the ci-read insteadOf rewrite below, not the
+          # checkout credential. Matches the repo convention (go-release/image-release/…).
+          persist-credentials: false
           # No submodules here: github.token can't read private sibling repos.
           # mise run all's gs:clone (if any) fetches them via the insteadOf rewrite below.
 

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -115,6 +115,18 @@ jobs:
       # reads GH_REPO natively, but we reference $REPO explicitly in API paths.
       GH_REPO: ${{ github.repository }}
     steps:
+      # Fail fast if the runner lacks the GitHub CLI: every API/release step below
+      # shells out to `gh`. ubuntu-latest ships it, but a self-hosted runs_on group
+      # might not — without this the workflow would die mid-release with an obscure
+      # "gh: command not found" instead of a clear preflight error.
+      - name: Preflight — require gh
+        shell: bash
+        run: |
+          command -v gh >/dev/null 2>&1 || {
+            echo "::error::GitHub CLI (gh) is not installed on this runner — auto-release requires it."
+            exit 1
+          }
+
       - name: Validate version format
         shell: bash
         run: |

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -136,6 +136,9 @@ jobs:
         run: |
           # Use the API (not git ls-remote): this step runs before any checkout, so
           # there is no local repo / "origin" remote to query.
+          # NOTE: git/ref/<ref> (singular) is the "get a single reference" endpoint —
+          # 200 if the exact tag exists, 404 if not — which is exactly what an existence
+          # check needs. It is NOT a typo for the plural git/refs/ (list) endpoint.
           if gh api "repos/${GH_REPO}/git/ref/tags/${VERSION}" >/dev/null 2>&1; then
             echo "::error::Tag ${VERSION} already exists — refusing to re-release."
             exit 1

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -345,7 +345,11 @@ jobs:
       # step above failed. Paired with the self-healing cleanup in "Configure git".
       - name: Revoke private module git config
         if: ${{ always() && steps.ci-read.outputs.token != '' }}
-        env:
-          APP_TOKEN: ${{ steps.ci-read.outputs.token }}
         run: |
-          git config --global --remove-section "url.https://x-access-token:${APP_TOKEN}@github.com/nics-dp/" 2>/dev/null || true
+          # Remove every url.*@github.com/nics-dp insteadOf section (both the trailing-
+          # slash and no-slash variants, regardless of token) so nothing token-bearing
+          # persists in a self-hosted runner's global git config. Same matcher as the
+          # setup self-heal — more thorough than removing only the section we wrote.
+          while read -r s; do
+            if [ -n "$s" ]; then git config --global --remove-section "$s" 2>/dev/null || true; fi
+          done < <(git config --global --name-only --get-regexp '^url\..*@github\.com/nics-dp' 2>/dev/null | sed -E 's/\.insteadof$//' | sort -u || true)

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -213,8 +213,9 @@ jobs:
         env:
           APP_TOKEN: ${{ steps.ci-read.outputs.token }}
         run: |
-          git config --global user.name "github-actions[bot]"
-          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          # No git user.name/email here: this workflow never makes a local commit (the
+          # merge is server-side via the REST API), and writing them with --global would
+          # clobber a self-hosted runner's identity across jobs. Matches go-release.yml.
           # Self-healing: drop any stale token-bearing url.*@github.com/nics-dp insteadOf
           # rewrites left by a prior run on a self-hosted runner (global git config can
           # persist across jobs) so we never pick up an expired token. Paired with the

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -1,0 +1,308 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+# Reusable workflow: one-shot release driver (no PR, no approval).
+#
+# Validates dev, snapshots it, merges to main, tags, and creates the GitHub
+# Release — which triggers the repo's release.yml to build/publish. main writes
+# use a release App that must be in the main/dev ruleset bypass_actors.
+#
+# LANGUAGE-AGNOSTIC: there is no actions/setup-go here. The toolchain (go,
+# python, node, uv, …) comes entirely from the repo's mise.toml [tools] via
+# jdx/mise-action, and the build/test/scan is just `mise run all`. The same
+# driver therefore serves go-service / go-lib / go-cli / frontend / python /
+# image repos unchanged — each repo's mise.toml decides what `all` does.
+#
+# dry_run=true: validate only against ci/release/<version>; skip merge/tag/release.
+# use_github_token=true: use the built-in GITHUB_TOKEN (not the release App) for the
+#   main push/tag/release — for test repos without the App configured or where main
+#   is unprotected. NOTE: a Release created by GITHUB_TOKEN does NOT trigger other
+#   workflows, so downstream release.yml won't fire in that mode.
+#
+# Usage in downstream `.github/workflows/auto-release.yml`:
+#   name: Auto-Release
+#   on:
+#     workflow_dispatch:
+#       inputs:
+#         version:    { description: "Release version (e.g. v0.3.0)", required: true, type: string }
+#         dry_run:    { description: "Validate only", required: false, type: boolean, default: false }
+#   permissions:
+#     contents: write
+#     pull-requests: read
+#   jobs:
+#     auto-release:
+#       uses: nics-dp/meta/.github/workflows/auto-release.yml@main
+#       with:
+#         version: ${{ inputs.version }}
+#         dry_run: ${{ inputs.dry_run }}
+#       secrets:
+#         ci_read_app_private_key:     ${{ secrets.CI_READ_APP_PRIVATE_KEY }}
+#         pre_release_app_private_key: ${{ secrets.PRE_RELEASE_APP_PRIVATE_KEY }}
+#       # (`secrets: inherit` also works.) client-ids are read from the
+#       # CI_READ_APP_CLIENT_ID / PRE_RELEASE_APP_CLIENT_ID org variables, which are
+#       # auto-available in reusable workflows — no passing needed.
+
+name: auto-release
+
+on:
+  workflow_call:
+    inputs:
+      version:
+        description: "Release version (e.g. v0.3.0); v<major>.<minor>.<patch>[.<hotfix>]"
+        required: true
+        type: string
+      dry_run:
+        description: "Validate only — skip merge/tag/release; use ci/release/<version> snapshot"
+        required: false
+        default: false
+        type: boolean
+      use_github_token:
+        description: "Use built-in GITHUB_TOKEN for main push/tag/release instead of the release App (test repos)"
+        required: false
+        default: false
+        type: boolean
+      runs_on:
+        description: 'Runner as JSON (e.g. ''"ubuntu-latest"'' or ''{"group":"releasers"}'')'
+        required: false
+        default: '"ubuntu-latest"'
+        type: string
+      fetch_depth:
+        description: "Git fetch depth for the snapshot checkout (0 = full history; needed by ci:trufflehog/betterleaks)"
+        required: false
+        default: 0
+        type: number
+      mise_version:
+        description: "Pinned mise version (kept in lockstep with mise-task.yml)"
+        required: false
+        default: "2026.6.14"
+        type: string
+    secrets:
+      ci_read_app_private_key:
+        required: false
+        description: "Private key of the nics-dp-ci-read App (paired with the CI_READ_APP_CLIENT_ID org variable). Used for private module/submodule fetch during `mise run all`."
+      pre_release_app_private_key:
+        required: false
+        description: "Private key of the release App (paired with the PRE_RELEASE_APP_CLIENT_ID org variable). Must be a main/dev ruleset bypass_actor. Only needed for real (non-dry-run) releases."
+
+# No concurrent releases: workflow-wide group, never cancel an in-flight
+# merge/tag/release. Same-version re-release is blocked by the duplicate-tag guard.
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+permissions:
+  contents: write # GITHUB_TOKEN creates the release/<version> or ci/release/<version> snapshot (unprotected)
+  pull-requests: read
+
+jobs:
+  release:
+    name: auto-release ${{ inputs.version }}${{ inputs.dry_run && ' (dry-run)' || '' }}
+    runs-on: ${{ fromJSON(inputs.runs_on) }}
+    env:
+      VERSION: ${{ inputs.version }}
+      DRY_RUN: ${{ inputs.dry_run }}
+      # mise's minimum_release_age supply-chain control is forwarded to the pipx
+      # backend as a pip-only flag that the uv-backed pipx installer rejects,
+      # breaking tool installs (e.g. semgrep). "0" disables that injection and
+      # requires mise >= 2026.6.3 (see mise_version input / mise-task.yml).
+      MISE_MINIMUM_RELEASE_AGE: "0"
+      # Harmless on non-Go repos; needed for private go-module fetch during build.
+      GOPRIVATE: github.com/nics-dp
+      GONOSUMDB: github.com/nics-dp
+      GONOPROXY: github.com/nics-dp
+      # secrets cannot be referenced in step-level if:, so bridge to env here.
+      HAS_CI_APP: ${{ vars.CI_READ_APP_CLIENT_ID != '' && secrets.ci_read_app_private_key != '' }}
+    steps:
+      - name: Validate version format
+        shell: bash
+        run: |
+          if [[ ! "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(\.[0-9]+)?$ ]]; then
+            echo "::error::Invalid version format: '$VERSION'. Expected: v<major>.<minor>.<patch>[.<hotfix>]"
+            exit 1
+          fi
+
+      - name: Duplicate-tag guard
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # Use the API (not git ls-remote): this step runs before any checkout, so
+          # there is no local repo / "origin" remote to query.
+          if gh api "repos/${{ github.repository }}/git/ref/tags/${VERSION}" >/dev/null 2>&1; then
+            echo "::error::Tag ${VERSION} already exists — refusing to re-release."
+            exit 1
+          fi
+          echo "No existing tag ${VERSION}."
+
+      - name: Resolve target branch
+        run: |
+          if [ "${DRY_RUN}" = "true" ]; then
+            echo "TARGET_BRANCH=ci/release/${VERSION}" >> "$GITHUB_ENV"
+          else
+            echo "TARGET_BRANCH=release/${VERSION}" >> "$GITHUB_ENV"
+          fi
+
+      # Read token for private module/submodule fetch during validation.
+      - name: Mint CI-read app token
+        id: ci-read
+        if: ${{ env.HAS_CI_APP == 'true' }}
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ vars.CI_READ_APP_CLIENT_ID }}
+          private-key: ${{ secrets.ci_read_app_private_key }}
+          owner: ${{ github.repository_owner }}
+
+      # Write token for main push + tag + release. Member of the main/dev ruleset
+      # bypass_actors. Skipped on dry-run and when use_github_token=true.
+      - name: Mint release app token
+        id: release-app
+        if: ${{ !inputs.dry_run && !inputs.use_github_token }}
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ vars.PRE_RELEASE_APP_CLIENT_ID }}
+          private-key: ${{ secrets.pre_release_app_private_key }}
+          owner: ${{ github.repository_owner }}
+
+      # Snapshot the exact dev commit being released into TARGET_BRANCH (unprotected
+      # namespace; release/* and ci/release/* are not in the main/dev ruleset).
+      # GITHUB_TOKEN (contents: write) suffices. Idempotent.
+      # NOTE on partial-failure recovery: a real run that fails AFTER "Merge to main"
+      # but before the release is created leaves main advanced without a release.
+      # Recovery is manual (create the release for the merged commit, or revert).
+      - name: Create snapshot branch from dev
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          sha="$(gh api "repos/${{ github.repository }}/git/refs/heads/dev" --jq .object.sha)"
+          if gh api "repos/${{ github.repository }}/git/refs/heads/${TARGET_BRANCH}" >/dev/null 2>&1; then
+            gh api -X PATCH "repos/${{ github.repository }}/git/refs/heads/${TARGET_BRANCH}" \
+              -f "sha=${sha}" -F force=true
+            echo "Reset ${TARGET_BRANCH} to dev@${sha}."
+          else
+            gh api "repos/${{ github.repository }}/git/refs" \
+              -f "ref=refs/heads/${TARGET_BRANCH}" -f "sha=${sha}"
+            echo "Created ${TARGET_BRANCH} from dev@${sha}."
+          fi
+
+      - name: Checkout snapshot branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ env.TARGET_BRANCH }}
+          fetch-depth: ${{ inputs.fetch_depth }}
+          token: ${{ github.token }}
+          # No submodules here: github.token can't read private sibling repos.
+          # mise run all's gs:clone (if any) fetches them via the insteadOf rewrite below.
+
+      - name: Configure git (private module auth)
+        if: ${{ steps.ci-read.outputs.token != '' }}
+        env:
+          APP_TOKEN: ${{ steps.ci-read.outputs.token }}
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          # insteadOf is multi-valued — the second line MUST use --add or it overwrites
+          # the first, breaking https go-module fetch (could not read Username).
+          git config --global url."https://x-access-token:${APP_TOKEN}@github.com/nics-dp/".insteadOf "https://github.com/nics-dp/"
+          git config --global --add url."https://x-access-token:${APP_TOKEN}@github.com/nics-dp/".insteadOf "git@github.com:nics-dp/"
+
+      # Toolchain comes from the repo's mise.toml [tools] — no per-language setup step.
+      - name: Set up mise
+        uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
+        with:
+          version: ${{ inputs.mise_version }}
+          cache: true
+          experimental: true
+
+      # Full release validation: init (deps/submodules/vendor) -> generate -> api-fix
+      # -> build -> test -> ci, exactly as the repo defines `all`. Does NOT bump deps;
+      # trusts dev's lockfile/go.mod.
+      - name: Run mise run all
+        run: mise run all
+
+      # The build must not change committed code (generate/api-fix/lint-fix produce
+      # no diff), so the published artifact faithfully reflects dev.
+      - name: Verify no working-tree drift
+        run: |
+          if ! git diff --quiet; then
+            echo "::error::mise run all modified tracked files — branch is not canonical."
+            git --no-pager diff --stat
+            exit 1
+          fi
+          echo "No drift — committed code is canonical."
+
+      - name: License scan
+        run: mise run ci:trivy-license
+
+      - name: Secret scan
+        run: mise run ci:betterleaks
+
+      - name: Deep secret scan
+        run: mise run ci:trufflehog
+
+      # TOCTOU mitigation: the duplicate-tag guard ran before the (long) validation,
+      # so a same-name tag/release could have appeared meanwhile. Re-check right
+      # before mutating main — shrinks the race window to this tiny gap.
+      - name: Re-check tag before merge
+        if: ${{ !inputs.dry_run }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if gh api "repos/${{ github.repository }}/git/ref/tags/${VERSION}" >/dev/null 2>&1; then
+            echo "::error::Tag ${VERSION} appeared during validation — aborting before touching main."
+            exit 1
+          fi
+          echo "Tag ${VERSION} still absent — proceeding to merge."
+
+      # Real runs only. Merge the validated snapshot into main via the REST Merges API
+      # (server-side merge), NOT a local `git push`:
+      #   1. Verified signatures: API-created commits are signed by GitHub (we omit
+      #      author/committer), satisfying the required_signatures rule genuinely.
+      #   2. Sidesteps the actions/checkout persisted GITHUB_TOKEN extraheader that
+      #      would otherwise hijack a local push to authenticate as github-actions[bot].
+      # The actor is the release App (in main/dev ruleset bypass_actors), so PR/CodeQL/
+      # signature rules are bypassed. use_github_token=true falls back to GITHUB_TOKEN.
+      - name: Merge to main
+        if: ${{ !inputs.dry_run }}
+        env:
+          GH_TOKEN: ${{ inputs.use_github_token && github.token || steps.release-app.outputs.token }}
+        run: |
+          # Don't read this call's body: 201 (merge created) and 204 (main already up to
+          # date) are both 2xx -> exit 0, while 409/403 are non-2xx -> gh exits non-zero
+          # -> step hard-fails under `bash -e`. Avoid --jq here (204 empty body would error).
+          gh api "repos/${{ github.repository }}/merges" \
+            -f base=main \
+            -f head="${TARGET_BRANCH}" \
+            -f commit_message="release: merge ${TARGET_BRANCH} into main for ${VERSION}" >/dev/null
+          MAIN_SHA="$(gh api "repos/${{ github.repository }}/git/refs/heads/main" --jq '.object.sha')"
+          echo "MAIN_SHA=${MAIN_SHA}" >> "$GITHUB_ENV"
+
+      # Real runs only. gh release create makes the tag AND the Release in one step;
+      # created by the release App (non-GITHUB_TOKEN) so release.yml's
+      # `release: created` trigger fires -> build/publish.
+      - name: Tag and create GitHub Release
+        if: ${{ !inputs.dry_run }}
+        env:
+          GH_TOKEN: ${{ inputs.use_github_token && github.token || steps.release-app.outputs.token }}
+        run: |
+          if [ -z "${MAIN_SHA}" ]; then
+            echo "::error::MAIN_SHA is empty — the Merge to main step did not complete."
+            exit 1
+          fi
+          gh release create "${VERSION}" \
+            --target "${MAIN_SHA}" \
+            --title "${VERSION}" \
+            --notes "Automated release ${VERSION} (merged ${TARGET_BRANCH} → main). Build/publish runs via release.yml."
+          echo "Created tag + release ${VERSION} at ${MAIN_SHA}."
+
+      - name: Summary
+        if: success()
+        run: |
+          {
+            echo "## auto-release — ${VERSION}"
+            echo
+            echo "✅ Validation passed for \`${TARGET_BRANCH}\`."
+            echo
+            if [ "${DRY_RUN}" = "true" ]; then
+              echo "> Dry-run: no merge, no tag, no release. main untouched, release.yml not triggered."
+            else
+              echo "Merged \`${TARGET_BRANCH}\` → \`main\`, tagged \`${VERSION}\`, created the Release."
+              echo "Build/publish is running via \`release.yml\` (triggered by the release)."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -189,7 +189,7 @@ jobs:
               -f "sha=${sha}" -F force=true
             echo "Reset ${TARGET_BRANCH} to dev@${sha}."
           else
-            gh api "repos/${GH_REPO}/git/refs" \
+            gh api -X POST "repos/${GH_REPO}/git/refs" \
               -f "ref=refs/heads/${TARGET_BRANCH}" -f "sha=${sha}"
             echo "Created ${TARGET_BRANCH} from dev@${sha}."
           fi
@@ -290,7 +290,7 @@ jobs:
           # Don't read this call's body: 201 (merge created) and 204 (main already up to
           # date) are both 2xx -> exit 0, while 409/403 are non-2xx -> gh exits non-zero
           # -> step hard-fails under `bash -e`. Avoid --jq here (204 empty body would error).
-          gh api "repos/${GH_REPO}/merges" \
+          gh api -X POST "repos/${GH_REPO}/merges" \
             -f base=main \
             -f head="${TARGET_BRANCH}" \
             -f commit_message="release: merge ${TARGET_BRANCH} into main for ${VERSION}" >/dev/null

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -64,7 +64,7 @@ on:
         required: false
         default: '"ubuntu-latest"'
         type: string
-      fetch_depth:
+      fetch-depth:
         description: "Git fetch depth for the snapshot checkout (0 = full history; needed by ci:trufflehog/betterleaks)"
         required: false
         default: 0
@@ -110,6 +110,10 @@ jobs:
       GONOPROXY: github.com/nics-dp
       # secrets cannot be referenced in step-level if:, so bridge to env here.
       HAS_CI_APP: ${{ vars.CI_READ_APP_CLIENT_ID != '' && secrets.ci_read_app_private_key != '' }}
+      # Pass github.repository via env (not ${{ }} inline in run:) — keeps it out of
+      # the shell script body so CodeQL's actions-injection rule stays clean. gh also
+      # reads GH_REPO natively, but we reference $REPO explicitly in API paths.
+      GH_REPO: ${{ github.repository }}
     steps:
       - name: Validate version format
         shell: bash
@@ -125,7 +129,7 @@ jobs:
         run: |
           # Use the API (not git ls-remote): this step runs before any checkout, so
           # there is no local repo / "origin" remote to query.
-          if gh api "repos/${{ github.repository }}/git/ref/tags/${VERSION}" >/dev/null 2>&1; then
+          if gh api "repos/${GH_REPO}/git/ref/tags/${VERSION}" >/dev/null 2>&1; then
             echo "::error::Tag ${VERSION} already exists — refusing to re-release."
             exit 1
           fi
@@ -170,22 +174,22 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          sha="$(gh api "repos/${{ github.repository }}/git/refs/heads/dev" --jq .object.sha)"
-          if gh api "repos/${{ github.repository }}/git/refs/heads/${TARGET_BRANCH}" >/dev/null 2>&1; then
-            gh api -X PATCH "repos/${{ github.repository }}/git/refs/heads/${TARGET_BRANCH}" \
+          sha="$(gh api "repos/${GH_REPO}/git/refs/heads/dev" --jq .object.sha)"
+          if gh api "repos/${GH_REPO}/git/refs/heads/${TARGET_BRANCH}" >/dev/null 2>&1; then
+            gh api -X PATCH "repos/${GH_REPO}/git/refs/heads/${TARGET_BRANCH}" \
               -f "sha=${sha}" -F force=true
             echo "Reset ${TARGET_BRANCH} to dev@${sha}."
           else
-            gh api "repos/${{ github.repository }}/git/refs" \
+            gh api "repos/${GH_REPO}/git/refs" \
               -f "ref=refs/heads/${TARGET_BRANCH}" -f "sha=${sha}"
             echo "Created ${TARGET_BRANCH} from dev@${sha}."
           fi
 
       - name: Checkout snapshot branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ env.TARGET_BRANCH }}
-          fetch-depth: ${{ inputs.fetch_depth }}
+          fetch-depth: ${{ inputs.fetch-depth }}
           token: ${{ github.token }}
           # No submodules here: github.token can't read private sibling repos.
           # mise run all's gs:clone (if any) fetches them via the insteadOf rewrite below.
@@ -244,7 +248,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          if gh api "repos/${{ github.repository }}/git/ref/tags/${VERSION}" >/dev/null 2>&1; then
+          if gh api "repos/${GH_REPO}/git/ref/tags/${VERSION}" >/dev/null 2>&1; then
             echo "::error::Tag ${VERSION} appeared during validation — aborting before touching main."
             exit 1
           fi
@@ -266,11 +270,11 @@ jobs:
           # Don't read this call's body: 201 (merge created) and 204 (main already up to
           # date) are both 2xx -> exit 0, while 409/403 are non-2xx -> gh exits non-zero
           # -> step hard-fails under `bash -e`. Avoid --jq here (204 empty body would error).
-          gh api "repos/${{ github.repository }}/merges" \
+          gh api "repos/${GH_REPO}/merges" \
             -f base=main \
             -f head="${TARGET_BRANCH}" \
             -f commit_message="release: merge ${TARGET_BRANCH} into main for ${VERSION}" >/dev/null
-          MAIN_SHA="$(gh api "repos/${{ github.repository }}/git/refs/heads/main" --jq '.object.sha')"
+          MAIN_SHA="$(gh api "repos/${GH_REPO}/git/refs/heads/main" --jq '.object.sha')"
           echo "MAIN_SHA=${MAIN_SHA}" >> "$GITHUB_ENV"
 
       # Real runs only. gh release create makes the tag AND the Release in one step;

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -223,6 +223,13 @@ jobs:
         run: |
           git config --global user.name "github-actions[bot]"
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          # Self-healing: drop any stale token-bearing url.*@github.com/nics-dp insteadOf
+          # rewrites left by a prior run on a self-hosted runner (global git config can
+          # persist across jobs) so we never pick up an expired token. Paired with the
+          # always() teardown step at the end. Mirrors go-release.yml.
+          while read -r s; do
+            if [ -n "$s" ]; then git config --global --remove-section "$s" 2>/dev/null || true; fi
+          done < <(git config --global --name-only --get-regexp '^url\..*@github\.com/nics-dp' 2>/dev/null | sed -E 's/\.insteadof$//' | sort -u || true)
           # insteadOf is multi-valued — the second line MUST use --add or it overwrites
           # the first, breaking https go-module fetch (could not read Username).
           git config --global url."https://x-access-token:${APP_TOKEN}@github.com/nics-dp/".insteadOf "https://github.com/nics-dp/"
@@ -332,3 +339,13 @@ jobs:
               echo "Build/publish is running via \`release.yml\` (triggered by the release)."
             fi
           } >> "$GITHUB_STEP_SUMMARY"
+
+      # Teardown: remove the token-bearing insteadOf rewrite so it can't persist in a
+      # self-hosted runner's global git config across jobs. always() = runs even if a
+      # step above failed. Paired with the self-healing cleanup in "Configure git".
+      - name: Revoke private module git config
+        if: ${{ always() && steps.ci-read.outputs.token != '' }}
+        env:
+          APP_TOKEN: ${{ steps.ci-read.outputs.token }}
+        run: |
+          git config --global --remove-section "url.https://x-access-token:${APP_TOKEN}@github.com/nics-dp/" 2>/dev/null || true

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -141,11 +141,18 @@ jobs:
           # NOTE: git/ref/<ref> (singular) is the "get a single reference" endpoint —
           # 200 if the exact tag exists, 404 if not — which is exactly what an existence
           # check needs. It is NOT a typo for the plural git/refs/ (list) endpoint.
-          if gh api "repos/${GH_REPO}/git/ref/tags/${VERSION}" >/dev/null 2>&1; then
+          # Distinguish 200 (exists → abort) from 404 (absent → proceed) from any other
+          # error (403/5xx/network/rate-limit). A bare `if gh api …; then` would treat
+          # every non-2xx as "absent" and let the release proceed to mutate main on a
+          # transient failure. Capture stderr; only a clean "(HTTP 404)" is safe to pass.
+          if err="$(gh api "repos/${GH_REPO}/git/ref/tags/${VERSION}" 2>&1 >/dev/null)"; then
             echo "::error::Tag ${VERSION} already exists — refusing to re-release."
             exit 1
           fi
-          echo "No existing tag ${VERSION}."
+          case "$err" in
+            *"HTTP 404"*) echo "No existing tag ${VERSION}." ;;
+            *) echo "::error::tag existence check failed (not a 404, refusing to proceed): ${err}"; exit 1 ;;
+          esac
 
       - name: Resolve target branch
         run: |
@@ -278,11 +285,17 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          if gh api "repos/${GH_REPO}/git/ref/tags/${VERSION}" >/dev/null 2>&1; then
+          # Same 200/404/other tri-state as the duplicate-tag guard: a transient API
+          # error must NOT be read as "tag absent" here — that would forfeit this
+          # TOCTOU re-check's whole purpose right before main is mutated.
+          if err="$(gh api "repos/${GH_REPO}/git/ref/tags/${VERSION}" 2>&1 >/dev/null)"; then
             echo "::error::Tag ${VERSION} appeared during validation — aborting before touching main."
             exit 1
           fi
-          echo "Tag ${VERSION} still absent — proceeding to merge."
+          case "$err" in
+            *"HTTP 404"*) echo "Tag ${VERSION} still absent — proceeding to merge." ;;
+            *) echo "::error::tag re-check failed (not a 404, refusing to touch main): ${err}"; exit 1 ;;
+          esac
 
       # Real runs only. Merge the validated snapshot into main via the REST Merges API
       # (server-side merge), NOT a local `git push`:

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -114,13 +114,15 @@ jobs:
       # shells out to `gh`. ubuntu-latest ships it, but a self-hosted runs_on group
       # might not — without this the workflow would die mid-release with an obscure
       # "gh: command not found" instead of a clear preflight error.
-      - name: Preflight — require gh
+      - name: Preflight — require gh and jq
         shell: bash
         run: |
-          command -v gh >/dev/null 2>&1 || {
-            echo "::error::GitHub CLI (gh) is not installed on this runner — auto-release requires it."
-            exit 1
-          }
+          for tool in gh jq; do
+            command -v "$tool" >/dev/null 2>&1 || {
+              echo "::error::'$tool' is not installed on this runner — auto-release requires it."
+              exit 1
+            }
+          done
 
       - name: Validate version format
         shell: bash
@@ -289,14 +291,22 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.release-app.outputs.token }}
         run: |
-          # Don't read this call's body: 201 (merge created) and 204 (main already up to
-          # date) are both 2xx -> exit 0, while 409/403 are non-2xx -> gh exits non-zero
-          # -> step hard-fails under `bash -e`. Avoid --jq here (204 empty body would error).
-          gh api -X POST "repos/${GH_REPO}/merges" \
+          # Capture the response so the tag points at the EXACT merge commit rather than a
+          # re-read of main (which could in principle race a concurrent advance — though the
+          # workflow concurrency group plus the main ruleset, where only this App can push
+          # main, already close that window). A plain assignment propagates gh's exit under
+          # `set -e`, so a 409 conflict / 403 rule violation still hard-fails here. 201
+          # returns the merge commit JSON; 204 (main already contains TARGET_BRANCH) is empty.
+          merge_resp="$(gh api -X POST "repos/${GH_REPO}/merges" \
             -f base=main \
             -f head="${TARGET_BRANCH}" \
-            -f commit_message="release: merge ${TARGET_BRANCH} into main for ${VERSION}" >/dev/null
-          MAIN_SHA="$(gh api "repos/${GH_REPO}/git/refs/heads/main" --jq '.object.sha')"
+            -f commit_message="release: merge ${TARGET_BRANCH} into main for ${VERSION}")"
+          if [ -n "${merge_resp}" ]; then
+            MAIN_SHA="$(printf '%s' "${merge_resp}" | jq -r '.sha')" # the new merge commit
+          else
+            # 204: main already contains the validated snapshot; tag its current tip.
+            MAIN_SHA="$(gh api "repos/${GH_REPO}/git/ref/heads/main" --jq '.object.sha')"
+          fi
           echo "MAIN_SHA=${MAIN_SHA}" >> "$GITHUB_ENV"
 
       # Real runs only. gh release create makes the tag AND the Release in one step;

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -94,7 +94,7 @@ permissions:
 
 jobs:
   release:
-    name: auto-release ${{ inputs.version }}${{ inputs.dry_run && ' (dry-run)' || '' }}
+    name: Auto-Release ${{ inputs.version }}${{ inputs.dry_run && ' (dry-run)' || '' }}
     runs-on: ${{ fromJSON(inputs.runs_on) }}
     # This driver targets Linux runners (ubuntu-latest, or a Linux self-hosted group
     # via runs_on); every run: step uses POSIX/bash. Pin bash so a runner whose default

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -304,8 +304,12 @@ jobs:
           if [ -n "${merge_resp}" ]; then
             MAIN_SHA="$(printf '%s' "${merge_resp}" | jq -r '.sha')" # the new merge commit
           else
-            # 204: main already contains the validated snapshot; tag its current tip.
-            MAIN_SHA="$(gh api "repos/${GH_REPO}/git/ref/heads/main" --jq '.object.sha')"
+            # 204: main already contains the validated snapshot. Tag the snapshot commit
+            # itself (TARGET_BRANCH) rather than main's tip — main may have advanced past
+            # the snapshot (e.g. a hotfix merged straight to main), and the release must
+            # point at the commit this run actually validated. It is reachable from main
+            # (the 204 guarantees main contains it), so the tag is valid.
+            MAIN_SHA="$(gh api "repos/${GH_REPO}/git/ref/heads/${TARGET_BRANCH}" --jq '.object.sha')"
           fi
           echo "MAIN_SHA=${MAIN_SHA}" >> "$GITHUB_ENV"
 

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -12,10 +12,6 @@
 # image repos unchanged — each repo's mise.toml decides what `all` does.
 #
 # dry_run=true: validate only against ci/release/<version>; skip merge/tag/release.
-# use_github_token=true: use the built-in GITHUB_TOKEN (not the release App) for the
-#   main push/tag/release — for test repos without the App configured or where main
-#   is unprotected. NOTE: a Release created by GITHUB_TOKEN does NOT trigger other
-#   workflows, so downstream release.yml won't fire in that mode.
 #
 # Usage in downstream `.github/workflows/auto-release.yml`:
 #   name: Auto-Release
@@ -51,11 +47,6 @@ on:
         type: string
       dry_run:
         description: "Validate only — skip merge/tag/release; use ci/release/<version> snapshot"
-        required: false
-        default: false
-        type: boolean
-      use_github_token:
-        description: "Use built-in GITHUB_TOKEN for main push/tag/release instead of the release App (test repos)"
         required: false
         default: false
         type: boolean
@@ -172,10 +163,10 @@ jobs:
           owner: ${{ github.repository_owner }}
 
       # Write token for main push + tag + release. Member of the main/dev ruleset
-      # bypass_actors. Skipped on dry-run and when use_github_token=true.
+      # bypass_actors. Skipped on dry-run.
       - name: Mint release app token
         id: release-app
-        if: ${{ !inputs.dry_run && !inputs.use_github_token }}
+        if: ${{ !inputs.dry_run }}
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           client-id: ${{ vars.PRE_RELEASE_APP_CLIENT_ID }}
@@ -290,11 +281,11 @@ jobs:
       #   2. Sidesteps the actions/checkout persisted GITHUB_TOKEN extraheader that
       #      would otherwise hijack a local push to authenticate as github-actions[bot].
       # The actor is the release App (in main/dev ruleset bypass_actors), so PR/CodeQL/
-      # signature rules are bypassed. use_github_token=true falls back to GITHUB_TOKEN.
+      # signature rules are bypassed.
       - name: Merge to main
         if: ${{ !inputs.dry_run }}
         env:
-          GH_TOKEN: ${{ inputs.use_github_token && github.token || steps.release-app.outputs.token }}
+          GH_TOKEN: ${{ steps.release-app.outputs.token }}
         run: |
           # Don't read this call's body: 201 (merge created) and 204 (main already up to
           # date) are both 2xx -> exit 0, while 409/403 are non-2xx -> gh exits non-zero
@@ -312,7 +303,7 @@ jobs:
       - name: Tag and create GitHub Release
         if: ${{ !inputs.dry_run }}
         env:
-          GH_TOKEN: ${{ inputs.use_github_token && github.token || steps.release-app.outputs.token }}
+          GH_TOKEN: ${{ steps.release-app.outputs.token }}
         run: |
           if [ -z "${MAIN_SHA}" ]; then
             echo "::error::MAIN_SHA is empty — the Merge to main step did not complete."

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -186,8 +186,11 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          sha="$(gh api "repos/${GH_REPO}/git/refs/heads/dev" --jq .object.sha)"
-          if gh api "repos/${GH_REPO}/git/refs/heads/${TARGET_BRANCH}" >/dev/null 2>&1; then
+          # Use singular git/ref/<ref> (exact "get a single reference", 404 if absent),
+          # not plural git/refs/<ref> which prefix-matches and would return an array
+          # for a longer sibling (e.g. heads/release/v0.3.0 matching release/v0.3.0.1).
+          sha="$(gh api "repos/${GH_REPO}/git/ref/heads/dev" --jq .object.sha)"
+          if gh api "repos/${GH_REPO}/git/ref/heads/${TARGET_BRANCH}" >/dev/null 2>&1; then
             gh api -X PATCH "repos/${GH_REPO}/git/refs/heads/${TARGET_BRANCH}" \
               -f "sha=${sha}" -F force=true
             echo "Reset ${TARGET_BRANCH} to dev@${sha}."
@@ -248,9 +251,12 @@ jobs:
       # no diff), so the published artifact faithfully reflects dev.
       - name: Verify no working-tree drift
         run: |
-          if ! git diff --quiet; then
-            echo "::error::mise run all modified tracked files — branch is not canonical."
-            git --no-pager diff --stat
+          # git status --porcelain (not git diff --quiet): the latter only sees tracked
+          # modifications, missing NEW untracked files a generate step may emit — which
+          # would mean the published artifact carries a file absent from the commit.
+          if [ -n "$(git status --porcelain)" ]; then
+            echo "::error::mise run all changed the working tree (modified or new files) — branch is not canonical."
+            git status --porcelain
             exit 1
           fi
           echo "No drift — committed code is canonical."

--- a/.github/workflows/self-release.yml
+++ b/.github/workflows/self-release.yml
@@ -1,0 +1,33 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+# meta dogfoods its own reusable auto-release driver. This self-caller lets meta
+# cut its own patch release (snapshot dev -> `mise run all` validate -> merge to
+# main -> tag -> GitHub Release) the same way consumer repos do.
+name: Self-Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Release version (e.g. v0.2.5.5)"
+        required: true
+        type: string
+      dry_run:
+        description: "Validate only (skip merge/tag/release)"
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+jobs:
+  self-release:
+    permissions:
+      contents: write # auto-release.yml's GITHUB_TOKEN creates the release snapshot branch + tag/release
+    uses: nics-dp/meta/.github/workflows/auto-release.yml@main
+    with:
+      version: ${{ inputs.version }}
+      dry_run: ${{ inputs.dry_run }}
+    secrets:
+      ci_read_app_private_key:     ${{ secrets.CI_READ_APP_PRIVATE_KEY }}
+      pre_release_app_private_key: ${{ secrets.PRE_RELEASE_APP_PRIVATE_KEY }}

--- a/.mise/tasks/go/api-fix
+++ b/.mise/tasks/go/api-fix
@@ -2,6 +2,7 @@
 #MISE description="Migrate Go source to new APIs via go fix (rewrites deprecated stdlib paths/calls)"
 #MISE hide=true
 #MISE raw=true
+#MISE depends=["go:install"]
 #MISE silent="stdout"
 
 set -euo pipefail

--- a/.mise/tasks/go/audit
+++ b/.mise/tasks/go/audit
@@ -2,6 +2,7 @@
 #MISE description="Run govulncheck vulnerability check"
 #MISE hide=true
 #MISE raw=true
+#MISE depends=["go:install"]
 #MISE tools={"go:golang.org/x/vuln/cmd/govulncheck"="latest"}
 
 govulncheck ./...

--- a/.mise/tasks/go/build
+++ b/.mise/tasks/go/build
@@ -2,6 +2,7 @@
 #MISE description="Build Go binary from cmd/"
 #MISE hide=true
 #MISE raw=true
+#MISE depends=["go:install"]
 #MISE silent="stdout"
 #USAGE arg "<name>" help="Binary name (auto-detected if cmd/ has only one entry)"
 # shellcheck disable=SC2154 # usage_name is set by mise USAGE

--- a/.mise/tasks/go/dead-code
+++ b/.mise/tasks/go/dead-code
@@ -2,6 +2,7 @@
 #MISE description="Find unreachable functions in production code; --whole-program also analyzes tests (golang.org/x/tools/cmd/deadcode)"
 #MISE hide=true
 #MISE raw=true
+#MISE depends=["go:install"]
 #MISE tools={"go:golang.org/x/tools/cmd/deadcode"="latest"}
 #USAGE arg "[entry]" help="Entry package(s) (default: ./... — roots at every main package, commonly cmd/*)"
 #USAGE flag "--filter <regex>" help="Only report functions matching regex"

--- a/.mise/tasks/go/generate
+++ b/.mise/tasks/go/generate
@@ -2,6 +2,7 @@
 #MISE description="Run go generate (code generation)"
 #MISE hide=true
 #MISE raw=true
+#MISE depends=["go:install"]
 #MISE silent="stdout"
 
 set -euo pipefail

--- a/.mise/tasks/go/lint-check
+++ b/.mise/tasks/go/lint-check
@@ -2,6 +2,7 @@
 #MISE description="Lint Go (read-only)"
 #MISE hide=true
 #MISE raw=true
+#MISE depends=["go:install"]
 #MISE tools={"aqua:golangci/golangci-lint"="2.12.2"}
 
 golangci-lint run ./...

--- a/.mise/tasks/go/sast
+++ b/.mise/tasks/go/sast
@@ -2,6 +2,7 @@
 #MISE description="Run gosec security scanner"
 #MISE hide=true
 #MISE raw=true
+#MISE depends=["go:install"]
 #MISE tools={"github:securego/gosec"="latest"}
 
 gosec -quiet ./...

--- a/.mise/tasks/go/test
+++ b/.mise/tasks/go/test
@@ -2,6 +2,7 @@
 #MISE description="Run Go tests. Modes: default=unit, --race, --coverage, --bench, --full=race+coverage+bench"
 #MISE hide=true
 #MISE raw=true
+#MISE depends=["go:install"]
 #USAGE flag "--race" help="Enable race detector"
 #USAGE flag "--coverage" help="Enable coverage (writes coverage.out)"
 #USAGE flag "--bench" help="Run benchmarks instead of tests"

--- a/mise.toml
+++ b/mise.toml
@@ -23,9 +23,18 @@ includes = [
 description = "Run all CI checks"
 depends = [
   "iac:trivy",
-  "ci:trivy-license",
   "ci:semgrep",
 ]
+
+# Full validation gate. Entry point for the auto-release driver (`mise run all`)
+# so meta can dogfood its own reusable release workflow. Config repo has no
+# build/test — validation is actionlint (workflow YAML) + the ci scans. All
+# steps are read-only (no working-tree drift), so they run in parallel.
+# Secret/license scans (betterleaks/trufflehog/trivy-license) are run separately
+# by the driver itself, so they are not duplicated here.
+[tasks.all]
+description = "Validation gate: actionlint + ci scans (auto-release driver entry point)"
+depends = ["iac:actionlint", "ci"]
 
 # ==============================================================================
 #  SBOM Tasks

--- a/templates/facades/mise.frontend.toml
+++ b/templates/facades/mise.frontend.toml
@@ -34,6 +34,7 @@ includes = ["git::https://github.com/nics-dp/meta.git//.mise/tasks?ref=main"]
 silent = "stdout"
 description = "Install JS deps + Playwright browsers"
 depends = ["node:install", "node:e2e-install"]
+depends_post = ["meta:bump"]
 
 [tasks.clean]
 silent = "stdout"
@@ -60,8 +61,11 @@ run = "bunx vitest bench --run"
 [tasks.update]
 silent = "stdout"
 description = "Bump deps and refresh shared atoms"
-depends = ["node:update", "meta:bump"]
-
+# meta:bump runs first in its OWN invocation (run array steps are separate
+# `mise run` processes): it refreshes the shared atom cache, then the deps
+# step re-resolves and runs against the latest upstream atoms. Separate
+# invocations also avoid the cache-clear race that depends/depends_post had.
+run = ["mise run meta:bump", "mise run node:update"]
 [tasks.ci]
 description = "Run all CI checks"
 # Native-binary toolchain (oxc/opengrep/tsgo): oxfmt replaces prettier; oxlint &
@@ -90,5 +94,5 @@ description = "Generate enriched SBOM and scan"
 depends = ["sbom:trivy", "sbom:grype"]
 
 [tasks.all]
-description = "init -> build -> test -> ci"
-depends = ["init", "build", "test", "ci"]
+description = "init first, then build/test/ci in parallel"
+run = ["mise run init", "mise run build test ci"]

--- a/templates/facades/mise.go-lib.toml
+++ b/templates/facades/mise.go-lib.toml
@@ -36,6 +36,7 @@ includes = ["git::https://github.com/nics-dp/meta.git//.mise/tasks?ref=main"]
 silent = "stdout"
 description = "Tidy and vendor Go modules"
 depends = ["go:install"]
+depends_post = ["meta:bump"]
 
 [tasks.clean]
 silent = "stdout"
@@ -50,9 +51,11 @@ depends_post = ["go:report"]
 [tasks.update]
 silent = "stdout"
 description = "Bump deps, update submodules, and refresh shared atoms"
-depends = ["go:update", "gs:update"]
-depends_post = ["meta:bump"]
-
+# meta:bump runs first in its OWN invocation (run array steps are separate
+# `mise run` processes): it refreshes the shared atom cache, then the deps
+# step re-resolves and runs against the latest upstream atoms. Separate
+# invocations also avoid the cache-clear race that depends/depends_post had.
+run = ["mise run meta:bump", "mise run go:update gs:update"]
 [tasks.ci]
 description = "Run all CI checks"
 depends = [
@@ -65,8 +68,8 @@ depends = [
 ]
 
 [tasks.all]
-description = "init -> generate -> api-fix -> test -> ci"
-depends = ["init", "go:generate", "go:api-fix", "test", "ci"]
+description = "init -> generate -> api-fix sequentially, then test/ci in parallel"
+run = ["mise run init", "mise run go:generate", "mise run go:api-fix", "mise run test ci"]
 
 [tasks.sbom]
 description = "Generate enriched SBOM and scan"

--- a/templates/facades/mise.go-service.toml
+++ b/templates/facades/mise.go-service.toml
@@ -40,6 +40,7 @@ includes = ["git::https://github.com/nics-dp/meta.git//.mise/tasks?ref=main"]
 silent = "stdout"
 description = "Bootstrap deps and submodules"
 depends = ["go:install", "gs:clone"]
+depends_post = ["meta:bump"]
 
 [tasks.clean]
 silent = "stdout"
@@ -82,9 +83,11 @@ depends = ["go:lib-remote"]
 [tasks.update]
 silent = "stdout"
 description = "Bump deps, refresh shared atoms, update submodules"
-depends = ["go:update", "gs:update"]
-depends_post = ["meta:bump"]
-
+# meta:bump runs first in its OWN invocation (run array steps are separate
+# `mise run` processes): it refreshes the shared atom cache, then the deps
+# step re-resolves and runs against the latest upstream atoms. Separate
+# invocations also avoid the cache-clear race that depends/depends_post had.
+run = ["mise run meta:bump", "mise run go:update gs:update"]
 [tasks.ci]
 description = "Run all CI checks"
 depends = [
@@ -103,5 +106,5 @@ description = "Generate enriched SBOM and scan"
 depends = ["sbom:trivy", "sbom:grype"]
 
 [tasks.all]
-description = "init -> generate -> api-fix -> build -> test -> ci"
-depends = ["init", "go:generate", "go:api-fix", "build", "test", "ci"]
+description = "init -> generate -> api-fix sequentially, then build/test/ci in parallel"
+run = ["mise run init", "mise run go:generate", "mise run go:api-fix", "mise run build test ci"]

--- a/templates/facades/mise.python.toml
+++ b/templates/facades/mise.python.toml
@@ -42,6 +42,7 @@ includes = ["git::https://github.com/nics-dp/meta.git//.mise/tasks?ref=main"]
 silent = "stdout"
 description = "Install Python deps"
 depends = ["py:install"]
+depends_post = ["meta:bump"]
 
 [tasks.clean]
 silent = "stdout"
@@ -70,8 +71,11 @@ depends = ["py:test --bench"]
 [tasks.update]
 silent = "stdout"
 description = "Bump deps and refresh shared atoms"
-depends = ["py:update", "meta:bump"]
-
+# meta:bump runs first in its OWN invocation (run array steps are separate
+# `mise run` processes): it refreshes the shared atom cache, then the deps
+# step re-resolves and runs against the latest upstream atoms. Separate
+# invocations also avoid the cache-clear race that depends/depends_post had.
+run = ["mise run meta:bump", "mise run py:update"]
 [tasks.ci]
 description = "Run all CI checks"
 depends = [
@@ -96,5 +100,5 @@ depends = [
 ]
 
 [tasks.all]
-description = "init -> build -> test -> ci"
-depends = ["init", "build", "test", "ci"]
+description = "init first, then build/test/ci in parallel"
+run = ["mise run init", "mise run build test ci"]


### PR DESCRIPTION
First promotion of the new auto-release infrastructure to main, breaking the bootstrap deadlock: every `@main` caller (meta self-release + 13 consumers) needs `auto-release.yml` to exist on main, but it currently only lives on dev.

Brings to main: auto-release.yml driver (#238), go:install atom deps + facade `all` sequencing + meta:bump wiring (#240), and meta self-release enablement (#242).

After this merge: `@main` callers work, consumer `go:install` atom deps take effect, and future meta releases run via the Self-Release driver. Tag v0.2.5.5 + GitHub Release will be created on the merged main.
