### PR TITLE
fix(ci): pass mise-task input via env to avoid shell injection

### DIFF
--- a/.github/workflows/mise-task.yml
+++ b/.github/workflows/mise-task.yml
@@ -126,6 +126,8 @@ jobs:
           TASK: ${{ inputs.task }}
         run: |
           set +e
+          # $TASK intentionally unquoted: split task+args (e.g. "ci:semgrep golang")
+          # shellcheck disable=SC2086
           mise run $TASK 2>&1 | tee /tmp/output.log
           exit "${PIPESTATUS[0]}"
         continue-on-error: true

--- a/.github/workflows/mise-task.yml
+++ b/.github/workflows/mise-task.yml
@@ -123,6 +123,9 @@ jobs:
         # shell metacharacters (;, |, &&), neutralizing injection.
         env:
           TASK: ${{ inputs.task }}
+        # Force bash: the run block uses bash-only syntax (read -ra, ${PIPESTATUS[0]})
+        # and runs_on may be a non-Ubuntu runner whose default shell isn't bash.
+        shell: bash
         run: |
           set +e
           # Split TASK into an argv array so task+args are preserved

--- a/.github/workflows/mise-task.yml
+++ b/.github/workflows/mise-task.yml
@@ -118,9 +118,15 @@ jobs:
 
       - id: check
         name: Run ${{ inputs.task }}
+        # Pass inputs.task via env, not inline ${{ }}, so it can't inject into the
+        # shell (semgrep run-shell-injection). Unquoted $TASK preserves task+arg
+        # word-split (e.g. "ci:semgrep golang" → task + arg); env expansion does
+        # NOT re-parse shell metacharacters (;, |, &&), neutralizing injection.
+        env:
+          TASK: ${{ inputs.task }}
         run: |
           set +e
-          mise run ${{ inputs.task }} 2>&1 | tee /tmp/output.log
+          mise run $TASK 2>&1 | tee /tmp/output.log
           exit "${PIPESTATUS[0]}"
         continue-on-error: true
 

--- a/.github/workflows/mise-task.yml
+++ b/.github/workflows/mise-task.yml
@@ -119,16 +119,17 @@ jobs:
       - id: check
         name: Run ${{ inputs.task }}
         # Pass inputs.task via env, not inline ${{ }}, so it can't inject into the
-        # shell (semgrep run-shell-injection). Unquoted $TASK preserves task+arg
-        # word-split (e.g. "ci:semgrep golang" → task + arg); env expansion does
-        # NOT re-parse shell metacharacters (;, |, &&), neutralizing injection.
+        # shell (semgrep run-shell-injection). env expansion does NOT re-parse
+        # shell metacharacters (;, |, &&), neutralizing injection.
         env:
           TASK: ${{ inputs.task }}
         run: |
           set +e
-          # $TASK intentionally unquoted: split task+args (e.g. "ci:semgrep golang")
-          # shellcheck disable=SC2086
-          mise run $TASK 2>&1 | tee /tmp/output.log
+          # Split TASK into an argv array so task+args are preserved
+          # (e.g. "ci:semgrep golang" → task + arg) WITHOUT triggering pathname
+          # globbing on * / ? / [ that an unquoted $TASK would.
+          read -ra task_args <<< "$TASK"
+          mise run "${task_args[@]}" 2>&1 | tee /tmp/output.log
           exit "${PIPESTATUS[0]}"
         continue-on-error: true
 

--- a/templates/facades/mise.frontend.toml
+++ b/templates/facades/mise.frontend.toml
@@ -89,10 +89,28 @@ depends = [
   "iac:trivy",
 ]
 
