### PR TITLE
fix(mise): use ::: so facade all/update multi-task steps execute

### DIFF
--- a/templates/facades/mise.frontend.toml
+++ b/templates/facades/mise.frontend.toml
@@ -95,4 +95,4 @@ depends = ["sbom:trivy", "sbom:grype"]
 
 [tasks.all]
 description = "init first, then build/test/ci in parallel"
-run = ["mise run init", "mise run build test ci"]
+run = ["mise run init", "mise run build ::: test ::: ci"]

--- a/templates/facades/mise.go-lib.toml
+++ b/templates/facades/mise.go-lib.toml
@@ -55,7 +55,7 @@ description = "Bump deps, update submodules, and refresh shared atoms"
 # `mise run` processes): it refreshes the shared atom cache, then the deps
 # step re-resolves and runs against the latest upstream atoms. Separate
 # invocations also avoid the cache-clear race that depends/depends_post had.
-run = ["mise run meta:bump", "mise run go:update gs:update"]
+run = ["mise run meta:bump", "mise run go:update ::: gs:update"]
 [tasks.ci]
 description = "Run all CI checks"
 depends = [
@@ -69,7 +69,7 @@ depends = [
 
 [tasks.all]
 description = "init -> generate -> api-fix sequentially, then test/ci in parallel"
-run = ["mise run init", "mise run go:generate", "mise run go:api-fix", "mise run test ci"]
+run = ["mise run init", "mise run go:generate", "mise run go:api-fix", "mise run test ::: ci"]
 
 [tasks.sbom]
 description = "Generate enriched SBOM and scan"

--- a/templates/facades/mise.go-service.toml
+++ b/templates/facades/mise.go-service.toml
@@ -87,7 +87,7 @@ description = "Bump deps, refresh shared atoms, update submodules"
 # `mise run` processes): it refreshes the shared atom cache, then the deps
 # step re-resolves and runs against the latest upstream atoms. Separate
 # invocations also avoid the cache-clear race that depends/depends_post had.
-run = ["mise run meta:bump", "mise run go:update gs:update"]
+run = ["mise run meta:bump", "mise run go:update ::: gs:update"]
 [tasks.ci]
 description = "Run all CI checks"
 depends = [
@@ -107,4 +107,4 @@ depends = ["sbom:trivy", "sbom:grype"]
 
 [tasks.all]
 description = "init -> generate -> api-fix sequentially, then build/test/ci in parallel"
-run = ["mise run init", "mise run go:generate", "mise run go:api-fix", "mise run build test ci"]
+run = ["mise run init", "mise run go:generate", "mise run go:api-fix", "mise run build ::: test ::: ci"]

--- a/templates/facades/mise.python.toml
+++ b/templates/facades/mise.python.toml
@@ -101,4 +101,4 @@ depends = [
 
 [tasks.all]
 description = "init first, then build/test/ci in parallel"
-run = ["mise run init", "mise run build test ci"]
+run = ["mise run init", "mise run build ::: test ::: ci"]


### PR DESCRIPTION
## Summary
`mise run A B C` (mise 2026.6.14) parses `B C` as positional args to task `A` — only `A` runs. Multi-task run-array steps therefore need `:::` separators, or the extra tasks are silently swallowed.

Impact (now fixed in all 4 facade templates):
- `[tasks.all]` last step `mise run build test ci` ran **only build** — test/ci never executed. Critically, the auto-release driver's `mise run all` validation gate inherited this, **silently skipping test/ci on release**.
- `[tasks.update]` 2nd step `mise run go:update gs:update` ran only go:update.

Fix: `mise run build ::: test ::: ci`, `mise run go:update ::: gs:update`, etc. The 13 consumer repos received the same fix on their branches.

Refs TMDs#239.
