### PR TITLE
ci: add pr-issue-check caller

### DIFF
--- a/.github/workflows/self-pr-issue-check.yml
+++ b/.github/workflows/self-pr-issue-check.yml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+
+name: pr-issue-check
+
+# PR gate: the PR must have a linked same-repo issue (Closes #N) and every
+# linked issue must have the `version` field set on its Project 3 item. See
+# nics-dp/meta/.github/workflows/pr-issue-check.yml for scope and details.
+# Intended to back an org-ruleset required status check
+# (`pr-issue-check / pr-issue-check`); keep the job id stable.
+on:
+  pull_request:
+    # `edited` re-runs the check when `Closes #N` is added to the body
+    types: [opened, edited, reopened, synchronize]
+
+permissions: {}
+
+jobs:
+  pr-issue-check:
+    permissions:
+      pull-requests: read
+      issues: read
+    uses: nics-dp/meta/.github/workflows/pr-issue-check.yml@main
+    secrets:
+      ci_read_app_private_key: ${{ secrets.CI_READ_APP_PRIVATE_KEY }}


### PR DESCRIPTION
## Summary

加入 org pr-issue-check PR gate 的 caller:base=dev 的 PR 須有同 repo linked issue 且該 issue 已設 Project 3 `version` 欄位,不符時紅燈附補救指引;main/release promotion 與 fork PR 自動 skip。

- reusable:`nics-dp/meta/.github/workflows/pr-issue-check.yml@main`(meta v0.2.5.7,設計/測試見 nics-dp/meta#251)
- job id 固定 `pr-issue-check` → check run 名 org-wide 一致(`pr-issue-check / pr-issue-check`),供後續 org ruleset required check 使用(觀察期後由 admin 手動開啟)
- `pull_request` types 含 `edited`:事後補 `Closes #N` 會自動重跑;補 Project `version` 欄位不觸發 event,需手動 re-run(check 失敗訊息內有說明)
- 本 PR 自己就走這個 gate(下方 Closes 即為驗證)

追蹤:nics-dp/TMDs#598

Closes #255