+
+[tasks.release-check]
+description = "Read-only validation for all/release driver (ci minus file-mutating *-fix atoms)"
+depends = [
+  "node:lint-check",
+  "node:oxlint",
+  "node:oxfmt-check",
+  "node:typecheck",
+  "node:typecheck-tsgo",
+  "node:knip",
+  "node:audit",
+  "node:bundle-size",
+  "node:e2e",
+  "node:lighthouse",
+  "ci:semgrep typescript javascript",
+  "iac:trivy",
+]
+
 [tasks.sbom]
 description = "Generate enriched SBOM and scan"
 depends = ["sbom:trivy", "sbom:grype"]
 
 [tasks.all]
 description = "init first, then build/test/ci in parallel"
-run = ["mise run init", "mise run build ::: test ::: ci"]
+run = ["mise run init", "mise run build ::: test ::: release-check"]

--- a/templates/facades/mise.frontend.toml
+++ b/templates/facades/mise.frontend.toml
@@ -112,5 +112,5 @@ description = "Generate enriched SBOM and scan"
 depends = ["sbom:trivy", "sbom:grype"]
 
 [tasks.all]
-description = "init first, then build/test/ci in parallel"
+description = "init first, then build/test/release-check in parallel"
 run = ["mise run init", "mise run build ::: test ::: release-check"]

--- a/templates/facades/mise.go-lib.toml
+++ b/templates/facades/mise.go-lib.toml
@@ -79,7 +79,7 @@ depends = [
 ]
 
 [tasks.all]
-description = "init -> generate -> api-fix sequentially, then test/ci in parallel"
+description = "init -> generate -> api-fix sequentially, then test/release-check in parallel"
 run = ["mise run init", "mise run go:generate", "mise run go:api-fix", "mise run test ::: release-check"]
 
 [tasks.sbom]

--- a/templates/facades/mise.go-lib.toml
+++ b/templates/facades/mise.go-lib.toml
@@ -67,9 +67,20 @@ depends = [
   "ci:semgrep golang",
 ]
 
+
+[tasks.release-check]
+description = "Read-only validation for all/release driver (ci minus file-mutating *-fix atoms)"
+depends = [
+  "go:lint-check",
+  "go:sast",
+  "go:audit",
+  "go:dead-code",
+  "ci:semgrep golang",
+]
+
 [tasks.all]
 description = "init -> generate -> api-fix sequentially, then test/ci in parallel"
-run = ["mise run init", "mise run go:generate", "mise run go:api-fix", "mise run test ::: ci"]
+run = ["mise run init", "mise run go:generate", "mise run go:api-fix", "mise run test ::: release-check"]
 
 [tasks.sbom]
 description = "Generate enriched SBOM and scan"

--- a/templates/facades/mise.go-service.toml
+++ b/templates/facades/mise.go-service.toml
@@ -119,5 +119,5 @@ description = "Generate enriched SBOM and scan"
 depends = ["sbom:trivy", "sbom:grype"]
 
 [tasks.all]
-description = "init -> generate -> api-fix sequentially, then build/test/ci in parallel"
+description = "init -> generate -> api-fix sequentially, then build/test/release-check in parallel"
 run = ["mise run init", "mise run go:generate", "mise run go:api-fix", "mise run build ::: test ::: release-check"]

--- a/templates/facades/mise.go-service.toml
+++ b/templates/facades/mise.go-service.toml
@@ -101,10 +101,23 @@ depends = [
   "iac:trivy",
 ]
 
+
+[tasks.release-check]
+description = "Read-only validation for all/release driver (ci minus file-mutating *-fix atoms)"
+depends = [
+  "go:lint-check",
+  "go:sast",
+  "go:audit",
+  "go:dead-code",
+  "iac:img:hadolint",
+  "ci:semgrep golang",
+  "iac:trivy",
+]
+
 [tasks.sbom]
 description = "Generate enriched SBOM and scan"
 depends = ["sbom:trivy", "sbom:grype"]
 
 [tasks.all]
 description = "init -> generate -> api-fix sequentially, then build/test/ci in parallel"
-run = ["mise run init", "mise run go:generate", "mise run go:api-fix", "mise run build ::: test ::: ci"]
+run = ["mise run init", "mise run go:generate", "mise run go:api-fix", "mise run build ::: test ::: release-check"]

--- a/templates/facades/mise.python.toml
+++ b/templates/facades/mise.python.toml
@@ -117,5 +117,5 @@ depends = [
 ]
 
 [tasks.all]
-description = "init first, then build/test/ci in parallel"
+description = "init first, then build/test/release-check in parallel"
 run = ["mise run init", "mise run build ::: test ::: release-check"]

--- a/templates/facades/mise.python.toml
+++ b/templates/facades/mise.python.toml
@@ -93,6 +93,23 @@ depends = [
   "ci:semgrep python",
 ]
 
+
+[tasks.release-check]
+description = "Read-only validation for all/release driver (ci minus file-mutating *-fix atoms)"
+depends = [
+  "py:lint-check",
+  "py:format-check",
+  "py:typecheck",
+  "py:typecheck --pyrefly",
+  "py:sast",
+  "py:audit",
+  "py:safety-db",
+  "py:complexity",
+  "py:dead-code",
+  "py:license-custom",
+  "ci:semgrep python",
+]
+
 [tasks.sbom]
 description = "Generate enriched SBOM, scan vulnerabilities, audit licenses"
 depends = [
@@ -101,4 +118,4 @@ depends = [
 
 [tasks.all]
 description = "init first, then build/test/ci in parallel"
-run = ["mise run init", "mise run build ::: test ::: ci"]
+run = ["mise run init", "mise run build ::: test ::: release-check"]


### PR DESCRIPTION
## Summary
Two related v0.2.5.6 changes surfaced by the meta self-release dogfood dry-run.

### 1. mise-task.yml shell-injection fix
`mise-task.yml` interpolated `${{ inputs.task }}` directly into a `run:` shell (`mise run ${{ inputs.task }}`) — a semgrep `run-shell-injection` finding. A crafted `task` value could inject shell commands.

Fix: route the input through an `env: TASK` var and split it into an argv array (`read -ra task_args <<< "$TASK"; mise run "${task_args[@]}"`). This preserves the task+arg word-split (e.g. `ci:semgrep golang`) and keeps injection neutralized (env-passed, no `${{ }}` in shell), while also avoiding the pathname globbing an unquoted `$TASK` would perform on `*`/`?`/`[`. The step is pinned `shell: bash` since the run block uses bash-only syntax and `runs_on` may be a non-Ubuntu runner. No `run:`-behavior change for normal task inputs.

Surfaced because `mise run all` now runs `ci:semgrep` on meta itself (meta's ci.yml never did), exposing this pre-existing finding in the core reusable workflow.

### 2. Facade `all` parallel tail runs read-only `release-check` (intentional behavior change)
The 4 facade templates' `[tasks.all]` PARALLEL TAIL (`build ::: test ::: release-check`) now runs a new read-only `release-check` task instead of `ci`. `release-check` = `ci` with the file-mutating `*-fix` atoms swapped for their `-check` equivalents (`go:lint-fix`->`go:lint-check`, `node:oxfmt-fix`->`node:oxfmt-check`, `py:format-fix`->`py:format-check`, deduped).

**What "read-only" means here:** the *parallel tail* must have no writer racing a reader — `ci`'s `lint-fix` mutated files while `build`/`test` read them (a real race under `:::`), so it is swapped for `lint-check`. The *sequential prefix* (`init -> generate -> api-fix`) runs BEFORE the tail and never concurrently with build/test, so it is not part of the read-only tail. `go:generate`/`go:api-fix` writes there are intentional canonical-enforcement: paired with the auto-release driver's verify-no-drift step, a dirty worktree means committed code is stale (generated/fixed output not committed) and the release correctly fails. `go generate`/`go fix` have no check-only variant, so prefix-run + verify-no-drift is the enforcement mechanism (unlike lint-fix, which does have `lint-check`).

This IS a deliberate behavior change to `mise run all`'s tail. `ci` (with the auto-fixing atoms) stays for local dev. The 13 consumer repos received the same change.

Refs TMDs#239.
